### PR TITLE
Validation tests

### DIFF
--- a/generator/main.py
+++ b/generator/main.py
@@ -397,6 +397,7 @@ def main():
         additional_params = {'native_methods': lambda typ: cpp_native_methods(api_params['types'], typ)}
         renders.append(FileRender('apicpp.h', 'nxt/nxtcpp.h', [base_params, api_params, additional_params]))
         renders.append(FileRender('apicpp.cpp', 'nxt/nxtcpp.cpp', [base_params, api_params, additional_params]))
+        renders.append(FileRender('apicpp_traits.h', 'nxt/nxtcpp_traits.h', [base_params, api_params, additional_params]))
 
     if 'mock_nxt' in targets:
         renders.append(FileRender('mock_api.h', 'mock/mock_nxt.h', [base_params, api_params, c_params]))

--- a/generator/templates/apicpp.h
+++ b/generator/templates/apicpp.h
@@ -58,8 +58,7 @@ namespace nxt {
     template<typename Derived, typename CType>
     class ObjectBase {
         public:
-            ObjectBase(): handle(nullptr) {
-            }
+            ObjectBase() = default;
             ObjectBase(CType handle): handle(handle) {
                 if (handle) Derived::NxtReference(handle);
             }
@@ -71,14 +70,13 @@ namespace nxt {
             Derived& operator=(ObjectBase const& other) = delete;
 
             ObjectBase(ObjectBase&& other) {
-                Derived::NxtRelease(handle);
                 handle = other.handle;
                 other.handle = 0;
             }
             Derived& operator=(ObjectBase&& other) {
                 if (&other == this) return static_cast<Derived&>(*this);
 
-                Derived::NxtRelease(handle);
+                if (handle) Derived::NxtRelease(handle);
                 handle = other.handle;
                 other.handle = 0;
 
@@ -106,7 +104,7 @@ namespace nxt {
             }
 
         protected:
-            CType handle;
+            CType handle = nullptr;
     };
 
     {% macro render_cpp_method_declaration(type, method) %}

--- a/generator/templates/apicpp_traits.h
+++ b/generator/templates/apicpp_traits.h
@@ -1,0 +1,43 @@
+//* Copyright 2017 The NXT Authors
+//*
+//* Licensed under the Apache License, Version 2.0 (the "License");
+//* you may not use this file except in compliance with the License.
+//* You may obtain a copy of the License at
+//*
+//*     http://www.apache.org/licenses/LICENSE-2.0
+//*
+//* Unless required by applicable law or agreed to in writing, software
+//* distributed under the License is distributed on an "AS IS" BASIS,
+//* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//* See the License for the specific language governing permissions and
+//* limitations under the License.
+
+#ifndef NXTCPP_TRAITS_H
+#define NXTCPP_TRAITS_H
+
+#include "nxtcpp.h"
+
+#include <type_traits>
+
+namespace nxt {
+
+    template<typename Builder>
+    using BuiltObject = decltype(std::declval<Builder>().GetResult());
+
+    template<typename BuiltObject>
+    struct BuiltObjectTrait {
+    };
+
+    {% for type in by_category["object"] if type.is_builder %}
+        template<>
+        struct BuiltObjectTrait<BuiltObject<{{as_cppType(type.name)}}>> {
+            using Builder = {{as_cppType(type.name)}};
+        };
+    {% endfor %}
+
+    template<typename BuiltObject>
+    using Builder = typename BuiltObjectTrait<BuiltObject>::Builder;
+
+};
+
+#endif // NXTCPP_TRAITS_H

--- a/src/backend/common/Builder.cpp
+++ b/src/backend/common/Builder.cpp
@@ -54,7 +54,7 @@ namespace backend {
         gotStatus = true;
 
         storedStatus = status;
-        storedMessage = std::move(message);
+        storedMessage = message;
     }
 
     bool BuilderBase::HandleResult(RefCounted* result) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 set(TESTS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(UNITTESTS_DIR ${TESTS_DIR}/unittests)
+set(VALIDATION_TESTS_DIR ${UNITTESTS_DIR}/validation)
 add_executable(nxt_unittests
     ${UNITTESTS_DIR}/BitSetIteratorTests.cpp
     ${UNITTESTS_DIR}/CommandAllocatorTests.cpp
@@ -24,6 +25,9 @@ add_executable(nxt_unittests
     ${UNITTESTS_DIR}/RefCountedTests.cpp
     ${UNITTESTS_DIR}/ToBackendTests.cpp
     ${UNITTESTS_DIR}/WireTests.cpp
+    ${VALIDATION_TESTS_DIR}/BufferValidationTest.cpp
+    ${VALIDATION_TESTS_DIR}/ValidationTest.cpp
+    ${VALIDATION_TESTS_DIR}/ValidationTest.h
     ${TESTS_DIR}/UnittestsMain.cpp
 )
 target_link_libraries(nxt_unittests gtest nxt_backend mock_nxt nxt_wire)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(nxt_unittests
     ${UNITTESTS_DIR}/CommandAllocatorTests.cpp
     ${UNITTESTS_DIR}/EnumClassBitmasksTests.cpp
     ${UNITTESTS_DIR}/MathTests.cpp
+    ${UNITTESTS_DIR}/ObjectBaseTests.cpp
     ${UNITTESTS_DIR}/PerStageTests.cpp
     ${UNITTESTS_DIR}/RefCountedTests.cpp
     ${UNITTESTS_DIR}/ToBackendTests.cpp

--- a/src/tests/unittests/ObjectBaseTests.cpp
+++ b/src/tests/unittests/ObjectBaseTests.cpp
@@ -1,0 +1,123 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "nxt/nxtcpp.h"
+
+class Object : public nxt::ObjectBase<Object, int*> {
+    public:
+        using ObjectBase::ObjectBase;
+        using ObjectBase::operator=;
+
+        static void NxtReference(int* handle) {
+            ASSERT_LT(0, *handle);
+            *handle += 1;
+        }
+        static void NxtRelease(int* handle) {
+            ASSERT_LT(0, *handle);
+            *handle -= 1;
+        }
+};
+
+// Test that creating an C++ object from a C object takes a ref.
+// Also test that the C++ object destructor removes a ref.
+TEST(ObjectBase, CTypeConstructor) {
+    int refcount = 1;
+    {
+        Object obj(&refcount);
+        ASSERT_EQ(2, refcount);
+    }
+    ASSERT_EQ(1, refcount);
+}
+
+// Test consuming a C object into a C++ object doesn't take a ref.
+TEST(ObjectBase, AcquireConstruction) {
+    int refcount = 1;
+    {
+        Object object = Object::Acquire(&refcount);
+        ASSERT_EQ(1, refcount);
+    }
+    ASSERT_EQ(0, refcount);
+}
+
+// Test that cloning takes a new ref. Also test .Get().
+TEST(ObjectBase, Clone) {
+    int refcount = 1;
+    {
+        Object obj1(&refcount);
+        Object obj2 = obj1.Clone();
+
+        ASSERT_EQ(3, refcount);
+        ASSERT_EQ(&refcount, obj1.Get());
+        ASSERT_EQ(&refcount, obj2.Get());
+    }
+    ASSERT_EQ(1, refcount);
+}
+
+// Test that Release consumes the C++ object into a C object and doesn't release
+TEST(ObjectBase, Release) {
+    int refcount = 1;
+    {
+        Object obj(&refcount);
+        ASSERT_EQ(2, refcount);
+
+        ASSERT_EQ(&refcount, obj.Release());
+        ASSERT_EQ(nullptr, obj.Get());
+        ASSERT_EQ(2, refcount);
+    }
+    ASSERT_EQ(2, refcount);
+}
+
+// Test using C++ objects in conditions
+TEST(ObjectBase, OperatorBool) {
+    int refcount = 1;
+    Object trueObj(&refcount);
+    Object falseObj;
+
+    if (falseObj || !trueObj) {
+        ASSERT_TRUE(false);
+    }
+}
+
+// Test the move constructor of C++ objects
+TEST(ObjectBase, MoveConstructor) {
+    int refcount = 1;
+    Object source(&refcount);
+    Object destination(std::move(source));
+
+    ASSERT_EQ(source.Get(), nullptr);
+    ASSERT_EQ(destination.Get(), &refcount);
+    ASSERT_EQ(2, refcount);
+
+    destination = Object();
+    ASSERT_EQ(refcount, 1);
+}
+
+// Test the move assignment of C++ objects
+TEST(ObjectBase, MoveAssignment) {
+    int refcount = 1;
+    Object source(&refcount);
+
+    Object destination;
+    destination = std::move(source);
+
+    ASSERT_EQ(source.Get(), nullptr);
+    ASSERT_EQ(destination.Get(), &refcount);
+    ASSERT_EQ(2, refcount);
+
+    destination = Object();
+    ASSERT_EQ(refcount, 1);
+}
+

--- a/src/tests/unittests/WireTests.cpp
+++ b/src/tests/unittests/WireTests.cpp
@@ -23,7 +23,6 @@
 using namespace testing;
 using namespace nxt::wire;
 
-
 class MockDeviceErrorCallback {
     public:
         MOCK_METHOD2(Call, void(const char* message, nxtCallbackUserdata userdata));

--- a/src/tests/unittests/validation/BufferValidationTest.cpp
+++ b/src/tests/unittests/validation/BufferValidationTest.cpp
@@ -1,0 +1,37 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ValidationTest.h"
+
+class BufferValidationTest : public ValidationTest {
+};
+
+TEST_F(BufferValidationTest, Creation) {
+    // Success
+    nxt::Buffer buf0 = AssertWillBeSuccess(device.CreateBufferBuilder())
+        .SetSize(4)
+        .SetAllowedUsage(nxt::BufferUsageBit::Uniform)
+        .GetResult();
+
+    // Test failure when specifying properties multiple times
+    nxt::Buffer buf1 = AssertWillBeError(device.CreateBufferBuilder())
+        .SetSize(4)
+        .SetSize(3)
+        .GetResult();
+
+    // Test failure when properties are missing
+    nxt::Buffer buf2 = AssertWillBeError(device.CreateBufferBuilder())
+        .SetSize(4)
+        .GetResult();
+}

--- a/src/tests/unittests/validation/ValidationTest.cpp
+++ b/src/tests/unittests/validation/ValidationTest.cpp
@@ -1,0 +1,70 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ValidationTest.h"
+
+#include "nxt/nxt.h"
+
+namespace backend {
+    namespace null {
+        void Init(nxtProcTable* procs, nxtDevice* device);
+    }
+}
+
+ValidationTest::ValidationTest() {
+    nxtProcTable procs;
+    nxtDevice cDevice;
+    backend::null::Init(&procs, &cDevice);
+
+    nxtSetProcs(&procs);
+    device = nxt::Device::Acquire(cDevice);
+}
+
+ValidationTest::~ValidationTest() {
+    // We need to destroy NXT objects before setting the procs to null otherwise the nxt*Release
+    // will call a nullptr
+    device = nxt::Device();
+    nxtSetProcs(nullptr);
+}
+
+void ValidationTest::TearDown() {
+    for (auto& expectation : expectations) {
+        std::string name = expectation.debugName;
+        if (name.empty()) {
+            name = "<no debug name set>";
+        }
+
+        ASSERT_TRUE(expectation.gotStatus) << "Didn't get a status for " << name;
+
+        ASSERT_NE(NXT_BUILDER_ERROR_STATUS_UNKNOWN, expectation.gotStatus) << "Got unknown status for " << name;
+
+        bool wasSuccess = expectation.status == NXT_BUILDER_ERROR_STATUS_SUCCESS;
+        ASSERT_EQ(expectation.expectSuccess, wasSuccess)
+            << "Got wrong status value for " << name
+            << ", status was " << expectation.status << " with \"" << expectation.statusMessage << "\"";
+    }
+}
+
+void ValidationTest::OnBuilderErrorStatus(nxtBuilderErrorStatus status, const char* message, nxt::CallbackUserdata userdata1, nxt::CallbackUserdata userdata2) {
+    auto* self = reinterpret_cast<ValidationTest*>(static_cast<uintptr_t>(userdata1));
+    size_t index = userdata2;
+
+    ASSERT_LT(index, self->expectations.size());
+
+    auto& expectation = self->expectations[index];
+    ASSERT_FALSE(expectation.gotStatus);
+    expectation.gotStatus = true;
+    expectation.status = status;
+    expectation.statusMessage = message;
+}

--- a/src/tests/unittests/validation/ValidationTest.h
+++ b/src/tests/unittests/validation/ValidationTest.h
@@ -1,0 +1,87 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TESTS_UNITTESTS_VALIDATIONTEST_H_
+#define TESTS_UNITTESTS_VALIDATIONTEST_H_
+
+#include "gtest/gtest.h"
+#include "nxt/nxtcpp.h"
+#include "nxt/nxtcpp_traits.h"
+
+class ValidationTest : public testing::Test {
+    public:
+        ValidationTest();
+        ~ValidationTest();
+
+        // Use these methods to add expectations on the validation of a builder. The expectations are
+        // checked on test teardown. Adding an expectation is done like the following:
+        //
+        //     nxt::Foo foo = AssertWillBe[Success|Error](device.CreateFooBuilder(), "my foo")
+        //         .SetBar(1)
+        //         .GetResult();
+        //
+        // The string argument is optional but will be printed when an expectations is missed, this
+        // will help debug tests where multiple expectations are added.
+        template<typename Builder>
+        Builder AssertWillBeSuccess(Builder builder, std::string debugName = "");
+        template<typename Builder>
+        Builder AssertWillBeError(Builder builder, std::string debugName = "");
+
+        void TearDown() override;
+
+    protected:
+        nxt::Device device;
+
+    private:
+        struct BuilderStatusExpectations {
+            bool expectSuccess;
+            std::string debugName;
+
+            bool gotStatus = false;
+            std::string statusMessage;
+            nxtBuilderErrorStatus status;
+        };
+        std::vector<BuilderStatusExpectations> expectations;
+
+        template<typename Builder>
+        Builder AddExpectation(Builder& builder, std::string debugName, bool expectSuccess);
+
+        static void OnBuilderErrorStatus(nxtBuilderErrorStatus status, const char* message, nxt::CallbackUserdata userdata1, nxt::CallbackUserdata userdata2);
+};
+
+template<typename Builder>
+Builder ValidationTest::AssertWillBeSuccess(Builder builder, std::string debugName) {
+    return AddExpectation(builder, debugName, true);
+}
+
+template<typename Builder>
+Builder ValidationTest::AssertWillBeError(Builder builder, std::string debugName) {
+    return AddExpectation(builder, debugName, false);
+}
+
+template<typename Builder>
+Builder ValidationTest::AddExpectation(Builder& builder, std::string debugName, bool expectSuccess) {
+    uint64_t userdata1 = reinterpret_cast<uintptr_t>(this);
+    uint64_t userdata2 = expectations.size();
+    builder.SetErrorCallback(OnBuilderErrorStatus, userdata1, userdata2);
+
+    expectations.emplace_back();
+    auto& expectation = expectations.back();
+    expectation.expectSuccess = expectSuccess;
+    expectation.debugName = debugName;
+
+    return std::move(builder);
+}
+
+#endif // TESTS_UNITTESTS_VALIDATIONTEST_H_


### PR DESCRIPTION
PTAL, this is adds the skeleton of validation tests.

I went through many iterations to try to make this work seamlessly with an added wire between the test code and the null backend, but didn't find a good way to do it (I stopped short of generating a whole new nxtcpp just for test purpose).
If we ever want to make validation tests work with the wire, we could create an alternative to TerribleCommandBuffer that doesn't buffer at all and basically makes all nxt calls synchronous.