### PR TITLE
Move Resource Barriers to D3D12 Binding

### DIFF
--- a/src/backend/d3d12/CommandBufferD3D12.cpp
+++ b/src/backend/d3d12/CommandBufferD3D12.cpp
@@ -57,17 +57,7 @@ namespace d3d12 {
                           D3D12_RECT scissorRect = { 0.f, 0.f, width, height };
                           commandList->RSSetViewports(1, &viewport);
                           commandList->RSSetScissorRects(1, &scissorRect);
-
-                          // TODO(enga@google.com): Set the back buffer as the render target only when a new render target is set
-                          D3D12_RESOURCE_BARRIER resourceBarrier;
-                          resourceBarrier.Transition.pResource = device->GetNextRenderTarget().Get();
-                          resourceBarrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PRESENT;
-                          resourceBarrier.Transition.StateAfter = D3D12_RESOURCE_STATE_RENDER_TARGET;
-                          resourceBarrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-                          resourceBarrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-                          resourceBarrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-                          commandList->ResourceBarrier(1, &resourceBarrier);
-                          commandList->OMSetRenderTargets(1, &device->GetNextRenderTargetDescriptor(), FALSE, nullptr);
+                          commandList->OMSetRenderTargets(1, &device->GetCurrentRenderTargetDescriptor(), FALSE, nullptr);
                       }
                       break;
 
@@ -109,16 +99,6 @@ namespace d3d12 {
                   case Command::EndRenderPass:
                       {
                           EndRenderPassCmd* cmd = commands.NextCommand<EndRenderPassCmd>();
-
-                          // TODO(enga@google.com): Present the back buffer only before swap
-                          D3D12_RESOURCE_BARRIER resourceBarrier;
-                          resourceBarrier.Transition.pResource = device->GetNextRenderTarget().Get();
-                          resourceBarrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
-                          resourceBarrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PRESENT;
-                          resourceBarrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-                          resourceBarrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-                          resourceBarrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-                          commandList->ResourceBarrier(1, &resourceBarrier);
                       }
                       break;
 

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -37,9 +37,9 @@ namespace d3d12 {
         return backendDevice->GetCommandQueue();
     }
 
-    void SetNextRenderTarget(nxtDevice device, ComPtr<ID3D12Resource> renderTargetResource, D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor) {
+    void SetNextRenderTargetDescriptor(nxtDevice device, D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor) {
         Device* backendDevice = reinterpret_cast<Device*>(device);
-        backendDevice->SetNextRenderTarget(renderTargetResource, renderTargetDescriptor);
+        backendDevice->SetNextRenderTargetDescriptor(renderTargetDescriptor);
     }
 
     void ASSERT_SUCCESS(HRESULT hr) {
@@ -64,16 +64,11 @@ namespace d3d12 {
         return commandQueue;
     }
 
-    ComPtr<ID3D12Resource> Device::GetNextRenderTarget() {
-        return renderTargetResource;
-    }
-
-    D3D12_CPU_DESCRIPTOR_HANDLE Device::GetNextRenderTargetDescriptor() {
+    D3D12_CPU_DESCRIPTOR_HANDLE Device::GetCurrentRenderTargetDescriptor() {
         return renderTargetDescriptor;
     }
 
-    void Device::SetNextRenderTarget(ComPtr<ID3D12Resource> renderTargetResource, D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor) {
-        this->renderTargetResource = renderTargetResource;
+    void Device::SetNextRenderTargetDescriptor(D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor) {
         this->renderTargetDescriptor = renderTargetDescriptor;
     }
 

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -104,10 +104,9 @@ namespace d3d12 {
 
             ComPtr<ID3D12Device> GetD3D12Device();
             ComPtr<ID3D12CommandQueue> GetCommandQueue();
-            ComPtr<ID3D12Resource> GetNextRenderTarget();
-            D3D12_CPU_DESCRIPTOR_HANDLE GetNextRenderTargetDescriptor();
+            D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentRenderTargetDescriptor();
 
-            void SetNextRenderTarget(ComPtr<ID3D12Resource> renderTargetResource, D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor);
+            void SetNextRenderTargetDescriptor(D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor);
 
             // NXT API
             void Reference();
@@ -116,7 +115,6 @@ namespace d3d12 {
         private:
             ComPtr<ID3D12Device> d3d12Device;
             ComPtr<ID3D12CommandQueue> commandQueue;
-            ComPtr<ID3D12Resource> renderTargetResource;
             D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor;
     };
 

--- a/src/backend/d3d12/QueueD3D12.h
+++ b/src/backend/d3d12/QueueD3D12.h
@@ -37,6 +37,9 @@ namespace d3d12 {
 
             ComPtr<ID3D12CommandAllocator> commandAllocator;
             ComPtr<ID3D12GraphicsCommandList> commandList;
+            ComPtr<ID3D12Fence> fence;
+            uint64_t fenceValue = 0;
+            HANDLE fenceEvent;
     };
 
 }


### PR DESCRIPTION
- Moves resource barriers from the D3D12 backend to the binding. Previously, resource transitions between `D3D12_RESOURCE_STATE_RENDER_TARGET` and `D3D12_RESOURCE_STATE_PRESENT` were done at the start and end of every render pass. This is incorrect and should only be done when the render target changes and buffers are swapped.

- With the binding handling the frame transitions, each frame has it's own `ID3D12CommandAllocator` so the next frame can be started before the current frame is done. This is what Microsoft shows to do in their frame buffering [example](https://github.com/Microsoft/DirectX-Graphics-Samples/blob/master/Samples/Desktop/D3D12HelloWorld/src/HelloFrameBuffering/D3D12HelloFrameBuffering.cpp)

- Fix which prevents a `Queue` from resetting an `ID3D12CommandAllocator` before its commands have completed on the GPU.