### PR TITLE
Test SerialQueue::FirstSerial

### DIFF
--- a/src/backend/common/SerialQueue.h
+++ b/src/backend/common/SerialQueue.h
@@ -110,12 +110,14 @@ namespace backend {
 
     template<typename T>
     void SerialQueue<T>::Enqueue(const std::vector<T>& values, Serial serial) {
+        ASSERT(values.size() > 0);
         ASSERT(Empty() || storage.back().first <= serial);
         storage.emplace_back(SerialPair(serial, {values}));
     }
 
     template<typename T>
     void SerialQueue<T>::Enqueue(std::vector<T>&& values, Serial serial) {
+        ASSERT(values.size() > 0);
         ASSERT(Empty() || storage.back().first <= serial);
         storage.emplace_back(SerialPair(serial, {values}));
     }

--- a/src/tests/unittests/SerialQueueTests.cpp
+++ b/src/tests/unittests/SerialQueueTests.cpp
@@ -117,3 +117,25 @@ TEST(SerialQueue, ClearUpTo) {
     }
     ASSERT_TRUE(expectedValues.empty());
 }
+
+// Test FirstSerial
+TEST(SerialQueue, FirstSerial) {
+    SerialQueue queue;
+
+    std::vector<int> vector1 = {1, 2, 3, 4};
+    std::vector<int> vector2 = {5, 6, 7, 8};
+    std::vector<int> vector3 = {9, 0};
+
+    queue.Enqueue(vector1, 0);
+    queue.Enqueue(std::move(vector2), 1);
+    queue.Enqueue(vector3, 2);
+
+    EXPECT_EQ(queue.FirstSerial(), 0);
+
+    queue.ClearUpTo(1);
+    EXPECT_EQ(queue.FirstSerial(), 2);
+
+    queue.Clear();
+    queue.Enqueue(vector1, 6);
+    EXPECT_EQ(queue.FirstSerial(), 6);
+}


### PR DESCRIPTION
Adds a test for SerialQueue::FirstSerial

I also noticed that SerialQueue::Enque on empty vectors would break things (and wouldn't really make sense anyway) so I added an assertion for that case.