### PR TITLE
D3D12 vertex and index buffers with resource transitions

### DIFF
--- a/examples/ComputeBoids.cpp
+++ b/examples/ComputeBoids.cpp
@@ -80,8 +80,8 @@ void initBuffers() {
 
     for (int i = 0; i < 2; i++) {
         particleBuffers[i] = device.CreateBufferBuilder()
-            .SetAllowedUsage(nxt::BufferUsageBit::MapWrite | nxt::BufferUsageBit::Vertex | nxt::BufferUsageBit::Storage)
-            .SetInitialUsage(nxt::BufferUsageBit::MapWrite)
+            .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::Vertex | nxt::BufferUsageBit::Storage)
+            .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
             .SetSize(sizeof(Particle) * kNumParticles)
             .GetResult();
 

--- a/examples/HelloCompute.cpp
+++ b/examples/HelloCompute.cpp
@@ -34,8 +34,8 @@ void init() {
     struct {uint32_t a; float b;} s;
     memset(&s, sizeof(s), 0);
     buffer = device.CreateBufferBuilder()
-        .SetAllowedUsage(nxt::BufferUsageBit::MapWrite | nxt::BufferUsageBit::Uniform | nxt::BufferUsageBit::Storage)
-        .SetInitialUsage(nxt::BufferUsageBit::MapWrite)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::Uniform | nxt::BufferUsageBit::Storage)
+        .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
         .SetSize(sizeof(s))
         .GetResult();
     buffer.SetSubData(0, sizeof(s) / sizeof(uint32_t), reinterpret_cast<uint32_t*>(&s));

--- a/examples/HelloDepthStencil.cpp
+++ b/examples/HelloDepthStencil.cpp
@@ -165,8 +165,8 @@ void init() {
         .GetResult();
 
     cameraBuffer = device.CreateBufferBuilder()
-        .SetAllowedUsage(nxt::BufferUsageBit::MapWrite | nxt::BufferUsageBit::Uniform)
-        .SetInitialUsage(nxt::BufferUsageBit::MapWrite)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::Uniform)
+        .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
         .SetSize(sizeof(CameraData))
         .GetResult();
 
@@ -265,7 +265,7 @@ void frame() {
         glm::vec3(0.0f, 1.0f, 0.0f)
     );
 
-    cameraBuffer.TransitionUsage(nxt::BufferUsageBit::MapWrite);
+    cameraBuffer.TransitionUsage(nxt::BufferUsageBit::TransferDst);
     cameraBuffer.SetSubData(0, sizeof(CameraData) / sizeof(uint32_t), reinterpret_cast<uint32_t*>(&cameraData));
 
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()

--- a/examples/HelloUBO.cpp
+++ b/examples/HelloUBO.cpp
@@ -66,8 +66,8 @@ void init() {
         .GetResult();
 
     buffer = device.CreateBufferBuilder()
-        .SetAllowedUsage(nxt::BufferUsageBit::MapWrite | nxt::BufferUsageBit::Uniform)
-        .SetInitialUsage(nxt::BufferUsageBit::MapWrite)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::Uniform)
+        .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
         .SetSize(sizeof(s))
         .GetResult();
 
@@ -87,7 +87,7 @@ void frame() {
     s.b += 0.02;
     if (s.b >= 1.0f) {s.b = 0.0f;}
 
-    buffer.TransitionUsage(nxt::BufferUsageBit::MapWrite);
+    buffer.TransitionUsage(nxt::BufferUsageBit::TransferDst);
     buffer.SetSubData(0, sizeof(s) / sizeof(uint32_t), reinterpret_cast<uint32_t*>(&s));
 
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()

--- a/examples/Utils.cpp
+++ b/examples/Utils.cpp
@@ -262,8 +262,8 @@ void CreateDefaultRenderPass(const nxt::Device& device, nxt::RenderPass* renderP
 
 nxt::Buffer CreateFrozenBufferFromData(const nxt::Device& device, const void* data, uint32_t size, nxt::BufferUsageBit usage) {
     nxt::Buffer buffer = device.CreateBufferBuilder()
-        .SetAllowedUsage(nxt::BufferUsageBit::MapWrite | usage)
-        .SetInitialUsage(nxt::BufferUsageBit::MapWrite)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | usage)
+        .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
         .SetSize(size)
         .GetResult();
     buffer.SetSubData(0, size / sizeof(uint32_t), reinterpret_cast<const uint32_t*>(data));

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -265,8 +265,8 @@ namespace {
             .GetResult();
 
         auto uniformBuffer = device.CreateBufferBuilder()
-            .SetAllowedUsage(nxt::BufferUsageBit::MapWrite | nxt::BufferUsageBit::Uniform)
-            .SetInitialUsage(nxt::BufferUsageBit::MapWrite)
+            .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::Uniform)
+            .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
             .SetSize(sizeof(u_transform_block))
             .GetResult();
 
@@ -489,7 +489,7 @@ namespace {
                 }
             }
             const MaterialInfo& material = getMaterial(iPrim.material, strides[0], strides[1], strides[2]);
-            material.uniformBuffer.TransitionUsage(nxt::BufferUsageBit::MapWrite);
+            material.uniformBuffer.TransitionUsage(nxt::BufferUsageBit::TransferDst);
             material.uniformBuffer.SetSubData(0,
                     sizeof(u_transform_block) / sizeof(uint32_t),
                     reinterpret_cast<const uint32_t*>(&transforms));

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -216,10 +216,14 @@ if (WIN32)
     SetPIC(d3d12_autogen)
 
     list(APPEND BACKEND_SOURCES
+        ${D3D12_DIR}/BufferD3D12.cpp
+        ${D3D12_DIR}/BufferD3D12.h
         ${D3D12_DIR}/CommandBufferD3D12.cpp
         ${D3D12_DIR}/CommandBufferD3D12.h
         ${D3D12_DIR}/D3D12Backend.cpp
         ${D3D12_DIR}/D3D12Backend.h
+        ${D3D12_DIR}/InputStateD3D12.cpp
+        ${D3D12_DIR}/InputStateD3D12.h
         ${D3D12_DIR}/PipelineD3D12.cpp
         ${D3D12_DIR}/PipelineD3D12.h
         ${D3D12_DIR}/PipelineLayoutD3D12.cpp

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -230,6 +230,8 @@ if (WIN32)
         ${D3D12_DIR}/PipelineLayoutD3D12.h
         ${D3D12_DIR}/QueueD3D12.cpp
         ${D3D12_DIR}/QueueD3D12.h
+        ${D3D12_DIR}/ResourceUploader.cpp
+        ${D3D12_DIR}/ResourceUploader.h
         ${D3D12_DIR}/ShaderModuleD3D12.cpp
         ${D3D12_DIR}/ShaderModuleD3D12.h
     )

--- a/src/backend/common/Buffer.cpp
+++ b/src/backend/common/Buffer.cpp
@@ -69,8 +69,8 @@ namespace backend {
             return;
         }
 
-        if (!(currentUsage & nxt::BufferUsageBit::MapWrite)) {
-            device->HandleError("Buffer needs the map write usage bit");
+        if (!(currentUsage & nxt::BufferUsageBit::TransferDst)) {
+            device->HandleError("Buffer needs the transfer dst usage bit");
             return;
         }
 

--- a/src/backend/common/Buffer.cpp
+++ b/src/backend/common/Buffer.cpp
@@ -145,7 +145,7 @@ namespace backend {
         return IsUsagePossible(allowedUsage, usage);
     }
 
-    void BufferBase::TransitionUsageImpl(nxt::BufferUsageBit usage) {
+    void BufferBase::UpdateUsageInternal(nxt::BufferUsageBit usage) {
         assert(IsTransitionPossible(usage));
         currentUsage = usage;
     }
@@ -155,7 +155,8 @@ namespace backend {
             device->HandleError("Buffer frozen or usage not allowed");
             return;
         }
-        TransitionUsageImpl(usage);
+        TransitionUsageImpl(currentUsage, usage);
+        currentUsage = usage;
     }
 
     void BufferBase::FreezeUsage(nxt::BufferUsageBit usage) {
@@ -164,6 +165,7 @@ namespace backend {
             return;
         }
         allowedUsage = usage;
+        TransitionUsageImpl(currentUsage, usage);
         currentUsage = usage;
         frozen = true;
     }

--- a/src/backend/common/Buffer.h
+++ b/src/backend/common/Buffer.h
@@ -35,7 +35,7 @@ namespace backend {
             bool IsTransitionPossible(nxt::BufferUsageBit usage) const;
             bool IsFrozen() const;
             bool HasFrozenUsage(nxt::BufferUsageBit usage) const;
-            void TransitionUsageImpl(nxt::BufferUsageBit usage);
+            void UpdateUsageInternal(nxt::BufferUsageBit usage);
 
             DeviceBase* GetDevice();
 
@@ -54,6 +54,7 @@ namespace backend {
             virtual void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) = 0;
             virtual void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t size) = 0;
             virtual void UnmapImpl() = 0;
+            virtual void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) = 0;
 
             DeviceBase* device;
             uint32_t size;

--- a/src/backend/common/Texture.cpp
+++ b/src/backend/common/Texture.cpp
@@ -87,7 +87,7 @@ namespace backend {
         return IsUsagePossible(allowedUsage, usage);
     }
 
-    void TextureBase::TransitionUsageImpl(nxt::TextureUsageBit usage) {
+    void TextureBase::UpdateUsageInternal(nxt::TextureUsageBit usage) {
         assert(IsTransitionPossible(usage));
         currentUsage = usage;
     }
@@ -97,7 +97,8 @@ namespace backend {
             device->HandleError("Texture frozen or usage not allowed");
             return;
         }
-        TransitionUsageImpl(usage);
+        TransitionUsageImpl(currentUsage, usage);
+        currentUsage = usage;
     }
 
     void TextureBase::FreezeUsage(nxt::TextureUsageBit usage) {
@@ -106,6 +107,7 @@ namespace backend {
             return;
         }
         allowedUsage = usage;
+        TransitionUsageImpl(currentUsage, usage);
         currentUsage = usage;
         frozen = true;
     }

--- a/src/backend/common/Texture.h
+++ b/src/backend/common/Texture.h
@@ -41,7 +41,7 @@ namespace backend {
             bool HasFrozenUsage(nxt::TextureUsageBit usage) const;
             static bool IsUsagePossible(nxt::TextureUsageBit allowedUsage, nxt::TextureUsageBit usage);
             bool IsTransitionPossible(nxt::TextureUsageBit usage) const;
-            void TransitionUsageImpl(nxt::TextureUsageBit usage);
+            void UpdateUsageInternal(nxt::TextureUsageBit usage);
 
             DeviceBase* GetDevice();
 
@@ -51,6 +51,8 @@ namespace backend {
             void FreezeUsage(nxt::TextureUsageBit usage);
 
         private:
+            virtual void TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) = 0;
+
             DeviceBase* device;
 
             nxt::TextureDimension dimension;

--- a/src/backend/d3d12/BufferD3D12.cpp
+++ b/src/backend/d3d12/BufferD3D12.cpp
@@ -1,0 +1,163 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BufferD3D12.h"
+
+#include "D3D12Backend.h"
+
+namespace backend {
+namespace d3d12 {
+
+    namespace {
+        D3D12_RESOURCE_STATES D3D12BufferUsage(nxt::BufferUsageBit usage) {
+            D3D12_RESOURCE_STATES resourceState = D3D12_RESOURCE_STATE_COMMON;
+
+            if (usage & nxt::BufferUsageBit::TransferSrc) {
+                resourceState |= D3D12_RESOURCE_STATE_COPY_SOURCE;
+            }
+            if (usage & nxt::BufferUsageBit::TransferDst) {
+                resourceState |= D3D12_RESOURCE_STATE_COPY_DEST;
+            }
+            if (usage & (nxt::BufferUsageBit::Vertex | nxt::BufferUsageBit::Uniform)) {
+                resourceState |= D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
+            }
+            if (usage & nxt::BufferUsageBit::Index) {
+                resourceState |= D3D12_RESOURCE_STATE_INDEX_BUFFER;
+            }
+            if (usage & nxt::BufferUsageBit::Storage) {
+                resourceState |= D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+            }
+
+            return resourceState;
+        }
+    }
+
+    Buffer::Buffer(Device* device, BufferBuilder* builder)
+        : BufferBase(builder), device(device) {
+
+        D3D12_RESOURCE_DESC resourceDescriptor;
+        resourceDescriptor.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        resourceDescriptor.Alignment = 0;
+        resourceDescriptor.Width = GetSize();
+        resourceDescriptor.Height = 1;
+        resourceDescriptor.DepthOrArraySize = 1;
+        resourceDescriptor.MipLevels = 1;
+        resourceDescriptor.Format = DXGI_FORMAT_UNKNOWN;
+        resourceDescriptor.SampleDesc.Count = 1;
+        resourceDescriptor.SampleDesc.Quality = 0;
+        resourceDescriptor.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        resourceDescriptor.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+        {
+            D3D12_HEAP_PROPERTIES heapProperties;
+            heapProperties.Type = D3D12_HEAP_TYPE_UPLOAD;
+            heapProperties.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+            heapProperties.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
+            heapProperties.CreationNodeMask = 0;
+            heapProperties.VisibleNodeMask = 0;
+
+            ASSERT_SUCCESS(device->GetD3D12Device()->CreateCommittedResource(
+                &heapProperties,
+                D3D12_HEAP_FLAG_NONE,
+                &resourceDescriptor,
+                D3D12_RESOURCE_STATE_GENERIC_READ,
+                nullptr,
+                IID_PPV_ARGS(&uploadResource)
+            ));
+        }
+
+        {
+            D3D12_HEAP_PROPERTIES heapProperties;
+            heapProperties.Type = D3D12_HEAP_TYPE_DEFAULT;
+            heapProperties.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+            heapProperties.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
+            heapProperties.CreationNodeMask = 0;
+            heapProperties.VisibleNodeMask = 0;
+
+            ASSERT_SUCCESS(device->GetD3D12Device()->CreateCommittedResource(
+                &heapProperties,
+                D3D12_HEAP_FLAG_NONE,
+                &resourceDescriptor,
+                D3D12BufferUsage(GetUsage()),
+                nullptr,
+                IID_PPV_ARGS(&resource)
+            ));
+        }
+    }
+
+    ComPtr<ID3D12Resource> Buffer::GetD3D12Resource() {
+        return resource;
+    }
+
+    bool Buffer::GetResourceTransitionBarrier(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage, D3D12_RESOURCE_BARRIER* barrier) {
+        D3D12_RESOURCE_STATES stateBefore = D3D12BufferUsage(currentUsage);
+        D3D12_RESOURCE_STATES stateAfter = D3D12BufferUsage(targetUsage);
+
+        if (stateBefore == stateAfter) {
+            return false;
+        }
+
+        barrier->Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier->Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+        barrier->Transition.pResource = resource.Get();
+        barrier->Transition.StateBefore = stateBefore;
+        barrier->Transition.StateAfter = stateAfter;
+        barrier->Transition.Subresource = 0;
+
+        return true;
+    }
+
+    D3D12_GPU_VIRTUAL_ADDRESS Buffer::GetVA() const {
+        return resource->GetGPUVirtualAddress();
+    }
+
+    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
+        uint32_t begin = start * sizeof(uint32_t);
+        uint32_t end = (start + count) * sizeof(uint32_t);
+
+        uint8_t* mappedResource = nullptr;
+
+        D3D12_RANGE readRange;
+        readRange.Begin = 0;
+        readRange.End = 0;
+
+        ASSERT_SUCCESS(uploadResource->Map(0, &readRange, reinterpret_cast<void**>(&mappedResource)));
+        memcpy(&mappedResource[begin], data, end - begin);
+
+        D3D12_RANGE writeRange;
+        writeRange.Begin = begin;
+        writeRange.End = end;
+
+        uploadResource->Unmap(0, &writeRange);
+
+        device->GetPendingCommandList()->CopyBufferRegion(resource.Get(), begin, uploadResource.Get(), begin, end - begin);
+    }
+
+    void Buffer::MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) {
+        // TODO(cwallez@chromium.org): Implement Map Read for the null backend
+    }
+
+    void Buffer::UnmapImpl() {
+        // TODO(cwallez@chromium.org): Implement Map Read for the null backend
+    }
+
+    void Buffer::TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) {
+        D3D12_RESOURCE_BARRIER barrier;
+        if (GetResourceTransitionBarrier(currentUsage, targetUsage, &barrier)) {
+            device->GetPendingCommandList()->ResourceBarrier(1, &barrier);
+        }
+    }
+
+}
+}

--- a/src/backend/d3d12/BufferD3D12.h
+++ b/src/backend/d3d12/BufferD3D12.h
@@ -1,0 +1,51 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_D3D12_BUFFERD3D12_H_
+#define BACKEND_D3D12_BUFFERD3D12_H_
+
+#include "common/Buffer.h"
+
+#include "d3d12_platform.h"
+
+namespace backend {
+namespace d3d12 {
+
+    class Device;
+
+    class Buffer : public BufferBase {
+        public:
+            Buffer(Device* device, BufferBuilder* builder);
+
+            ComPtr<ID3D12Resource> GetD3D12Resource();
+            D3D12_GPU_VIRTUAL_ADDRESS GetVA() const;
+            bool GetResourceTransitionBarrier(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage, D3D12_RESOURCE_BARRIER* barrier);
+
+        private:
+            Device* device;
+            ComPtr<ID3D12Resource> uploadResource;
+            ComPtr<ID3D12Resource> resource;
+
+            // NXT API
+            void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
+            void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
+            void UnmapImpl() override;
+            void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) override;
+
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_BUFFERD3D12_H_

--- a/src/backend/d3d12/CommandBufferD3D12.cpp
+++ b/src/backend/d3d12/CommandBufferD3D12.cpp
@@ -16,156 +16,212 @@
 
 #include "common/Commands.h"
 #include "D3D12Backend.h"
+#include "BufferD3D12.h"
+#include "InputStateD3D12.h"
 #include "PipelineD3D12.h"
 #include "PipelineLayoutD3D12.h"
 
 namespace backend {
 namespace d3d12 {
 
-      CommandBuffer::CommandBuffer(Device* device, CommandBufferBuilder* builder)
-          : CommandBufferBase(builder), device(device), commands(builder->AcquireCommands()) {
-      }
+    namespace {
+        DXGI_FORMAT DXGIIndexFormat(nxt::IndexFormat format) {
+            switch (format) {
+                case nxt::IndexFormat::Uint16:
+                    return DXGI_FORMAT_R16_UINT;
+                case nxt::IndexFormat::Uint32:
+                    return DXGI_FORMAT_R32_UINT;
+            }
+        }
+    }
 
-      CommandBuffer::~CommandBuffer() {
-          FreeCommands(&commands);
-      }
+    CommandBuffer::CommandBuffer(Device* device, CommandBufferBuilder* builder)
+        : CommandBufferBase(builder), device(device), commands(builder->AcquireCommands()) {
+    }
 
-      void CommandBuffer::FillCommands(ComPtr<ID3D12GraphicsCommandList> commandList) {
-          Command type;
-          Pipeline* lastPipeline = nullptr;
+    CommandBuffer::~CommandBuffer() {
+        FreeCommands(&commands);
+    }
 
-          RenderPass* currentRenderPass = nullptr;
-          Framebuffer* currentFramebuffer = nullptr;
+    void CommandBuffer::FillCommands(ComPtr<ID3D12GraphicsCommandList> commandList) {
+        Command type;
+        Pipeline* lastPipeline = nullptr;
 
-          while(commands.NextCommandId(&type)) {
-              switch (type) {
-                  case Command::AdvanceSubpass:
-                      {
-                          commands.NextCommand<AdvanceSubpassCmd>();
-                      }
-                      break;
+        RenderPass* currentRenderPass = nullptr;
+        Framebuffer* currentFramebuffer = nullptr;
 
-                  case Command::BeginRenderPass:
-                      {
-                          BeginRenderPassCmd* beginRenderPassCmd = commands.NextCommand<BeginRenderPassCmd>();
-                          currentRenderPass = ToBackend(beginRenderPassCmd->renderPass.Get());
-                          currentFramebuffer = ToBackend(beginRenderPassCmd->framebuffer.Get());
+        while(commands.NextCommandId(&type)) {
+            switch (type) {
+                case Command::AdvanceSubpass:
+                    {
+                        commands.NextCommand<AdvanceSubpassCmd>();
+                    }
+                    break;
 
-                          float width = (float) currentFramebuffer->GetWidth();
-                          float height = (float) currentFramebuffer->GetHeight();
-                          D3D12_VIEWPORT viewport = { 0.f, 0.f, width, height, 0.f, 1.f };
-                          D3D12_RECT scissorRect = { 0.f, 0.f, width, height };
-                          commandList->RSSetViewports(1, &viewport);
-                          commandList->RSSetScissorRects(1, &scissorRect);
-                          commandList->OMSetRenderTargets(1, &device->GetCurrentRenderTargetDescriptor(), FALSE, nullptr);
-                      }
-                      break;
+                case Command::BeginRenderPass:
+                    {
+                        BeginRenderPassCmd* beginRenderPassCmd = commands.NextCommand<BeginRenderPassCmd>();
+                        currentRenderPass = ToBackend(beginRenderPassCmd->renderPass.Get());
+                        currentFramebuffer = ToBackend(beginRenderPassCmd->framebuffer.Get());
 
-                  case Command::CopyBufferToBuffer:
-                      {
-                          CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
-                      }
-                      break;
+                        float width = (float) currentFramebuffer->GetWidth();
+                        float height = (float) currentFramebuffer->GetHeight();
+                        D3D12_VIEWPORT viewport = { 0.f, 0.f, width, height, 0.f, 1.f };
+                        D3D12_RECT scissorRect = { 0.f, 0.f, width, height };
+                        commandList->RSSetViewports(1, &viewport);
+                        commandList->RSSetScissorRects(1, &scissorRect);
+                        commandList->OMSetRenderTargets(1, &device->GetCurrentRenderTargetDescriptor(), FALSE, nullptr);
+                    }
+                    break;
+                case Command::CopyBufferToBuffer:
+                    {
+                        CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
+                    }
+                    break;
 
-                  case Command::CopyBufferToTexture:
-                      {
-                          CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();
-                      }
-                      break;
+                case Command::CopyBufferToTexture:
+                    {
+                        CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();
+                    }
+                    break;
 
-                  case Command::Dispatch:
-                      {
-                          DispatchCmd* dispatch = commands.NextCommand<DispatchCmd>();
+                case Command::Dispatch:
+                    {
+                        DispatchCmd* dispatch = commands.NextCommand<DispatchCmd>();
 
-                          ASSERT(lastPipeline->IsCompute());
-                          commandList->Dispatch(dispatch->x, dispatch->y, dispatch->z);
-                      }
-                      break;
+                        ASSERT(lastPipeline->IsCompute());
+                        commandList->Dispatch(dispatch->x, dispatch->y, dispatch->z);
+                    }
+                    break;
 
-                  case Command::DrawArrays:
-                      {
-                          DrawArraysCmd* draw = commands.NextCommand<DrawArraysCmd>();
+                case Command::DrawArrays:
+                    {
+                        DrawArraysCmd* draw = commands.NextCommand<DrawArraysCmd>();
 
-                          commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-                          commandList->DrawInstanced(
-                              draw->vertexCount,
-                              draw->instanceCount,
-                              draw->firstVertex,
-                              draw->firstInstance
-                          );
-                      }
-                      break;
+                        commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+                        commandList->DrawInstanced(
+                            draw->vertexCount,
+                            draw->instanceCount,
+                            draw->firstVertex,
+                            draw->firstInstance
+                        );
+                    }
+                    break;
 
-                  case Command::DrawElements:
-                      {
-                          DrawElementsCmd* draw = commands.NextCommand<DrawElementsCmd>();
-                      }
-                      break;
+                case Command::DrawElements:
+                    {
+                        DrawElementsCmd* draw = commands.NextCommand<DrawElementsCmd>();
 
-                  case Command::EndRenderPass:
-                      {
-                          EndRenderPassCmd* cmd = commands.NextCommand<EndRenderPassCmd>();
-                      }
-                      break;
+                        commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+                        commandList->DrawIndexedInstanced(
+                            draw->indexCount,
+                            draw->instanceCount,
+                            draw->firstIndex,
+                            0,
+                            draw->firstInstance
+                        );
+                    }
+                    break;
 
-                  case Command::SetPipeline:
-                      {
-                          SetPipelineCmd* cmd = commands.NextCommand<SetPipelineCmd>();
-                          lastPipeline = ToBackend(cmd->pipeline).Get();
-                          PipelineLayout* pipelineLayout = ToBackend(lastPipeline->GetLayout());
+                case Command::EndRenderPass:
+                    {
+                        EndRenderPassCmd* cmd = commands.NextCommand<EndRenderPassCmd>();
+                    }
+                    break;
 
-                          // TODO
-                          if (lastPipeline->IsCompute()) {
-                          } else {
-                              commandList->SetGraphicsRootSignature(pipelineLayout->GetRootSignature().Get());
-                              commandList->SetPipelineState(lastPipeline->GetRenderPipelineState().Get());
-                          }
-                      }
-                      break;
+                case Command::SetPipeline:
+                    {
+                        SetPipelineCmd* cmd = commands.NextCommand<SetPipelineCmd>();
+                        lastPipeline = ToBackend(cmd->pipeline).Get();
+                        PipelineLayout* pipelineLayout = ToBackend(lastPipeline->GetLayout());
 
-                  case Command::SetPushConstants:
-                      {
-                          SetPushConstantsCmd* cmd = commands.NextCommand<SetPushConstantsCmd>();
-                      }
-                      break;
+                        // TODO
+                        if (lastPipeline->IsCompute()) {
+                        } else {
+                            commandList->SetGraphicsRootSignature(pipelineLayout->GetRootSignature().Get());
+                            commandList->SetPipelineState(lastPipeline->GetRenderPipelineState().Get());
+                        }
+                    }
+                    break;
 
-                  case Command::SetStencilReference:
+                case Command::SetPushConstants:
+                    {
+                        SetPushConstantsCmd* cmd = commands.NextCommand<SetPushConstantsCmd>();
+                    }
+                    break;
+
+                case Command::SetStencilReference:
                     {
                         SetStencilReferenceCmd* cmd = commands.NextCommand<SetStencilReferenceCmd>();
                     }
                     break;
 
-                  case Command::SetBindGroup:
-                      {
-                          SetBindGroupCmd* cmd = commands.NextCommand<SetBindGroupCmd>();
-                      }
-                      break;
+                case Command::SetBindGroup:
+                    {
+                        SetBindGroupCmd* cmd = commands.NextCommand<SetBindGroupCmd>();
+                    }
+                    break;
 
-                  case Command::SetIndexBuffer:
-                      {
-                          SetIndexBufferCmd* cmd = commands.NextCommand<SetIndexBufferCmd>();
-                      }
-                      break;
+                case Command::SetIndexBuffer:
+                    {
+                        SetIndexBufferCmd* cmd = commands.NextCommand<SetIndexBufferCmd>();
 
-                  case Command::SetVertexBuffers:
-                      {
-                          SetVertexBuffersCmd* cmd = commands.NextCommand<SetVertexBuffersCmd>();
-                      }
-                      break;
+                        Buffer* buffer = ToBackend(cmd->buffer.Get());
+                        D3D12_INDEX_BUFFER_VIEW bufferView;
+                        bufferView.BufferLocation = buffer->GetVA() + cmd->offset;
+                        bufferView.SizeInBytes = buffer->GetSize() - cmd->offset;
+                        bufferView.Format = DXGIIndexFormat(cmd->format);
 
-                  case Command::TransitionBufferUsage:
-                      {
-                          TransitionBufferUsageCmd* cmd = commands.NextCommand<TransitionBufferUsageCmd>();
-                      }
-                      break;
+                        commandList->IASetIndexBuffer(&bufferView);
+                    }
+                    break;
 
-                  case Command::TransitionTextureUsage:
-                      {
-                          TransitionTextureUsageCmd* cmd = commands.NextCommand<TransitionTextureUsageCmd>();
-                      }
-                      break;
-              }
-          }
-      }
+                case Command::SetVertexBuffers:
+                    {
+                        SetVertexBuffersCmd* cmd = commands.NextCommand<SetVertexBuffersCmd>();
+                        auto buffers = commands.NextData<Ref<BufferBase>>(cmd->count);
+                        auto offsets = commands.NextData<uint32_t>(cmd->count);
+
+                        auto inputState = ToBackend(lastPipeline->GetInputState());
+
+                        std::array<D3D12_VERTEX_BUFFER_VIEW, kMaxVertexInputs> d3d12BufferViews;
+                        for (uint32_t i = 0; i < cmd->count; ++i) {
+                            auto input = inputState->GetInput(cmd->startSlot + i);
+                            Buffer* buffer = ToBackend(buffers[i].Get());
+                            d3d12BufferViews[i].BufferLocation = buffer->GetVA() + offsets[i];
+                            d3d12BufferViews[i].StrideInBytes = input.stride;
+                            d3d12BufferViews[i].SizeInBytes = buffer->GetSize() - offsets[i];
+                        }
+
+                        commandList->IASetVertexBuffers(cmd->startSlot, cmd->count, d3d12BufferViews.data());
+                    }
+                    break;
+
+                case Command::TransitionBufferUsage:
+                    {
+                        TransitionBufferUsageCmd* cmd = commands.NextCommand<TransitionBufferUsageCmd>();
+
+                        Buffer* buffer = ToBackend(cmd->buffer.Get());
+
+                        D3D12_RESOURCE_BARRIER barrier;
+                        if (buffer->GetResourceTransitionBarrier(buffer->GetUsage(), cmd->usage, &barrier)) {
+                            commandList->ResourceBarrier(1, &barrier);
+                        }
+
+                        buffer->UpdateUsageInternal(cmd->usage);
+                    }
+                    break;
+
+                case Command::TransitionTextureUsage:
+                    {
+                        TransitionTextureUsageCmd* cmd = commands.NextCommand<TransitionTextureUsageCmd>();
+
+                        Texture* texture = ToBackend(cmd->texture.Get());
+                        texture->UpdateUsageInternal(cmd->usage);
+                    }
+                    break;
+            }
+        }
+    }
 }
 }

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -156,6 +156,9 @@ namespace d3d12 {
         // TODO(cwallez@chromium.org): Implement Map Read for the null backend
     }
 
+    void Buffer::TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) {
+    }
+
     // BufferView
 
     BufferView::BufferView(Device* device, BufferViewBuilder* builder)
@@ -196,6 +199,9 @@ namespace d3d12 {
 
     Texture::Texture(Device* device, TextureBuilder* builder)
         : TextureBase(builder), device(device) {
+    }
+
+    void Texture::TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) {
     }
 
     // TextureView

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -14,7 +14,9 @@
 
 #include "D3D12Backend.h"
 
+#include "BufferD3D12.h"
 #include "CommandBufferD3D12.h"
+#include "InputStateD3D12.h"
 #include "PipelineD3D12.h"
 #include "PipelineLayoutD3D12.h"
 #include "QueueD3D12.h"
@@ -51,6 +53,15 @@ namespace d3d12 {
         queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
         queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
         ASSERT_SUCCESS(d3d12Device->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(&commandQueue)));
+
+        ASSERT_SUCCESS(d3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&pendingCommandAllocator)));
+        ASSERT_SUCCESS(d3d12Device->CreateCommandList(
+            0,
+            D3D12_COMMAND_LIST_TYPE_DIRECT,
+            pendingCommandAllocator.Get(),
+            nullptr,
+            IID_PPV_ARGS(&pendingCommandList)
+        ));
     }
 
     Device::~Device() {
@@ -62,6 +73,14 @@ namespace d3d12 {
 
     ComPtr<ID3D12CommandQueue> Device::GetCommandQueue() {
         return commandQueue;
+    }
+
+    ComPtr<ID3D12CommandAllocator> Device::GetPendingCommandAllocator() {
+        return pendingCommandAllocator;
+    }
+
+    ComPtr<ID3D12GraphicsCommandList> Device::GetPendingCommandList() {
+        return pendingCommandList;
     }
 
     D3D12_CPU_DESCRIPTOR_HANDLE Device::GetCurrentRenderTargetDescriptor() {
@@ -139,26 +158,6 @@ namespace d3d12 {
         : BindGroupLayoutBase(builder), device(device) {
     }
 
-    // Buffer
-
-    Buffer::Buffer(Device* device, BufferBuilder* builder)
-        : BufferBase(builder), device(device) {
-    }
-
-    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
-    }
-
-    void Buffer::MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) {
-        // TODO(cwallez@chromium.org): Implement Map Read for the null backend
-    }
-
-    void Buffer::UnmapImpl() {
-        // TODO(cwallez@chromium.org): Implement Map Read for the null backend
-    }
-
-    void Buffer::TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) {
-    }
-
     // BufferView
 
     BufferView::BufferView(Device* device, BufferViewBuilder* builder)
@@ -175,12 +174,6 @@ namespace d3d12 {
 
     Framebuffer::Framebuffer(Device* device, FramebufferBuilder* builder)
         : FramebufferBase(builder), device(device) {
-    }
-
-    // InputState
-
-    InputState::InputState(Device* device, InputStateBuilder * builder)
-        : InputStateBase(builder), device(device) {
     }
 
     // RenderPass

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -32,6 +32,7 @@
 #include "common/ToBackend.h"
 
 #include "d3d12_platform.h"
+#include "ResourceUploader.h"
 
 namespace backend {
 namespace d3d12 {
@@ -109,8 +110,13 @@ namespace d3d12 {
             ComPtr<ID3D12CommandAllocator> GetPendingCommandAllocator();
             ComPtr<ID3D12GraphicsCommandList> GetPendingCommandList();
             D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentRenderTargetDescriptor();
+            ResourceUploader* GetResourceUploader();
 
             void SetNextRenderTargetDescriptor(D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor);
+
+            void Tick();
+            uint64_t GetSerial() const;
+            void IncrementSerial();
 
             // NXT API
             void Reference();
@@ -122,6 +128,12 @@ namespace d3d12 {
             ComPtr<ID3D12CommandAllocator> pendingCommandAllocator;
             ComPtr<ID3D12GraphicsCommandList> pendingCommandList;
             D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor;
+
+            ResourceUploader resourceUploader;
+
+            uint64_t serial = 0;
+            ComPtr<ID3D12Fence> fence;
+            HANDLE fenceEvent;
     };
 
 

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -145,6 +145,7 @@ namespace d3d12 {
             void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
             void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
             void UnmapImpl() override;
+            void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) override;
 
             Device* device;
     };
@@ -202,6 +203,8 @@ namespace d3d12 {
             Texture(Device* device, TextureBuilder* builder);
 
         private:
+            void TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) override;
+
             Device* device;
     };
 

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -106,6 +106,8 @@ namespace d3d12 {
 
             ComPtr<ID3D12Device> GetD3D12Device();
             ComPtr<ID3D12CommandQueue> GetCommandQueue();
+            ComPtr<ID3D12CommandAllocator> GetPendingCommandAllocator();
+            ComPtr<ID3D12GraphicsCommandList> GetPendingCommandList();
             D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentRenderTargetDescriptor();
 
             void SetNextRenderTargetDescriptor(D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor);
@@ -117,6 +119,8 @@ namespace d3d12 {
         private:
             ComPtr<ID3D12Device> d3d12Device;
             ComPtr<ID3D12CommandQueue> commandQueue;
+            ComPtr<ID3D12CommandAllocator> pendingCommandAllocator;
+            ComPtr<ID3D12GraphicsCommandList> pendingCommandList;
             D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor;
     };
 
@@ -134,19 +138,6 @@ namespace d3d12 {
             BindGroupLayout(Device* device, BindGroupLayoutBuilder* builder);
 
         private:
-            Device* device;
-    };
-
-    class Buffer : public BufferBase {
-        public:
-            Buffer(Device* device, BufferBuilder* builder);
-
-        private:
-            void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
-            void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
-            void UnmapImpl() override;
-            void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) override;
-
             Device* device;
     };
 
@@ -169,14 +160,6 @@ namespace d3d12 {
     class DepthStencilState : public DepthStencilStateBase {
         public:
             DepthStencilState(Device* device, DepthStencilStateBuilder* builder);
-
-        private:
-            Device* device;
-    };
-
-    class InputState : public InputStateBase {
-        public:
-            InputState(Device* device, InputStateBuilder* builder);
 
         private:
             Device* device;

--- a/src/backend/d3d12/GeneratedCodeIncludes.h
+++ b/src/backend/d3d12/GeneratedCodeIncludes.h
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "D3D12Backend.h"
+#include "BufferD3D12.h"
 #include "CommandBufferD3D12.h"
+#include "InputStateD3D12.h"
 #include "PipelineD3D12.h"
 #include "PipelineLayoutD3D12.h"
 #include "QueueD3D12.h"

--- a/src/backend/d3d12/InputStateD3D12.cpp
+++ b/src/backend/d3d12/InputStateD3D12.cpp
@@ -1,0 +1,82 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "InputStateD3D12.h"
+
+namespace backend {
+namespace d3d12 {
+
+    static DXGI_FORMAT VertexFormatType(nxt::VertexFormat format) {
+        switch (format) {
+            case nxt::VertexFormat::FloatR32G32B32A32:
+                return DXGI_FORMAT_R32G32B32A32_FLOAT;
+            case nxt::VertexFormat::FloatR32G32B32:
+                return DXGI_FORMAT_R32G32B32_FLOAT;
+            case nxt::VertexFormat::FloatR32G32:
+                return DXGI_FORMAT_R32G32_FLOAT;
+        }
+    }
+
+    static D3D12_INPUT_CLASSIFICATION InputStepModeFunction(nxt::InputStepMode mode) {
+        switch (mode) {
+            case nxt::InputStepMode::Vertex:
+                return D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
+            case nxt::InputStepMode::Instance:
+                return D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA;
+        }
+    }
+
+    InputState::InputState(Device* device, InputStateBuilder* builder)
+        : InputStateBase(builder), device(device) {
+
+        const auto& attributesSetMask = GetAttributesSetMask();
+
+        size_t count = 0;
+        for (size_t i = 0; i < attributesSetMask.size(); ++i) {
+            if (!attributesSetMask[i]) {
+                continue;
+            }
+
+            D3D12_INPUT_ELEMENT_DESC& inputElementDescriptor = inputElementDescriptors[count++];
+
+            const AttributeInfo& attribute = GetAttribute(i);
+
+            // If the HLSL semantic is TEXCOORDN the SemanticName should be "TEXCOORD" and the SemanticIndex N
+            inputElementDescriptor.SemanticName = "TEXCOORD";
+            inputElementDescriptor.SemanticIndex = i;
+            inputElementDescriptor.Format = VertexFormatType(attribute.format);
+            inputElementDescriptor.InputSlot = attribute.bindingSlot;
+
+            const InputInfo& input = GetInput(attribute.bindingSlot);
+
+            inputElementDescriptor.AlignedByteOffset = attribute.offset;
+            inputElementDescriptor.InputSlotClass = InputStepModeFunction(input.stepMode);
+            if (inputElementDescriptor.InputSlotClass == D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA) {
+                inputElementDescriptor.InstanceDataStepRate = 0;
+            } else {
+                inputElementDescriptor.InstanceDataStepRate = 1;
+            }
+        }
+
+        inputLayoutDescriptor.pInputElementDescs = inputElementDescriptors;
+        inputLayoutDescriptor.NumElements = count;
+
+    }
+
+    const D3D12_INPUT_LAYOUT_DESC& InputState::GetD3D12InputLayoutDescriptor() const {
+        return inputLayoutDescriptor;
+    }
+
+}
+}

--- a/src/backend/d3d12/InputStateD3D12.h
+++ b/src/backend/d3d12/InputStateD3D12.h
@@ -1,0 +1,42 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_D3D12_INPUTSTATED3D12_H_
+#define BACKEND_D3D12_INPUTSTATED3D12_H_
+
+#include "common/InputState.h"
+
+#include "d3d12_platform.h"
+
+namespace backend {
+namespace d3d12 {
+
+    class Device;
+
+    class InputState : public InputStateBase {
+        public:
+            InputState(Device* device, InputStateBuilder* builder);
+
+            const D3D12_INPUT_LAYOUT_DESC& GetD3D12InputLayoutDescriptor() const;
+
+        private:
+            Device* device;
+            D3D12_INPUT_LAYOUT_DESC inputLayoutDescriptor;
+            D3D12_INPUT_ELEMENT_DESC inputElementDescriptors[kMaxVertexAttributes];
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_INPUTSTATED3D12_H_

--- a/src/backend/d3d12/PipelineD3D12.cpp
+++ b/src/backend/d3d12/PipelineD3D12.cpp
@@ -15,6 +15,7 @@
 #include "PipelineD3D12.h"
 
 #include "D3D12Backend.h"
+#include "InputStateD3D12.h"
 #include "ShaderModuleD3D12.h"
 #include "PipelineLayoutD3D12.h"
 
@@ -114,6 +115,9 @@ namespace d3d12 {
                     shader->BytecodeLength = compiledShader[stage]->GetBufferSize();
                 }
             }
+
+            InputState* inputState = ToBackend(GetInputState());
+            descriptor.InputLayout = inputState->GetD3D12InputLayoutDescriptor();
 
             descriptor.pRootSignature = ToBackend(GetLayout())->GetRootSignature().Get();
 

--- a/src/backend/d3d12/QueueD3D12.cpp
+++ b/src/backend/d3d12/QueueD3D12.cpp
@@ -31,6 +31,7 @@ namespace d3d12 {
             nullptr,
             IID_PPV_ARGS(&commandList)
         ));
+        ASSERT_SUCCESS(commandList->Close());
 
         ASSERT_SUCCESS(device->GetD3D12Device()->CreateFence(fenceValue, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence)));
         fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
@@ -38,22 +39,12 @@ namespace d3d12 {
     }
 
     void Queue::Submit(uint32_t numCommands, CommandBuffer* const * commands) {
-        ComPtr<ID3D12CommandAllocator> pendingCommandAllocator = device->GetPendingCommandAllocator();
-        ComPtr<ID3D12GraphicsCommandList> pendingCommandList = device->GetPendingCommandList();
-        ASSERT_SUCCESS(pendingCommandList->Close());
+        device->Tick();
 
-        for (uint32_t i = 0; i < numCommands; ++i) {
-            commands[i]->FillCommands(commandList);
-        }
-        ASSERT_SUCCESS(commandList->Close());
-
-        ID3D12CommandList* commandLists[] = { pendingCommandList.Get(), commandList.Get() };
-        device->GetCommandQueue()->ExecuteCommandLists(_countof(commandLists), commandLists);
-
-        // TODO(enga@google.com): This will stall on the submit because
+        // TODO(enga@google.com): This will stall on the previous submit because
         // the commands must finish exeuting before the ID3D12CommandAllocator is reset.
         // This should be fixed / optimized by using multiple command allocators.
-        const uint64_t currentFence = ++fenceValue;
+        const uint64_t currentFence = fenceValue++;
         ASSERT_SUCCESS(device->GetCommandQueue()->Signal(fence.Get(), fenceValue));
 
         if (fence->GetCompletedValue() < currentFence) {
@@ -62,9 +53,15 @@ namespace d3d12 {
         }
 
         ASSERT_SUCCESS(commandAllocator->Reset());
-        ASSERT_SUCCESS(pendingCommandAllocator->Reset());
-        ASSERT_SUCCESS(pendingCommandList->Reset(pendingCommandAllocator.Get(), NULL));
         ASSERT_SUCCESS(commandList->Reset(commandAllocator.Get(), NULL));
+
+        for (uint32_t i = 0; i < numCommands; ++i) {
+            commands[i]->FillCommands(commandList);
+        }
+        ASSERT_SUCCESS(commandList->Close());
+
+        ID3D12CommandList* commandLists[] = { commandList.Get() };
+        device->GetCommandQueue()->ExecuteCommandLists(_countof(commandLists), commandLists);
     }
 
 }

--- a/src/backend/d3d12/ResourceUploader.cpp
+++ b/src/backend/d3d12/ResourceUploader.cpp
@@ -1,0 +1,96 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ResourceUploader.h"
+
+#include "D3D12Backend.h"
+
+namespace backend {
+namespace d3d12 {
+
+    ResourceUploader::ResourceUploader(Device* device) : device(device) {
+    }
+
+    void ResourceUploader::UploadToBuffer(ComPtr<ID3D12Resource> resource, uint32_t start, uint32_t count, const uint8_t* data) {
+        D3D12_RESOURCE_DESC resourceDescriptor;
+        resourceDescriptor.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        resourceDescriptor.Alignment = 0;
+        resourceDescriptor.Width = count;
+        resourceDescriptor.Height = 1;
+        resourceDescriptor.DepthOrArraySize = 1;
+        resourceDescriptor.MipLevels = 1;
+        resourceDescriptor.Format = DXGI_FORMAT_UNKNOWN;
+        resourceDescriptor.SampleDesc.Count = 1;
+        resourceDescriptor.SampleDesc.Quality = 0;
+        resourceDescriptor.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        resourceDescriptor.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+        ComPtr<ID3D12Resource> uploadResource;
+
+        D3D12_HEAP_PROPERTIES heapProperties;
+        heapProperties.Type = D3D12_HEAP_TYPE_UPLOAD;
+        heapProperties.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+        heapProperties.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
+        heapProperties.CreationNodeMask = 0;
+        heapProperties.VisibleNodeMask = 0;
+
+        // TODO(enga@google.com): Use a ResourceAllocationManager
+        ASSERT_SUCCESS(device->GetD3D12Device()->CreateCommittedResource(
+            &heapProperties,
+            D3D12_HEAP_FLAG_NONE,
+            &resourceDescriptor,
+            D3D12_RESOURCE_STATE_GENERIC_READ,
+            nullptr,
+            IID_PPV_ARGS(&uploadResource)
+        ));
+
+        D3D12_RANGE readRange;
+        readRange.Begin = 0;
+        readRange.End = 0;
+
+        D3D12_RANGE writeRange;
+        writeRange.Begin = 0;
+        writeRange.End = count;
+
+        uint8_t* mappedResource = nullptr;
+
+        ASSERT_SUCCESS(uploadResource->Map(0, &readRange, reinterpret_cast<void**>(&mappedResource)));
+        memcpy(mappedResource, data, count);
+        uploadResource->Unmap(0, &writeRange);
+        device->GetPendingCommandList()->CopyBufferRegion(resource.Get(), start, uploadResource.Get(), 0, count);
+
+        pendingResources.push_back(uploadResource);
+    }
+
+    void ResourceUploader::EnqueueUploadingResources(const uint64_t serial) {
+        if (pendingResources.size() > 0) {
+            uploadingResources.push_back(std::make_pair(serial, std::move(pendingResources)));
+            pendingResources.clear();
+        }
+    }
+
+    void ResourceUploader::FreeCompletedResources(const uint64_t lastCompletedSerial) {
+        auto it = uploadingResources.begin();
+        while (it != uploadingResources.end()) {
+            if (it->first < lastCompletedSerial) {
+                it++;
+            } else {
+                break;
+            }
+        }
+        uploadingResources.erase(uploadingResources.begin(), it);
+    }
+
+}
+}

--- a/src/backend/d3d12/ResourceUploader.h
+++ b/src/backend/d3d12/ResourceUploader.h
@@ -1,0 +1,47 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_D3D12_RESOURCEUPLOADER_H_
+#define BACKEND_D3D12_RESOURCEUPLOADER_H_
+
+#include "d3d12_platform.h"
+
+#include <map>
+#include <vector>
+
+namespace backend {
+namespace d3d12 {
+
+    class Device;
+
+    class ResourceUploader {
+        public:
+            ResourceUploader(Device* device);
+
+            void UploadToBuffer(ComPtr<ID3D12Resource> resource, uint32_t start, uint32_t count, const uint8_t* data);
+            void EnqueueUploadingResources(const uint64_t serial);
+            void FreeCompletedResources(const uint64_t lastCompletedSerial);
+
+        private:
+            Device* device;
+
+            std::vector<ComPtr<ID3D12Resource>> pendingResources;
+            std::vector<std::pair<uint64_t, std::vector<ComPtr<ID3D12Resource>>>> uploadingResources;
+
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_RESOURCEUPLOADER_H_

--- a/src/backend/metal/MetalBackend.h
+++ b/src/backend/metal/MetalBackend.h
@@ -162,6 +162,7 @@ namespace metal {
             void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
             void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
             void UnmapImpl() override;
+            void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) override;
 
             Device* device;
             std::mutex mutex;
@@ -309,6 +310,8 @@ namespace metal {
             id<MTLTexture> GetMTLTexture();
 
         private:
+            void TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) override;
+
             Device* device;
             id<MTLTexture> mtlTexture = nil;
     };

--- a/src/backend/metal/MetalBackend.mm
+++ b/src/backend/metal/MetalBackend.mm
@@ -233,6 +233,9 @@ namespace metal {
         // TODO(cwallez@chromium.org): Implement Map Read for the metal backend
     }
 
+    void Buffer::TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) {
+    }
+
     // BufferView
 
     BufferView::BufferView(Device* device, BufferViewBuilder* builder)
@@ -669,7 +672,7 @@ namespace metal {
                     {
                         TransitionBufferUsageCmd* cmd = commands.NextCommand<TransitionBufferUsageCmd>();
 
-                        cmd->buffer->TransitionUsageImpl(cmd->usage);
+                        cmd->buffer->UpdateUsageInternal(cmd->usage);
                     }
                     break;
 
@@ -677,7 +680,7 @@ namespace metal {
                     {
                         TransitionTextureUsageCmd* cmd = commands.NextCommand<TransitionTextureUsageCmd>();
 
-                        cmd->texture->TransitionUsageImpl(cmd->usage);
+                        cmd->texture->UpdateUsageInternal(cmd->usage);
                     }
                     break;
 ;
@@ -1154,6 +1157,9 @@ namespace metal {
 
     id<MTLTexture> Texture::GetMTLTexture() {
         return mtlTexture;
+    }
+
+    void Texture::TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) {
     }
 
     // TextureView

--- a/src/backend/null/NullBackend.cpp
+++ b/src/backend/null/NullBackend.cpp
@@ -83,7 +83,7 @@ namespace null {
         return module;
     }
     TextureBase* Device::CreateTexture(TextureBuilder* builder) {
-        return new TextureBase(builder);
+        return new Texture(builder);
     }
     TextureViewBase* Device::CreateTextureView(TextureViewBuilder* builder) {
         return new TextureViewBase(builder);
@@ -149,6 +149,9 @@ namespace null {
     void Buffer::UnmapImpl() {
     }
 
+    void Buffer::TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) {
+    }
+
     // Queue
 
     Queue::Queue(QueueBuilder* builder)
@@ -166,6 +169,18 @@ namespace null {
         }
 
         operations.clear();
+    }
+
+    // Texture
+
+    Texture::Texture(TextureBuilder* builder)
+        : TextureBase(builder) {
+    }
+
+    Texture::~Texture() {
+    }
+
+    void Texture::TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) {
     }
 
 }

--- a/src/backend/null/NullBackend.cpp
+++ b/src/backend/null/NullBackend.cpp
@@ -116,7 +116,7 @@ namespace null {
 
     Buffer::Buffer(BufferBuilder* builder)
         : BufferBase(builder) {
-        if (GetAllowedUsage() & (nxt::BufferUsageBit::MapRead | nxt::BufferUsageBit::MapWrite)) {
+        if (GetAllowedUsage() & (nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::MapRead | nxt::BufferUsageBit::MapWrite)) {
             backingData = std::unique_ptr<char[]>(new char[GetSize()]);
         }
     }

--- a/src/backend/null/NullBackend.h
+++ b/src/backend/null/NullBackend.h
@@ -52,7 +52,7 @@ namespace null {
     using RenderPass = RenderPassBase;
     using Sampler = SamplerBase;
     using ShaderModule = ShaderModuleBase;
-    using Texture = TextureBase;
+    class Texture;
     using TextureView = TextureViewBase;
 
     struct NullBackendTraits {
@@ -129,6 +129,7 @@ namespace null {
             void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
             void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
             void UnmapImpl() override;
+            void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) override;
 
             std::unique_ptr<char[]> backingData;
     };
@@ -140,6 +141,15 @@ namespace null {
 
             // NXT API
             void Submit(uint32_t numCommands, CommandBuffer* const * commands);
+    };
+
+    class Texture : public TextureBase {
+        public:
+            Texture(TextureBuilder* buidler);
+            ~Texture();
+
+        private:
+            void TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) override;
     };
 
 }

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -325,7 +325,7 @@ namespace opengl {
                     {
                         TransitionBufferUsageCmd* cmd = commands.NextCommand<TransitionBufferUsageCmd>();
 
-                        cmd->buffer->TransitionUsageImpl(cmd->usage);
+                        cmd->buffer->UpdateUsageInternal(cmd->usage);
                     }
                     break;
 
@@ -333,7 +333,7 @@ namespace opengl {
                     {
                         TransitionTextureUsageCmd* cmd = commands.NextCommand<TransitionTextureUsageCmd>();
 
-                        cmd->texture->TransitionUsageImpl(cmd->usage);
+                        cmd->texture->UpdateUsageInternal(cmd->usage);
                     }
                     break;
             }

--- a/src/backend/opengl/OpenGLBackend.cpp
+++ b/src/backend/opengl/OpenGLBackend.cpp
@@ -141,6 +141,9 @@ namespace opengl {
         // TODO(cwallez@chromium.org): Implement Map Read for the GL backend
     }
 
+    void Buffer::TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) {
+    }
+
     // BufferView
 
     BufferView::BufferView(Device* device, BufferViewBuilder* builder)

--- a/src/backend/opengl/OpenGLBackend.h
+++ b/src/backend/opengl/OpenGLBackend.h
@@ -128,6 +128,7 @@ namespace opengl {
             void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
             void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
             void UnmapImpl() override;
+            void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) override;
 
             Device* device;
             GLuint buffer = 0;

--- a/src/backend/opengl/TextureGL.cpp
+++ b/src/backend/opengl/TextureGL.cpp
@@ -76,6 +76,9 @@ namespace opengl {
         return GetGLFormatInfo(GetFormat());
     }
 
+    void Texture::TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) {
+    }
+
     // TextureView
 
     TextureView::TextureView(Device* device, TextureViewBuilder* builder)

--- a/src/backend/opengl/TextureGL.h
+++ b/src/backend/opengl/TextureGL.h
@@ -39,6 +39,8 @@ namespace opengl {
             TextureFormatInfo GetGLFormat() const;
 
         private:
+            void TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) override;
+
             Device* device;
             GLuint handle;
             GLenum target;

--- a/src/tests/unittests/validation/BufferValidationTests.cpp
+++ b/src/tests/unittests/validation/BufferValidationTests.cpp
@@ -41,8 +41,8 @@ class BufferValidationTest : public ValidationTest {
         nxt::Buffer CreateSetSubDataBuffer(uint32_t size) {
             return device.CreateBufferBuilder()
                 .SetSize(size)
-                .SetAllowedUsage(nxt::BufferUsageBit::MapWrite)
-                .SetInitialUsage(nxt::BufferUsageBit::MapWrite)
+                .SetAllowedUsage(nxt::BufferUsageBit::TransferDst)
+                .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
                 .GetResult();
         }
 
@@ -275,7 +275,7 @@ TEST_F(BufferValidationTest, SetSubDataOutOfBounds) {
 TEST_F(BufferValidationTest, SetSubDataWrongUsage) {
     nxt::Buffer buf = device.CreateBufferBuilder()
         .SetSize(4)
-        .SetAllowedUsage(nxt::BufferUsageBit::MapWrite | nxt::BufferUsageBit::Vertex)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::Vertex)
         .SetInitialUsage(nxt::BufferUsageBit::Vertex)
         .GetResult();
 


### PR DESCRIPTION
PTAL. This adds buffers to the D3D12 backend so `HelloVertices`, `HelloIndices`, and `HelloInstancing` are now working. `Buffer::SetSubData` now requires `nxt::BufferUsageBit::TransferDst`, maps an upload buffer, and schedules a copy to the backing resource. Not yet sure what to do with transitions to `MapRead` / `MapWrite` and this will likely need to be updated after #43.

There's some indentation changes in `CommandBufferD3D12.cpp` because parts of it were previously indented with 6 spaces.