### PR TITLE
Create a command buffer builder state tracker object

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -35,6 +35,8 @@ list(APPEND BACKEND_SOURCES
     ${COMMON_DIR}/CommandBuffer.h
     ${COMMON_DIR}/DepthStencilState.cpp
     ${COMMON_DIR}/DepthStencilState.h
+    ${COMMON_DIR}/CommandBufferStateTracker.cpp
+    ${COMMON_DIR}/CommandBufferStateTracker.h
     ${COMMON_DIR}/Device.cpp
     ${COMMON_DIR}/Device.h
     ${COMMON_DIR}/Forward.h

--- a/src/backend/common/CommandBuffer.h
+++ b/src/backend/common/CommandBuffer.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BACKEND_COMMON_COMMANDBUFFERGL_H_
-#define BACKEND_COMMON_COMMANDBUFFERGL_H_
+#ifndef BACKEND_COMMON_COMMANDBUFFER_H_
+#define BACKEND_COMMON_COMMANDBUFFER_H_
 
 #include "nxt/nxtcpp.h"
 
@@ -21,6 +21,7 @@
 #include "Builder.h"
 #include "RefCounted.h"
 
+#include <memory>
 #include <set>
 #include <utility>
 
@@ -28,6 +29,7 @@ namespace backend {
 
     class BindGroupBase;
     class BufferBase;
+    class CommandBufferStateTracker;
     class FramebufferBase;
     class DeviceBase;
     class PipelineBase;
@@ -88,16 +90,13 @@ namespace backend {
             CommandBufferBase* GetResultImpl() override;
             void MoveToIterator();
 
+            std::unique_ptr<CommandBufferStateTracker> state;
             CommandAllocator allocator;
             CommandIterator iterator;
             bool movedToIterator = false;
             bool commandsAcquired = false;
-            // These pointers will remain valid since they are referenced by
-            // the bind groups which are referenced by this command buffer.
-            std::set<BufferBase*> buffersTransitioned;
-            std::set<TextureBase*> texturesTransitioned;
     };
 
 }
 
-#endif // BACKEND_COMMON_COMMANDBUFFERGL_H_
+#endif // BACKEND_COMMON_COMMANDBUFFER_H_

--- a/src/backend/common/CommandBufferStateTracker.cpp
+++ b/src/backend/common/CommandBufferStateTracker.cpp
@@ -1,0 +1,500 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "CommandBufferStateTracker.h"
+
+#include "Forward.h"
+#include "BindGroup.h"
+#include "BindGroupLayout.h"
+#include "BitSetIterator.h"
+#include "Buffer.h"
+#include "Framebuffer.h"
+#include "InputState.h"
+#include "Pipeline.h"
+#include "PipelineLayout.h"
+#include "RenderPass.h"
+#include "Texture.h"
+
+namespace backend {
+    CommandBufferStateTracker::CommandBufferStateTracker(CommandBufferBuilder* builder)
+        : builder(builder) {
+    }
+
+    bool CommandBufferStateTracker::HaveRenderPass() const {
+        return currentRenderPass != nullptr;
+    }
+
+    bool CommandBufferStateTracker::ValidateCanCopy() const {
+        if (currentRenderPass) {
+            builder->HandleError("Copy cannot occur during a render pass");
+            return false;
+        }
+        return true;
+    }
+
+    bool CommandBufferStateTracker::ValidateCanUseBufferAs(BufferBase* buffer, nxt::BufferUsageBit usage) const {
+        if (!BufferHasGuaranteedUsageBit(buffer, usage)) {
+            builder->HandleError("Buffer is not in the necessary usage");
+            return false;
+        }
+        return true;
+    }
+
+    bool CommandBufferStateTracker::ValidateCanUseTextureAs(TextureBase* texture, nxt::TextureUsageBit usage) const {
+        if (!TextureHasGuaranteedUsageBit(texture, usage)) {
+            builder->HandleError("Texture is not in the necessary usage");
+            return false;
+        }
+        return true;
+    }
+
+    bool CommandBufferStateTracker::ValidateCanDispatch() {
+        constexpr ValidationAspects requiredAspects =
+            1 << VALIDATION_ASPECT_COMPUTE_PIPELINE |
+            1 << VALIDATION_ASPECT_BIND_GROUPS;
+        if ((requiredAspects & ~aspects).none()) {
+            // Fast return-true path if everything is good
+            return true;
+        }
+
+        if (!aspects[VALIDATION_ASPECT_COMPUTE_PIPELINE]) {
+            builder->HandleError("No active compute pipeline");
+            return false;
+        }
+        // Compute the lazily computed aspects
+        if (!RecomputeHaveAspectBindGroups()) {
+            builder->HandleError("Some bind groups are not set");
+            return false;
+        }
+        return true;
+    }
+
+    bool CommandBufferStateTracker::ValidateCanDrawArrays() {
+        // TODO(kainino@chromium.org): Check for a current render pass
+        constexpr ValidationAspects requiredAspects =
+            1 << VALIDATION_ASPECT_RENDER_PIPELINE |
+            1 << VALIDATION_ASPECT_BIND_GROUPS |
+            1 << VALIDATION_ASPECT_VERTEX_BUFFERS;
+        if ((requiredAspects & ~aspects).none()) {
+            // Fast return-true path if everything is good
+            return true;
+        }
+
+        return RevalidateCanDraw();
+    }
+
+    bool CommandBufferStateTracker::ValidateCanDrawElements() {
+        // TODO(kainino@chromium.org): Check for a current render pass
+        constexpr ValidationAspects requiredAspects =
+            1 << VALIDATION_ASPECT_RENDER_PIPELINE |
+            1 << VALIDATION_ASPECT_BIND_GROUPS |
+            1 << VALIDATION_ASPECT_VERTEX_BUFFERS |
+            1 << VALIDATION_ASPECT_INDEX_BUFFER;
+        if ((requiredAspects & ~aspects).none()) {
+            // Fast return-true path if everything is good
+            return true;
+        }
+
+        if (!aspects[VALIDATION_ASPECT_INDEX_BUFFER]) {
+            builder->HandleError("Cannot DrawElements without index buffer set");
+            return false;
+        }
+        return RevalidateCanDraw();
+    }
+
+    bool CommandBufferStateTracker::BeginSubpass() {
+        if (currentRenderPass == nullptr) {
+            builder->HandleError("Can't begin a subpass without an active render pass");
+            return false;
+        }
+        if (subpassActive) {
+            builder->HandleError("Can't begin a subpass without ending the previous subpass");
+            return false;
+        }
+        if (currentSubpass >= currentRenderPass->GetSubpassCount()) {
+            builder->HandleError("Can't begin a subpass beyond the last subpass");
+            return false;
+        }
+
+        auto& subpassInfo = currentRenderPass->GetSubpassInfo(currentSubpass);
+        for (auto location : IterateBitSet(subpassInfo.colorAttachmentsSet)) {
+            auto attachmentSlot = subpassInfo.colorAttachments[location];
+            auto* tv = currentFramebuffer->GetTextureView(attachmentSlot);
+            // TODO(kainino@chromium.org): the TextureView can only be null
+            // because of the null=backbuffer hack (null representing the
+            // backbuffer). Once that hack is removed (once we have WSI)
+            // this check isn't needed.
+            if (tv == nullptr) {
+                continue;
+            }
+
+            auto* texture = tv->GetTexture();
+            if (texture->HasFrozenUsage(nxt::TextureUsageBit::ColorAttachment)) {
+                continue;
+            }
+            if (!texture->IsTransitionPossible(nxt::TextureUsageBit::ColorAttachment)) {
+                builder->HandleError("Can't transition attachment to ColorAttachment usage");
+                return false;
+            }
+            mostRecentTextureUsages[texture] = nxt::TextureUsageBit::ColorAttachment;
+            texturesTransitioned.insert(texture);
+        }
+
+        subpassActive = true;
+        return true;
+    };
+
+    bool CommandBufferStateTracker::EndSubpass() {
+        if (currentRenderPass == nullptr) {
+            builder->HandleError("Can't end a subpass without an active render pass");
+            return false;
+        }
+        if (!subpassActive) {
+            builder->HandleError("Can't end a subpass without beginning one");
+            return false;
+        }
+
+        auto& subpassInfo = currentRenderPass->GetSubpassInfo(currentSubpass);
+        for (auto location : IterateBitSet(subpassInfo.colorAttachmentsSet)) {
+            auto attachmentSlot = subpassInfo.colorAttachments[location];
+            auto* tv = currentFramebuffer->GetTextureView(attachmentSlot);
+            // TODO(kainino@chromium.org): the TextureView can only be null
+            // because of the null=backbuffer hack (null representing the
+            // backbuffer). Once that hack is removed (once we have WSI)
+            // this check isn't needed.
+            if (tv == nullptr) {
+                continue;
+            }
+
+            auto* texture = tv->GetTexture();
+            if (texture->IsFrozen()) {
+                continue;
+            }
+
+            mostRecentTextureUsages[texture] = nxt::TextureUsageBit::None;
+        }
+
+        currentSubpass += 1;
+        subpassActive = false;
+        UnsetPipeline();
+        return true;
+    };
+
+    bool CommandBufferStateTracker::BeginRenderPass(RenderPassBase* renderPass, FramebufferBase* framebuffer) {
+        if (currentRenderPass != nullptr) {
+            builder->HandleError("A render pass is already active");
+            return false;
+        }
+        if (!framebuffer->GetRenderPass()->IsCompatibleWith(renderPass)) {
+            builder->HandleError("Framebuffer is incompatible with this render pass");
+            return false;
+        }
+
+        currentRenderPass = renderPass;
+        currentFramebuffer = framebuffer;
+        currentSubpass = 0;
+        subpassActive = false;
+
+        // TODO(kainino@chromium.org): remove this when AdvanceSubpass is removed.
+        if (!BeginSubpass()) {
+            return false;
+        }
+
+        UnsetPipeline();
+        return true;
+    }
+
+    bool CommandBufferStateTracker::AdvanceSubpass() {
+        // TODO(kainino@chromium.org): remove this function when AdvanceSubpass is removed.
+        return EndSubpass() && BeginSubpass();
+    }
+
+    bool CommandBufferStateTracker::EndRenderPass() {
+        if (currentRenderPass == nullptr) {
+            builder->HandleError("No render pass is currently active");
+            return false;
+        }
+        // TODO(kainino@chromium.org): remove this when AdvanceSubpass is removed.
+        if (!EndSubpass()) {
+            return false;
+        }
+        if (subpassActive) {
+            builder->HandleError("Can't end a render pass while a subpass is active");
+            return false;
+        }
+        if (currentSubpass < currentRenderPass->GetSubpassCount() - 1) {
+            builder->HandleError("Can't end a render pass before the last subpass");
+            return false;
+        }
+        currentRenderPass = nullptr;
+        currentFramebuffer = nullptr;
+
+        return true;
+    }
+
+    bool CommandBufferStateTracker::SetPipeline(PipelineBase* pipeline) {
+        PipelineLayoutBase* layout = pipeline->GetLayout();
+
+        if (pipeline->IsCompute()) {
+            if (currentRenderPass) {
+                builder->HandleError("Can't use a compute pipeline while a render pass is active");
+                return false;
+            }
+            aspects.set(VALIDATION_ASPECT_COMPUTE_PIPELINE);
+        } else {
+            if (!currentRenderPass) {
+                builder->HandleError("A render pass must be active when a render pipeline is set");
+                return false;
+            }
+            if (!pipeline->GetRenderPass()->IsCompatibleWith(currentRenderPass)) {
+                builder->HandleError("Pipeline is incompatible with this render pass");
+                return false;
+            }
+            aspects.set(VALIDATION_ASPECT_RENDER_PIPELINE);
+        }
+        aspects.reset(VALIDATION_ASPECT_BIND_GROUPS);
+        bindgroupsSet = ~layout->GetBindGroupsLayoutMask();
+
+        // Only bindgroups that were not the same layout in the last pipeline need to be set again.
+        if (lastPipeline) {
+            PipelineLayoutBase* lastLayout = lastPipeline->GetLayout();
+            for (uint32_t i = 0; i < kMaxBindGroups; ++i) {
+                if (lastLayout->GetBindGroupLayout(i) == layout->GetBindGroupLayout(i)) {
+                    bindgroupsSet |= uint64_t(1) << i;
+                }
+            }
+        }
+
+        lastPipeline = pipeline;
+        return true;
+    }
+
+    bool CommandBufferStateTracker::SetBindGroup(uint32_t index, BindGroupBase* bindgroup) {
+        if (bindgroup->GetLayout() != lastPipeline->GetLayout()->GetBindGroupLayout(index)) {
+            builder->HandleError("Bind group layout mismatch");
+            return false;
+        }
+        if (!ValidateBindGroupUsages(bindgroup)) {
+            return false;
+        }
+        bindgroupsSet.set(index);
+
+        return true;
+    }
+
+    bool CommandBufferStateTracker::SetIndexBuffer(BufferBase* buffer) {
+        if (!HavePipeline()) {
+            builder->HandleError("Can't set the index buffer without a pipeline");
+            return false;
+        }
+
+        auto usage = nxt::BufferUsageBit::Index;
+        if (!BufferHasGuaranteedUsageBit(buffer, usage)) {
+            builder->HandleError("Buffer needs the index usage bit to be guaranteed");
+            return false;
+        }
+
+        aspects.set(VALIDATION_ASPECT_INDEX_BUFFER);
+        return true;
+    }
+
+    bool CommandBufferStateTracker::SetVertexBuffer(uint32_t index, BufferBase* buffer) {
+        if (!HavePipeline()) {
+            builder->HandleError("Can't set vertex buffers without a pipeline");
+            return false;
+        }
+
+        auto usage = nxt::BufferUsageBit::Vertex;
+        if (!BufferHasGuaranteedUsageBit(buffer, usage)) {
+            builder->HandleError("Buffer needs vertex usage bit to be guaranteed");
+            return false;
+        }
+
+        inputsSet.set(index);
+        return true;
+    }
+
+    bool CommandBufferStateTracker::TransitionBufferUsage(BufferBase* buffer, nxt::BufferUsageBit usage) {
+        if (!buffer->IsTransitionPossible(usage)) {
+            if (buffer->IsFrozen()) {
+                builder->HandleError("Buffer transition not possible (usage is frozen)");
+            } else if (!BufferBase::IsUsagePossible(buffer->GetAllowedUsage(), usage)) {
+                builder->HandleError("Buffer transition not possible (usage not allowed)");
+            } else {
+                builder->HandleError("Buffer transition not possible");
+            }
+            return false;
+        }
+
+        mostRecentBufferUsages[buffer] = usage;
+        buffersTransitioned.insert(buffer);
+        return true;
+    }
+
+    bool CommandBufferStateTracker::TransitionTextureUsage(TextureBase* texture, nxt::TextureUsageBit usage) {
+        if (!IsTextureTransitionPossible(texture, usage)) {
+            if (texture->IsFrozen()) {
+                builder->HandleError("Texture transition not possible (usage is frozen)");
+            } else if (!TextureBase::IsUsagePossible(texture->GetAllowedUsage(), usage)) {
+                builder->HandleError("Texture transition not possible (usage not allowed)");
+            } else {
+                builder->HandleError("Texture transition not possible");
+            }
+            return false;
+        }
+
+        mostRecentTextureUsages[texture] = usage;
+        texturesTransitioned.insert(texture);
+        return true;
+    }
+
+    bool CommandBufferStateTracker::BufferHasGuaranteedUsageBit(BufferBase* buffer, nxt::BufferUsageBit usage) const {
+        ASSERT(usage != nxt::BufferUsageBit::None && nxt::HasZeroOrOneBits(usage));
+        if (buffer->HasFrozenUsage(usage)) {
+            return true;
+        }
+        auto it = mostRecentBufferUsages.find(buffer);
+        return it != mostRecentBufferUsages.end() && (it->second & usage);
+    };
+
+    bool CommandBufferStateTracker::TextureHasGuaranteedUsageBit(TextureBase* texture, nxt::TextureUsageBit usage) const {
+        ASSERT(usage != nxt::TextureUsageBit::None && nxt::HasZeroOrOneBits(usage));
+        if (texture->HasFrozenUsage(usage)) {
+            return true;
+        }
+        auto it = mostRecentTextureUsages.find(texture);
+        return it != mostRecentTextureUsages.end() && (it->second & usage);
+    };
+
+    bool CommandBufferStateTracker::IsTextureTransitionPossible(TextureBase* texture, nxt::TextureUsageBit usage) const {
+        const nxt::TextureUsageBit attachmentUsages =
+            nxt::TextureUsageBit::ColorAttachment |
+            nxt::TextureUsageBit::DepthStencilAttachment;
+        ASSERT(usage != nxt::TextureUsageBit::None && nxt::HasZeroOrOneBits(usage));
+        if (usage & attachmentUsages) {
+            return false;
+        }
+        auto it = mostRecentTextureUsages.find(texture);
+        if (it != mostRecentTextureUsages.end()) {
+            if (it->second & attachmentUsages) {
+                return false;
+            }
+        }
+        return texture->IsTransitionPossible(usage);
+    };
+
+    bool CommandBufferStateTracker::RecomputeHaveAspectBindGroups() {
+        if (aspects[VALIDATION_ASPECT_BIND_GROUPS]) {
+            return true;
+        }
+        if (bindgroupsSet.all()) {
+            aspects.set(VALIDATION_ASPECT_BIND_GROUPS);
+            return true;
+        }
+        return false;
+    }
+
+    bool CommandBufferStateTracker::RecomputeHaveAspectVertexBuffers() {
+        if (aspects[VALIDATION_ASPECT_VERTEX_BUFFERS]) {
+            return true;
+        }
+        auto requiredInputs = lastPipeline->GetInputState()->GetInputsSetMask();
+        if ((inputsSet & ~requiredInputs).none()) {
+            aspects.set(VALIDATION_ASPECT_VERTEX_BUFFERS);
+            return true;
+        }
+        return false;
+    }
+
+    bool CommandBufferStateTracker::HavePipeline() const {
+        constexpr ValidationAspects pipelineAspects =
+            1 << VALIDATION_ASPECT_COMPUTE_PIPELINE |
+            1 << VALIDATION_ASPECT_RENDER_PIPELINE;
+        return (aspects & pipelineAspects).any();
+    }
+
+    bool CommandBufferStateTracker::ValidateBindGroupUsages(BindGroupBase* group) const {
+        const auto& layoutInfo = group->GetLayout()->GetBindingInfo();
+        for (size_t i = 0; i < kMaxBindingsPerGroup; ++i) {
+            if (!layoutInfo.mask[i]) {
+                continue;
+            }
+
+            nxt::BindingType type = layoutInfo.types[i];
+            switch (type) {
+                case nxt::BindingType::UniformBuffer:
+                case nxt::BindingType::StorageBuffer:
+                    {
+                        nxt::BufferUsageBit requiredUsage;
+                        switch (type) {
+                            case nxt::BindingType::UniformBuffer:
+                                requiredUsage = nxt::BufferUsageBit::Uniform;
+                                break;
+
+                            case nxt::BindingType::StorageBuffer:
+                                requiredUsage = nxt::BufferUsageBit::Storage;
+                                break;
+
+                            default:
+                                assert(false);
+                                return false;
+                        }
+
+                        auto buffer = group->GetBindingAsBufferView(i)->GetBuffer();
+                        if (!BufferHasGuaranteedUsageBit(buffer, requiredUsage)) {
+                            builder->HandleError("Can't guarantee buffer usage needed by bind group");
+                            return false;
+                        }
+                    }
+                    break;
+                case nxt::BindingType::SampledTexture:
+                    {
+                        auto requiredUsage = nxt::TextureUsageBit::Sampled;
+
+                        auto texture = group->GetBindingAsTextureView(i)->GetTexture();
+                        if (!TextureHasGuaranteedUsageBit(texture, requiredUsage)) {
+                            builder->HandleError("Can't guarantee texture usage needed by bind group");
+                            return false;
+                        }
+                    }
+                    break;
+                case nxt::BindingType::Sampler:
+                    continue;
+            }
+        }
+        return true;
+    };
+
+    bool CommandBufferStateTracker::RevalidateCanDraw() {
+        if (!aspects[VALIDATION_ASPECT_RENDER_PIPELINE]) {
+            builder->HandleError("No active render pipeline");
+            return false;
+        }
+        // Compute the lazily computed aspects
+        if (!RecomputeHaveAspectBindGroups()) {
+            builder->HandleError("Some bind groups are not set");
+            return false;
+        }
+        if (!RecomputeHaveAspectVertexBuffers()) {
+            builder->HandleError("Some vertex buffers are not set");
+            return false;
+        }
+        return true;
+    }
+
+    void CommandBufferStateTracker::UnsetPipeline() {
+        // All of the aspects (currently) are pipeline-dependent.
+        aspects.reset();
+    }
+}

--- a/src/backend/common/CommandBufferStateTracker.h
+++ b/src/backend/common/CommandBufferStateTracker.h
@@ -1,0 +1,102 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_COMMON_COMMANDBUFFERSTATETRACKER_H
+#define BACKEND_COMMON_COMMANDBUFFERSTATETRACKER_H
+
+#include "CommandBuffer.h"
+
+#include <bitset>
+#include <map>
+#include <set>
+
+namespace backend {
+    class CommandBufferStateTracker {
+        public:
+            explicit CommandBufferStateTracker(CommandBufferBuilder* builder);
+
+            // Non-state-modifying validation functions
+            bool HaveRenderPass() const;
+            bool ValidateCanCopy() const;
+            bool ValidateCanUseBufferAs(BufferBase* buffer, nxt::BufferUsageBit usage) const;
+            bool ValidateCanUseTextureAs(TextureBase* texture, nxt::TextureUsageBit usage) const;
+            bool ValidateCanDispatch();
+            bool ValidateCanDrawArrays();
+            bool ValidateCanDrawElements();
+
+            // State-modifying methods
+            bool BeginSubpass();
+            bool EndSubpass();
+            bool BeginRenderPass(RenderPassBase* renderPass, FramebufferBase* framebuffer);
+            bool AdvanceSubpass();
+            bool EndRenderPass();
+            bool SetPipeline(PipelineBase* pipeline);
+            bool SetBindGroup(uint32_t index, BindGroupBase* bindgroup);
+            bool SetIndexBuffer(BufferBase* buffer);
+            bool SetVertexBuffer(uint32_t index, BufferBase* buffer);
+            bool TransitionBufferUsage(BufferBase* buffer, nxt::BufferUsageBit usage);
+            bool TransitionTextureUsage(TextureBase* texture, nxt::TextureUsageBit usage);
+
+            // These collections are copied to the CommandBuffer at build time.
+            // These pointers will remain valid since they are referenced by
+            // the bind groups which are referenced by this command buffer.
+            std::set<BufferBase*> buffersTransitioned;
+            std::set<TextureBase*> texturesTransitioned;
+
+        private:
+            enum ValidationAspect {
+                VALIDATION_ASPECT_RENDER_PIPELINE,
+                VALIDATION_ASPECT_COMPUTE_PIPELINE,
+                VALIDATION_ASPECT_BIND_GROUPS,
+                VALIDATION_ASPECT_VERTEX_BUFFERS,
+                VALIDATION_ASPECT_INDEX_BUFFER,
+
+                VALIDATION_ASPECT_COUNT
+            };
+            using ValidationAspects = std::bitset<VALIDATION_ASPECT_COUNT>;
+
+            // Usage helper functions
+            bool BufferHasGuaranteedUsageBit(BufferBase* buffer, nxt::BufferUsageBit usage) const;
+            bool TextureHasGuaranteedUsageBit(TextureBase* texture, nxt::TextureUsageBit usage) const;
+            bool IsTextureTransitionPossible(TextureBase* texture, nxt::TextureUsageBit usage) const;
+
+            // Queries for lazily evaluated aspects
+            bool RecomputeHaveAspectBindGroups();
+            bool RecomputeHaveAspectVertexBuffers();
+
+            bool HavePipeline() const;
+            bool ValidateBindGroupUsages(BindGroupBase* group) const;
+            bool RevalidateCanDraw();
+
+            void UnsetPipeline();
+
+            CommandBufferBuilder* builder;
+
+            ValidationAspects aspects;
+
+            std::bitset<kMaxBindGroups> bindgroupsSet;
+            std::bitset<kMaxVertexInputs> inputsSet;
+            PipelineBase* lastPipeline = nullptr;
+
+            std::map<BufferBase*, nxt::BufferUsageBit> mostRecentBufferUsages;
+            std::map<TextureBase*, nxt::TextureUsageBit> mostRecentTextureUsages;
+
+            RenderPassBase* currentRenderPass = nullptr;
+            FramebufferBase* currentFramebuffer = nullptr;
+            bool subpassActive = false;
+            uint32_t currentSubpass = 0;
+    };
+}
+
+#endif // BACKEND_COMMON_COMMANDBUFFERSTATETRACKER_H


### PR DESCRIPTION
Dependent on #18, so this will be easier to review after that's merged and this is rebased. Defer if you want.

Later (after this lands) I plan to move more of the logic from CommandBuffer.cpp to CommandBufferStateTracker.cpp.