### PR TITLE
Introduce Allocation Managers to the D3D12 backend

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -219,6 +219,8 @@ if (WIN32)
     list(APPEND BACKEND_SOURCES
         ${D3D12_DIR}/BufferD3D12.cpp
         ${D3D12_DIR}/BufferD3D12.h
+        ${D3D12_DIR}/CommandAllocatorManager.cpp
+        ${D3D12_DIR}/CommandAllocatorManager.h
         ${D3D12_DIR}/CommandBufferD3D12.cpp
         ${D3D12_DIR}/CommandBufferD3D12.h
         ${D3D12_DIR}/D3D12Backend.cpp

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -233,6 +233,8 @@ if (WIN32)
         ${D3D12_DIR}/PipelineLayoutD3D12.h
         ${D3D12_DIR}/QueueD3D12.cpp
         ${D3D12_DIR}/QueueD3D12.h
+        ${D3D12_DIR}/ResourceAllocator.cpp
+        ${D3D12_DIR}/ResourceAllocator.h
         ${D3D12_DIR}/ResourceUploader.cpp
         ${D3D12_DIR}/ResourceUploader.h
         ${D3D12_DIR}/ShaderModuleD3D12.cpp

--- a/src/backend/common/SerialQueue.h
+++ b/src/backend/common/SerialQueue.h
@@ -78,6 +78,8 @@ namespace backend {
             void Clear();
             void ClearUpTo(Serial serial);
 
+            Serial FirstSerial() const;
+
         private:
             // Returns the first StorageIterator that a serial bigger than serial.
             StorageIterator FindUpTo(Serial serial) const;
@@ -141,6 +143,12 @@ namespace backend {
     template<typename T>
     void SerialQueue<T>::ClearUpTo(Serial serial) {
         storage.erase(storage.begin(), FindUpTo(serial));
+    }
+
+    template<typename T>
+    Serial SerialQueue<T>::FirstSerial() const {
+        ASSERT(!Empty());
+        return storage.front().first;
     }
 
     template<typename T>

--- a/src/backend/d3d12/BufferD3D12.cpp
+++ b/src/backend/d3d12/BufferD3D12.cpp
@@ -15,6 +15,7 @@
 #include "BufferD3D12.h"
 
 #include "D3D12Backend.h"
+#include "ResourceAllocator.h"
 
 namespace backend {
 namespace d3d12 {
@@ -59,22 +60,11 @@ namespace d3d12 {
         resourceDescriptor.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
         resourceDescriptor.Flags = D3D12_RESOURCE_FLAG_NONE;
 
-        D3D12_HEAP_PROPERTIES heapProperties;
-        heapProperties.Type = D3D12_HEAP_TYPE_DEFAULT;
-        heapProperties.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
-        heapProperties.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
-        heapProperties.CreationNodeMask = 0;
-        heapProperties.VisibleNodeMask = 0;
+        resource = device->GetResourceAllocator()->Allocate(D3D12_HEAP_TYPE_DEFAULT, resourceDescriptor, D3D12BufferUsage(GetUsage()));
+    }
 
-        // TODO(enga@google.com): Use a ResourceAllocationManager
-        ASSERT_SUCCESS(device->GetD3D12Device()->CreateCommittedResource(
-            &heapProperties,
-            D3D12_HEAP_FLAG_NONE,
-            &resourceDescriptor,
-            D3D12BufferUsage(GetUsage()),
-            nullptr,
-            IID_PPV_ARGS(&resource)
-        ));
+    Buffer::~Buffer() {
+        device->GetResourceAllocator()->Release(resource);
     }
 
     ComPtr<ID3D12Resource> Buffer::GetD3D12Resource() {

--- a/src/backend/d3d12/BufferD3D12.cpp
+++ b/src/backend/d3d12/BufferD3D12.cpp
@@ -16,6 +16,7 @@
 
 #include "D3D12Backend.h"
 #include "ResourceAllocator.h"
+#include "ResourceUploader.h"
 
 namespace backend {
 namespace d3d12 {

--- a/src/backend/d3d12/BufferD3D12.h
+++ b/src/backend/d3d12/BufferD3D12.h
@@ -27,6 +27,7 @@ namespace d3d12 {
     class Buffer : public BufferBase {
         public:
             Buffer(Device* device, BufferBuilder* builder);
+            ~Buffer();
 
             ComPtr<ID3D12Resource> GetD3D12Resource();
             D3D12_GPU_VIRTUAL_ADDRESS GetVA() const;
@@ -34,7 +35,6 @@ namespace d3d12 {
 
         private:
             Device* device;
-            ComPtr<ID3D12Resource> uploadResource;
             ComPtr<ID3D12Resource> resource;
 
             // NXT API

--- a/src/backend/d3d12/CommandAllocatorManager.cpp
+++ b/src/backend/d3d12/CommandAllocatorManager.cpp
@@ -1,0 +1,66 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "CommandAllocatorManager.h"
+
+#include "D3D12Backend.h"
+
+#include "common/BitSetIterator.h"
+
+namespace backend {
+namespace d3d12 {
+
+    CommandAllocatorManager::CommandAllocatorManager(Device* device) : device(device), allocatorCount(0) {
+        freeAllocators.set();
+    }
+
+    ComPtr<ID3D12CommandAllocator> CommandAllocatorManager::ReserveCommandAllocator() {
+        // If there are no free allocators, get the oldest serial in flight and wait on it
+        if (freeAllocators.none()) {
+            const uint64_t firstSerial = inFlightCommandAllocators.FirstSerial();
+            device->WaitForSerial(firstSerial);
+            ResetCompletedAllocators(firstSerial);
+        }
+
+        ASSERT(freeAllocators.any());
+
+        // Get the index of the first free allocator from the bitset
+        unsigned int firstFreeIndex = *(IterateBitSet(freeAllocators).begin());
+
+        if (firstFreeIndex >= allocatorCount) {
+            ASSERT(firstFreeIndex == allocatorCount);
+            allocatorCount++;
+            ASSERT_SUCCESS(device->GetD3D12Device()->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&commandAllocators[firstFreeIndex])));
+        }
+
+        // Mark the command allocator as used
+        freeAllocators.reset(firstFreeIndex);
+
+        // Enqueue the command allocator. It will be scheduled for reset after the next ExecuteCommandLists
+        inFlightCommandAllocators.Enqueue({commandAllocators[firstFreeIndex], firstFreeIndex}, device->GetSerial());
+
+        return commandAllocators[firstFreeIndex];
+    }
+
+    void CommandAllocatorManager::ResetCompletedAllocators(uint64_t lastCompletedSerial) {
+        // Reset all command allocators that are no longer in flight
+        for (auto it : inFlightCommandAllocators.IterateUpTo(lastCompletedSerial)) {
+            ASSERT_SUCCESS(it.commandAllocator->Reset());
+            freeAllocators.set(it.index);
+        }
+        inFlightCommandAllocators.ClearUpTo(lastCompletedSerial);
+    }
+
+}
+}

--- a/src/backend/d3d12/CommandAllocatorManager.h
+++ b/src/backend/d3d12/CommandAllocatorManager.h
@@ -1,0 +1,58 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_D3D12_COMMANDALLOCATORMANAGER_H_
+#define BACKEND_D3D12_COMMANDALLOCATORMANAGER_H_
+
+#include "d3d12_platform.h"
+
+#include "common/SerialQueue.h"
+
+#include <bitset>
+
+namespace backend {
+namespace d3d12 {
+
+    class Device;
+
+    class CommandAllocatorManager {
+        public:
+            CommandAllocatorManager(Device* device);
+
+            // A CommandAllocator that is reserved must be used before the next Device::Tick where the next serial has completed on the GPU
+            // at this time, the CommandAllocator will be reset
+            ComPtr<ID3D12CommandAllocator> ReserveCommandAllocator();
+            void ResetCompletedAllocators(uint64_t lastCompletedSerial);
+
+        private:
+            Device* device;
+
+            // This must be at least 2 because the Device and Queue use separate command allocators
+            static constexpr unsigned int kMaxCommandAllocators = 32;
+            unsigned int allocatorCount;
+
+            struct IndexedCommandAllocator {
+                ComPtr<ID3D12CommandAllocator> commandAllocator;
+                unsigned int index;
+            };
+
+            ComPtr<ID3D12CommandAllocator> commandAllocators[kMaxCommandAllocators];
+            std::bitset<kMaxCommandAllocators> freeAllocators;
+            SerialQueue<IndexedCommandAllocator> inFlightCommandAllocators;
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_COMMANDALLOCATORMANAGER_H_

--- a/src/backend/d3d12/CommandAllocatorManager.h
+++ b/src/backend/d3d12/CommandAllocatorManager.h
@@ -30,8 +30,8 @@ namespace d3d12 {
         public:
             CommandAllocatorManager(Device* device);
 
-            // A CommandAllocator that is reserved must be used before the next Device::Tick where the next serial has completed on the GPU
-            // at this time, the CommandAllocator will be reset
+            // A CommandAllocator that is reserved must be used on the next ExecuteCommandLists
+            // otherwise its commands may be reset before execution has completed on the GPU
             ComPtr<ID3D12CommandAllocator> ReserveCommandAllocator();
             void ResetCompletedAllocators(uint64_t lastCompletedSerial);
 

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -105,9 +105,6 @@ namespace d3d12 {
         ID3D12CommandList* commandLists[] = { pendingCommandList.Get() };
         commandQueue->ExecuteCommandLists(_countof(commandLists), commandLists);
 
-        // Update state tracking for objects requiring the serial
-        resourceUploader.EnqueueUploadingResources(GetSerial() + 1);
-
         IncrementSerial();
 
         // Signal when the pending commands have finished

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -32,8 +32,9 @@
 #include "common/ToBackend.h"
 
 #include "d3d12_platform.h"
-#include "ResourceUploader.h"
 #include "CommandAllocatorManager.h"
+#include "ResourceAllocator.h"
+#include "ResourceUploader.h"
 
 namespace backend {
 namespace d3d12 {
@@ -110,11 +111,13 @@ namespace d3d12 {
 
             ComPtr<ID3D12Device> GetD3D12Device();
             ComPtr<ID3D12CommandQueue> GetCommandQueue();
+
             CommandAllocatorManager* GetCommandAllocatorManager();
+            ResourceAllocator* GetResourceAllocator();
             ResourceUploader* GetResourceUploader();
 
             ComPtr<ID3D12GraphicsCommandList> GetPendingCommandList();
-            
+
             D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentRenderTargetDescriptor();
             void SetNextRenderTargetDescriptor(D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor);
 
@@ -137,8 +140,9 @@ namespace d3d12 {
             ComPtr<ID3D12CommandQueue> commandQueue;
 
             CommandAllocatorManager commandAllocatorManager;
+            ResourceAllocator resourceAllocator;
             ResourceUploader resourceUploader;
-            
+
             struct PendingCommandList {
                 ComPtr<ID3D12CommandAllocator> commandAllocator;
                 ComPtr<ID3D12GraphicsCommandList> commandList;

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -113,10 +113,10 @@ namespace d3d12 {
             ComPtr<ID3D12Device> GetD3D12Device();
             ComPtr<ID3D12CommandQueue> GetCommandQueue();
 
-            CommandAllocatorManager* GetCommandAllocatorManager();
             ResourceAllocator* GetResourceAllocator();
             ResourceUploader* GetResourceUploader();
 
+            void OpenCommandList(ComPtr<ID3D12GraphicsCommandList>* commandList);
             ComPtr<ID3D12GraphicsCommandList> GetPendingCommandList();
 
             D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentRenderTargetDescriptor();
@@ -145,7 +145,6 @@ namespace d3d12 {
             ResourceUploader* resourceUploader;
 
             struct PendingCommandList {
-                ComPtr<ID3D12CommandAllocator> commandAllocator;
                 ComPtr<ID3D12GraphicsCommandList> commandList;
                 bool open = false;
             } pendingCommands;

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -32,9 +32,6 @@
 #include "common/ToBackend.h"
 
 #include "d3d12_platform.h"
-#include "CommandAllocatorManager.h"
-#include "ResourceAllocator.h"
-#include "ResourceUploader.h"
 
 namespace backend {
 namespace d3d12 {
@@ -56,6 +53,10 @@ namespace d3d12 {
     class TextureView;
     class Framebuffer;
     class RenderPass;
+
+    class CommandAllocatorManager;
+    class ResourceAllocator;
+    class ResourceUploader;
 
     struct D3D12BackendTraits {
         using BindGroupType = BindGroup;
@@ -139,9 +140,9 @@ namespace d3d12 {
             ComPtr<ID3D12Device> d3d12Device;
             ComPtr<ID3D12CommandQueue> commandQueue;
 
-            CommandAllocatorManager commandAllocatorManager;
-            ResourceAllocator resourceAllocator;
-            ResourceUploader resourceUploader;
+            CommandAllocatorManager* commandAllocatorManager;
+            ResourceAllocator* resourceAllocator;
+            ResourceUploader* resourceUploader;
 
             struct PendingCommandList {
                 ComPtr<ID3D12CommandAllocator> commandAllocator;

--- a/src/backend/d3d12/QueueD3D12.cpp
+++ b/src/backend/d3d12/QueueD3D12.cpp
@@ -15,6 +15,7 @@
 #include "QueueD3D12.h"
 
 #include "D3D12Backend.h"
+#include "CommandAllocatorManager.h"
 #include "CommandBufferD3D12.h"
 
 namespace backend {

--- a/src/backend/d3d12/QueueD3D12.h
+++ b/src/backend/d3d12/QueueD3D12.h
@@ -35,11 +35,7 @@ namespace d3d12 {
         private:
             Device* device;
 
-            ComPtr<ID3D12CommandAllocator> commandAllocator;
             ComPtr<ID3D12GraphicsCommandList> commandList;
-            ComPtr<ID3D12Fence> fence;
-            uint64_t fenceValue = 0;
-            HANDLE fenceEvent;
     };
 
 }

--- a/src/backend/d3d12/ResourceAllocator.cpp
+++ b/src/backend/d3d12/ResourceAllocator.cpp
@@ -1,0 +1,92 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ResourceAllocator.h"
+
+#include "D3D12Backend.h"
+
+namespace backend {
+namespace d3d12 {
+
+    namespace {
+        static constexpr D3D12_HEAP_PROPERTIES kDefaultHeapProperties = {
+            D3D12_HEAP_TYPE_DEFAULT,
+            D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+            D3D12_MEMORY_POOL_UNKNOWN,
+            0,
+            0
+        };
+
+        static constexpr D3D12_HEAP_PROPERTIES kUploadHeapProperties = {
+            D3D12_HEAP_TYPE_UPLOAD,
+            D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+            D3D12_MEMORY_POOL_UNKNOWN,
+            0,
+            0
+        };
+
+        static constexpr D3D12_HEAP_PROPERTIES kReadbackHeapProperties = {
+            D3D12_HEAP_TYPE_READBACK,
+            D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+            D3D12_MEMORY_POOL_UNKNOWN,
+            0,
+            0
+        };
+    }
+
+    ResourceAllocator::ResourceAllocator(Device* device) : device(device) {
+    }
+
+    ComPtr<ID3D12Resource> ResourceAllocator::Allocate(D3D12_HEAP_TYPE heapType, const D3D12_RESOURCE_DESC &resourceDescriptor, D3D12_RESOURCE_STATES initialUsage) {
+        const D3D12_HEAP_PROPERTIES* heapProperties = nullptr;
+        switch(heapType) {
+            case D3D12_HEAP_TYPE_DEFAULT:
+                heapProperties = &kDefaultHeapProperties;
+                break;
+            case D3D12_HEAP_TYPE_UPLOAD:
+                heapProperties = &kUploadHeapProperties;
+                break;
+            case D3D12_HEAP_TYPE_READBACK:
+                heapProperties = &kReadbackHeapProperties;
+                break;
+            default:
+                ASSERT(false);
+        }
+
+        ComPtr<ID3D12Resource> resource;
+
+        // TODO(enga@google.com): Use CreatePlacedResource
+        ASSERT_SUCCESS(device->GetD3D12Device()->CreateCommittedResource(
+            heapProperties,
+            D3D12_HEAP_FLAG_NONE,
+            &resourceDescriptor,
+            initialUsage,
+            nullptr,
+            IID_PPV_ARGS(&resource)
+        ));
+
+        return resource;
+    }
+
+    void ResourceAllocator::Release(ComPtr<ID3D12Resource> resource) {
+        // Resources may still be in use on the GPU. Enqueue them so that we hold onto them until GPU execution has completed
+        releasedResources.Enqueue(resource, device->GetSerial());
+    }
+
+    void ResourceAllocator::FreeUnusedResources(uint64_t lastCompletedSerial) {
+        releasedResources.ClearUpTo(lastCompletedSerial);
+    }
+
+}
+}

--- a/src/backend/d3d12/ResourceAllocator.h
+++ b/src/backend/d3d12/ResourceAllocator.h
@@ -19,8 +19,6 @@
 
 #include "common/SerialQueue.h"
 
-#include <set>
-
 namespace backend {
 namespace d3d12 {
 

--- a/src/backend/d3d12/ResourceAllocator.h
+++ b/src/backend/d3d12/ResourceAllocator.h
@@ -12,36 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BACKEND_D3D12_RESOURCEUPLOADER_H_
-#define BACKEND_D3D12_RESOURCEUPLOADER_H_
+#ifndef BACKEND_D3D12_RESOURCEALLOCATIONMANAGER_H_
+#define BACKEND_D3D12_RESOURCEALLOCATIONMANAGER_H_
 
 #include "d3d12_platform.h"
 
-#include "common/Forward.h"
+#include "common/SerialQueue.h"
+
+#include <set>
 
 namespace backend {
 namespace d3d12 {
 
     class Device;
 
-    class ResourceUploader {
-        public:
-            ResourceUploader(Device* device);
+    class ResourceAllocator {
 
-            void UploadToBuffer(ComPtr<ID3D12Resource> resource, uint32_t start, uint32_t count, const uint8_t* data);
+        public:
+            ResourceAllocator(Device* device);
+
+            ComPtr<ID3D12Resource> Allocate(D3D12_HEAP_TYPE heapType, const D3D12_RESOURCE_DESC &resourceDescriptor, D3D12_RESOURCE_STATES initialUsage);
+            void Release(ComPtr<ID3D12Resource> resource);
+            void FreeUnusedResources(uint64_t lastCompletedSerial);
 
         private:
-            struct UploadHandle {
-                ComPtr<ID3D12Resource> resource;
-                uint8_t* mappedBuffer;
-            };
-
-            UploadHandle GetUploadBuffer(uint32_t requiredSize);
-            void Release(UploadHandle uploadHandle);
-
             Device* device;
+
+            SerialQueue<ComPtr<ID3D12Resource>> releasedResources;
     };
+
 }
 }
 
-#endif // BACKEND_D3D12_RESOURCEUPLOADER_H_
+#endif // BACKEND_D3D12_RESOURCEALLOCATIONMANAGER_H_

--- a/src/backend/d3d12/ResourceUploader.cpp
+++ b/src/backend/d3d12/ResourceUploader.cpp
@@ -15,6 +15,7 @@
 #include "ResourceUploader.h"
 
 #include "D3D12Backend.h"
+#include "ResourceAllocator.h"
 
 namespace backend {
 namespace d3d12 {

--- a/src/backend/d3d12/ResourceUploader.cpp
+++ b/src/backend/d3d12/ResourceUploader.cpp
@@ -70,7 +70,7 @@ namespace d3d12 {
         uploadResource->Unmap(0, &writeRange);
         device->GetPendingCommandList()->CopyBufferRegion(resource.Get(), start, uploadResource.Get(), 0, count);
 
-        uploadingResources.Enqueue(std::move(uploadResource), device->GetSerial() + 1);
+        uploadingResources.Enqueue(std::move(uploadResource), device->GetSerial());
     }
 
     void ResourceUploader::FreeCompletedResources(const uint64_t lastCompletedSerial) {

--- a/src/backend/d3d12/ResourceUploader.cpp
+++ b/src/backend/d3d12/ResourceUploader.cpp
@@ -70,26 +70,11 @@ namespace d3d12 {
         uploadResource->Unmap(0, &writeRange);
         device->GetPendingCommandList()->CopyBufferRegion(resource.Get(), start, uploadResource.Get(), 0, count);
 
-        pendingResources.push_back(uploadResource);
-    }
-
-    void ResourceUploader::EnqueueUploadingResources(const uint64_t serial) {
-        if (pendingResources.size() > 0) {
-            uploadingResources.push_back(std::make_pair(serial, std::move(pendingResources)));
-            pendingResources.clear();
-        }
+        uploadingResources.Enqueue(std::move(uploadResource), device->GetSerial() + 1);
     }
 
     void ResourceUploader::FreeCompletedResources(const uint64_t lastCompletedSerial) {
-        auto it = uploadingResources.begin();
-        while (it != uploadingResources.end()) {
-            if (it->first < lastCompletedSerial) {
-                it++;
-            } else {
-                break;
-            }
-        }
-        uploadingResources.erase(uploadingResources.begin(), it);
+        uploadingResources.ClearUpTo(lastCompletedSerial);
     }
 
 }

--- a/src/backend/d3d12/ResourceUploader.h
+++ b/src/backend/d3d12/ResourceUploader.h
@@ -17,6 +17,8 @@
 
 #include "d3d12_platform.h"
 
+#include "common/SerialQueue.h"
+
 #include <map>
 #include <vector>
 
@@ -30,15 +32,12 @@ namespace d3d12 {
             ResourceUploader(Device* device);
 
             void UploadToBuffer(ComPtr<ID3D12Resource> resource, uint32_t start, uint32_t count, const uint8_t* data);
-            void EnqueueUploadingResources(const uint64_t serial);
             void FreeCompletedResources(const uint64_t lastCompletedSerial);
 
         private:
             Device* device;
 
-            std::vector<ComPtr<ID3D12Resource>> pendingResources;
-            std::vector<std::pair<uint64_t, std::vector<ComPtr<ID3D12Resource>>>> uploadingResources;
-
+            SerialQueue<ComPtr<ID3D12Resource>> uploadingResources;
     };
 
 }


### PR DESCRIPTION
- Adds `CommandAllocatorManager` to manage creation and lifetimes of `ID3D12CommandAllocator`s using a `SerialQueue`. On `Device::TickImpl`, old Command Allocators will be reset so a Command Allocator must be used before the next Tick.
- Adds `ExecuteCommandLists` to the device to ensure that pending commands are always executed first
- Adds `ResourceAllocationManager` to manage creation of `ID3D12Resource`s. This is currently a simple interface which always uses `CreateCommittedResource`. Freeing resources places them on a `SerialQueue` to be released when the GPU finishes work up to the current serial. Freeing them is currently totally unnecessary because they won't actually be freed until the ComPtr is released, but is implemented so that it will be easier to replace resources with objects that the ResourceAllocationManager handles internally.
- Updates `ResourceUploader` to use `ResourceAllocationManager`