### PR TITLE
B2b copy

### DIFF
--- a/next.json
+++ b/next.json
@@ -236,6 +236,19 @@
                 "name": "end render pass"
             },
             {
+                "name": "copy buffer to buffer",
+                "args": [
+                    {"name": "source", "type": "buffer"},
+                    {"name": "source offset", "type": "uint32_t"},
+                    {"name": "destination", "type": "buffer"},
+                    {"name": "destination offset", "type": "uint32_t"},
+                    {"name": "size", "type": "uint32_t"}
+                ],
+                "TODO": [
+                    "Restrictions on the alignment of the copy? Cf Metal on OSX"
+                ]
+            },
+            {
                 "name": "copy buffer to texture",
                 "args": [
                     {"name": "buffer", "type": "buffer"},

--- a/src/backend/common/CommandBuffer.h
+++ b/src/backend/common/CommandBuffer.h
@@ -61,6 +61,7 @@ namespace backend {
             // NXT API
             void AdvanceSubpass();
             void BeginRenderPass(RenderPassBase* renderPass, FramebufferBase* framebuffer);
+            void CopyBufferToBuffer(BufferBase* source, uint32_t sourceOffset, BufferBase* destination, uint32_t destinationOffset, uint32_t size);
             void CopyBufferToTexture(BufferBase* buffer, uint32_t bufferOffset,
                                      TextureBase* texture, uint32_t x, uint32_t y, uint32_t z,
                                      uint32_t width, uint32_t height, uint32_t depth, uint32_t level);

--- a/src/backend/common/Commands.h
+++ b/src/backend/common/Commands.h
@@ -30,6 +30,7 @@ namespace backend {
     enum class Command {
         AdvanceSubpass,
         BeginRenderPass,
+        CopyBufferToBuffer,
         CopyBufferToTexture,
         Dispatch,
         DrawArrays,
@@ -51,6 +52,14 @@ namespace backend {
     struct BeginRenderPassCmd {
         Ref<RenderPassBase> renderPass;
         Ref<FramebufferBase> framebuffer;
+    };
+
+    struct CopyBufferToBufferCmd {
+        Ref<BufferBase> source;
+        Ref<BufferBase> destination;
+        uint32_t sourceOffset;
+        uint32_t destinationOffset;
+        uint32_t size;
     };
 
     struct CopyBufferToTextureCmd {

--- a/src/backend/d3d12/CommandBufferD3D12.cpp
+++ b/src/backend/d3d12/CommandBufferD3D12.cpp
@@ -61,6 +61,12 @@ namespace d3d12 {
                       }
                       break;
 
+                  case Command::CopyBufferToBuffer:
+                      {
+                          CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
+                      }
+                      break;
+
                   case Command::CopyBufferToTexture:
                       {
                           CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();

--- a/src/backend/metal/MetalBackend.mm
+++ b/src/backend/metal/MetalBackend.mm
@@ -368,6 +368,20 @@ namespace metal {
                     }
                     break;
 
+                case Command::CopyBufferToBuffer:
+                    {
+                        CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
+
+                        encoders.EnsureBlit(commandBuffer);
+                        [encoders.blit
+                            copyFromBuffer:ToBackend(copy->source)->GetMTLBuffer()
+                            sourceOffset:copy->sourceOffset
+                            toBuffer:ToBackend(copy->destination)->GetMTLBuffer()
+                            destinationOffset:copy->destinationOffset
+                            size:copy->size];
+                    }
+                    break;
+
                 case Command::CopyBufferToTexture:
                     {
                         CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -78,6 +78,19 @@ namespace opengl {
                     }
                     break;
 
+                case Command::CopyBufferToBuffer:
+                    {
+                        CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
+
+                        glBindBuffer(GL_PIXEL_PACK_BUFFER, ToBackend(copy->source)->GetHandle());
+                        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, ToBackend(copy->destination)->GetHandle());
+                        glCopyBufferSubData(GL_PIXEL_PACK_BUFFER, GL_PIXEL_UNPACK_BUFFER, copy->sourceOffset, copy->destinationOffset, copy->size);
+
+                        glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+                        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+                    }
+                    break;
+
                 case Command::CopyBufferToTexture:
                     {
                         CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(nxt_unittests
     ${VALIDATION_TESTS_DIR}/BufferValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/CommandBufferValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/ComputeValidationTests.cpp
+    ${VALIDATION_TESTS_DIR}/CopyCommandsValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/DepthStencilStateValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/FramebufferValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/RenderPassValidationTests.cpp

--- a/src/tests/unittests/validation/CopyCommandsValidationTests.cpp
+++ b/src/tests/unittests/validation/CopyCommandsValidationTests.cpp
@@ -1,0 +1,106 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ValidationTest.h"
+
+class CopyCommandTest_B2B : public ValidationTest {
+};
+
+// Test a successfull B2B copy
+TEST_F(CopyCommandTest_B2B, Success) {
+    nxt::Buffer source = device.CreateBufferBuilder()
+        .SetSize(16)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferSrc)
+        .GetResult();
+    source.FreezeUsage(nxt::BufferUsageBit::TransferSrc);
+
+    nxt::Buffer destination = device.CreateBufferBuilder()
+        .SetSize(16)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferDst)
+        .GetResult();
+    destination.FreezeUsage(nxt::BufferUsageBit::TransferDst);
+
+    // Copy different copies, including some that touch the OOB condition
+    nxt::CommandBuffer commands = AssertWillBeSuccess(device.CreateCommandBufferBuilder())
+        .CopyBufferToBuffer(source, 0, destination, 0, 16)
+        .CopyBufferToBuffer(source, 8, destination, 0, 8)
+        .CopyBufferToBuffer(source, 0, destination, 8, 8)
+        .GetResult();
+}
+
+// Test B2B copies with overflows
+TEST_F(CopyCommandTest_B2B, OutOfBounds) {
+    nxt::Buffer source = device.CreateBufferBuilder()
+        .SetSize(16)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferSrc)
+        .GetResult();
+    source.FreezeUsage(nxt::BufferUsageBit::TransferSrc);
+
+    nxt::Buffer destination = device.CreateBufferBuilder()
+        .SetSize(16)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferDst)
+        .GetResult();
+    destination.FreezeUsage(nxt::BufferUsageBit::TransferDst);
+
+    // OOB on the source
+    {
+        nxt::CommandBuffer commands = AssertWillBeError(device.CreateCommandBufferBuilder())
+            .CopyBufferToBuffer(source, 8, destination, 0, 12)
+            .GetResult();
+    }
+
+    // OOB on the destination
+    {
+        nxt::CommandBuffer commands = AssertWillBeError(device.CreateCommandBufferBuilder())
+            .CopyBufferToBuffer(source, 0, destination, 8, 12)
+            .GetResult();
+    }
+}
+
+// Test B2B copies with overflows
+TEST_F(CopyCommandTest_B2B, BadUsage) {
+    nxt::Buffer source = device.CreateBufferBuilder()
+        .SetSize(16)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferSrc)
+        .GetResult();
+    source.FreezeUsage(nxt::BufferUsageBit::TransferSrc);
+
+    nxt::Buffer destination = device.CreateBufferBuilder()
+        .SetSize(16)
+        .SetAllowedUsage(nxt::BufferUsageBit::TransferDst)
+        .GetResult();
+    destination.FreezeUsage(nxt::BufferUsageBit::TransferDst);
+
+    nxt::Buffer vertex = device.CreateBufferBuilder()
+        .SetSize(16)
+        .SetAllowedUsage(nxt::BufferUsageBit::Vertex)
+        .GetResult();
+    vertex.FreezeUsage(nxt::BufferUsageBit::Vertex);
+
+    // Source with incorrect usage
+    {
+        nxt::CommandBuffer commands = AssertWillBeError(device.CreateCommandBufferBuilder())
+            .CopyBufferToBuffer(vertex, 0, destination, 0, 16)
+            .GetResult();
+    }
+
+    // Destination with incorrect usage
+    {
+        nxt::CommandBuffer commands = AssertWillBeError(device.CreateCommandBufferBuilder())
+            .CopyBufferToBuffer(source, 0, vertex, 0, 16)
+            .GetResult();
+    }
+}
+
+// TODO(cwallez@chromium.org): Test that B2B copies are forbidden inside renderpasses


### PR DESCRIPTION
PTAL, this implements (but doesn't end2end test) the buffer to buffer copies that will be necessary to copy data from the GPU to a MapRead buffer.

Part of #45 