### PR TITLE
CopyBufferToTexture buffer offset

### DIFF
--- a/examples/HelloTriangle.cpp
+++ b/examples/HelloTriangle.cpp
@@ -85,7 +85,7 @@ void initTextures() {
 
     nxt::CommandBuffer copy = device.CreateCommandBufferBuilder()
         .TransitionTextureUsage(texture, nxt::TextureUsageBit::TransferDst)
-        .CopyBufferToTexture(stagingBuffer, texture, 0, 0, 0, 1024, 1024, 1, 0)
+        .CopyBufferToTexture(stagingBuffer, 0, texture, 0, 0, 0, 1024, 1024, 1, 0)
         .GetResult();
 
     queue.Submit(1, &copy);

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -377,7 +377,7 @@ namespace {
             staging.FreezeUsage(nxt::BufferUsageBit::TransferSrc);
             auto cmdbuf = device.CreateCommandBufferBuilder()
                 .TransitionTextureUsage(oTexture, nxt::TextureUsageBit::TransferDst)
-                .CopyBufferToTexture(staging, oTexture, 0, 0, 0, 1, 1, 1, 0)
+                .CopyBufferToTexture(staging, 0, oTexture, 0, 0, 0, 1, 1, 1, 0)
                 .GetResult();
             queue.Submit(1, &cmdbuf);
             oTexture.FreezeUsage(nxt::TextureUsageBit::Sampled);
@@ -440,7 +440,7 @@ namespace {
             staging.FreezeUsage(nxt::BufferUsageBit::TransferSrc);
             auto cmdbuf = device.CreateCommandBufferBuilder()
                 .TransitionTextureUsage(oTexture, nxt::TextureUsageBit::TransferDst)
-                .CopyBufferToTexture(staging, oTexture, 0, 0, 0, iImage.width, iImage.height, 1, 0)
+                .CopyBufferToTexture(staging, 0, oTexture, 0, 0, 0, iImage.width, iImage.height, 1, 0)
                 .GetResult();
             queue.Submit(1, &cmdbuf);
             oTexture.FreezeUsage(nxt::TextureUsageBit::Sampled);

--- a/generator/templates/mock_api.cpp
+++ b/generator/templates/mock_api.cpp
@@ -16,7 +16,7 @@
 
 namespace {
     {% for type in by_category["object"] %}
-        {% for method in native_methods(type) %}
+        {% for method in native_methods(type) if len(method.arguments) < 10 %}
             {{as_cType(method.return_type.name)}} Forward{{as_MethodSuffix(type.name, method.name)}}(
                 {{-as_cType(type.name)}} self
                 {%- for arg in method.arguments -%}
@@ -45,7 +45,7 @@ void ProcTableAsClass::GetProcTableAndDevice(nxtProcTable* table, nxtDevice* dev
     *device = GetNewDevice();
 
     {% for type in by_category["object"] %}
-        {% for method in native_methods(type) %}
+        {% for method in native_methods(type) if len(method.arguments) < 10 %}
             table->{{as_varName(type.name, method.name)}} = reinterpret_cast<{{as_cProc(type.name, method.name)}}>(Forward{{as_MethodSuffix(type.name, method.name)}});
         {% endfor %}
     {% endfor %}

--- a/generator/templates/mock_api.h
+++ b/generator/templates/mock_api.h
@@ -29,7 +29,7 @@ class ProcTableAsClass {
         {% endfor %}
 
         {% for type in by_category["object"] %}
-            {% for method in native_methods(type) %}
+            {% for method in native_methods(type) if len(method.arguments) < 10 %}
                 virtual {{as_cType(method.return_type.name)}} {{as_MethodSuffix(type.name, method.name)}}(
                     {{-as_cType(type.name)}} {{as_varName(type.name)}}
                     {%- for arg in method.arguments -%}
@@ -47,7 +47,7 @@ class ProcTableAsClass {
 class MockProcTable : public ProcTableAsClass {
     public:
         {% for type in by_category["object"] %}
-            {% for method in native_methods(type) %}
+            {% for method in native_methods(type) if len(method.arguments) < 10 %}
                 MOCK_METHOD{{len(method.arguments) + 1}}(
                     {{-as_MethodSuffix(type.name, method.name)}},
                     {{as_cType(method.return_type.name)}}(

--- a/next.json
+++ b/next.json
@@ -207,6 +207,7 @@
                 "name": "copy buffer to texture",
                 "args": [
                     {"name": "buffer", "type": "buffer"},
+                    {"name": "buffer offset", "type": "uint32_t"},
                     {"name": "texture", "type": "texture"},
                     {"name": "x", "type": "uint32_t"},
                     {"name": "y", "type": "uint32_t"},
@@ -219,11 +220,9 @@
                 "TODO": [
                     "Make pretty with Offset and Extents structures",
                     "Allow choosing the aspect (depth vs. stencil)?",
-                    "The following where removed because gmock supports only 10 arguments",
-                    "this means the buffer is assumed to be packed and starting at 0.",
+                    "Add these arguments too",
                     {"name": "row length", "type": "uint32_t"},
-                    {"name": "image height", "type": "uint32_t"},
-                    {"name": "buffer offset", "type": "uint32_t"}
+                    {"name": "image height", "type": "uint32_t"}
                 ]
             },
             {

--- a/src/backend/common/CommandBuffer.cpp
+++ b/src/backend/common/CommandBuffer.cpp
@@ -245,6 +245,7 @@ namespace backend {
                     {
                         CopyBufferToTextureCmd* copy = iterator.NextCommand<CopyBufferToTextureCmd>();
                         BufferBase* buffer = copy->buffer.Get();
+                        uint32_t bufferOffset = copy->bufferOffset;
                         TextureBase* texture = copy->texture.Get();
                         uint64_t width = copy->width;
                         uint64_t height = copy->height;
@@ -273,8 +274,7 @@ namespace backend {
                         uint64_t pixelSize = TextureFormatPixelSize(texture->GetFormat());
                         uint64_t dataSize = width * height * depth * pixelSize;
 
-                        // TODO(cwallez@chromium.org): handle buffer offset when it is in the command.
-                        if (dataSize > static_cast<uint64_t>(buffer->GetSize())) {
+                        if (dataSize + static_cast<uint64_t>(bufferOffset) > static_cast<uint64_t>(buffer->GetSize())) {
                             device->HandleError("Copy would read after end of the buffer");
                             return false;
                         }
@@ -497,11 +497,13 @@ namespace backend {
         return device->CreateCommandBuffer(this);
     }
 
-    void CommandBufferBuilder::CopyBufferToTexture(BufferBase* buffer, TextureBase* texture, uint32_t x, uint32_t y, uint32_t z,
+    void CommandBufferBuilder::CopyBufferToTexture(BufferBase* buffer, uint32_t bufferOffset,
+                                                   TextureBase* texture, uint32_t x, uint32_t y, uint32_t z,
                                                    uint32_t width, uint32_t height, uint32_t depth, uint32_t level) {
         CopyBufferToTextureCmd* copy = allocator.Allocate<CopyBufferToTextureCmd>(Command::CopyBufferToTexture);
         new(copy) CopyBufferToTextureCmd;
         copy->buffer = buffer;
+        copy->bufferOffset = bufferOffset;
         copy->texture = texture;
         copy->x = x;
         copy->y = y;

--- a/src/backend/common/CommandBuffer.h
+++ b/src/backend/common/CommandBuffer.h
@@ -57,7 +57,8 @@ namespace backend {
             // NXT API
             CommandBufferBase* GetResult();
 
-            void CopyBufferToTexture(BufferBase* buffer, TextureBase* texture, uint32_t x, uint32_t y, uint32_t z,
+            void CopyBufferToTexture(BufferBase* buffer, uint32_t bufferOffset,
+                                     TextureBase* texture, uint32_t x, uint32_t y, uint32_t z,
                                      uint32_t width, uint32_t height, uint32_t depth, uint32_t level);
             void Dispatch(uint32_t x, uint32_t y, uint32_t z);
             void DrawArrays(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);

--- a/src/backend/common/Commands.h
+++ b/src/backend/common/Commands.h
@@ -41,6 +41,7 @@ namespace backend {
 
     struct CopyBufferToTextureCmd {
         Ref<BufferBase> buffer;
+        uint32_t bufferOffset;
         Ref<TextureBase> texture;
         uint32_t x, y, z;
         uint32_t width, height, depth;

--- a/src/backend/metal/MetalBackend.mm
+++ b/src/backend/metal/MetalBackend.mm
@@ -330,7 +330,7 @@ namespace metal {
                         encoders.EnsureBlit(commandBuffer);
                         [encoders.blit
                             copyFromBuffer:buffer->GetMTLBuffer()
-                            sourceOffset:0
+                            sourceOffset:copy->bufferOffset
                             sourceBytesPerRow:rowSize
                             sourceBytesPerImage:(rowSize * copy->height)
                             sourceSize:size

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -74,7 +74,8 @@ namespace opengl {
                         glBindTexture(target, texture->GetHandle());
 
                         glTexSubImage2D(target, copy->level, copy->x, copy->y, copy->width, copy->height,
-                                        format.format, format.type, nullptr);
+                                        format.format, format.type,
+                                        reinterpret_cast<void*>(static_cast<uintptr_t>(copy->bufferOffset)));
                         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
                     }
                     break;


### PR DESCRIPTION
PTAL, this removes the gMock issue blocking #9 and adds bufferOffset to Buffer -> Texture copies. Missing arguments are rowLength, imageHeight and which aspects to copy, which aren't too useful.