### PR TITLE
Texture to buffer copies

### DIFF
--- a/next.json
+++ b/next.json
@@ -296,6 +296,28 @@
                 ]
             },
             {
+                "name": "copy texture to buffer",
+                "args": [
+                    {"name": "texture", "type": "texture"},
+                    {"name": "x", "type": "uint32_t"},
+                    {"name": "y", "type": "uint32_t"},
+                    {"name": "z", "type": "uint32_t"},
+                    {"name": "width", "type": "uint32_t"},
+                    {"name": "height", "type": "uint32_t"},
+                    {"name": "depth", "type": "uint32_t"},
+                    {"name": "level", "type": "uint32_t"},
+                    {"name": "buffer", "type": "buffer"},
+                    {"name": "buffer offset", "type": "uint32_t"}
+                ],
+                "TODO": [
+                    "Make pretty with Offset and Extents structures",
+                    "Allow choosing the aspect (depth vs. stencil)?",
+                    "Add these arguments too",
+                    {"name": "row length", "type": "uint32_t"},
+                    {"name": "image height", "type": "uint32_t"}
+                ]
+            },
+            {
                 "name": "dispatch",
                 "args": [
                     {"name": "x", "type": "uint32_t"},

--- a/src/backend/common/CommandBuffer.cpp
+++ b/src/backend/common/CommandBuffer.cpp
@@ -250,11 +250,6 @@ namespace backend {
                         uint64_t z = copy->z;
                         uint32_t level = copy->level;
 
-                        if (width == 0 || height == 0 || depth == 0) {
-                            HandleError("Empty copy");
-                            return false;
-                        }
-
                         // TODO(cwallez@chromium.org): check for overflows
                         uint64_t pixelSize = TextureFormatPixelSize(texture->GetFormat());
                         uint64_t dataSize = width * height * depth * pixelSize;

--- a/src/backend/common/CommandBuffer.h
+++ b/src/backend/common/CommandBuffer.h
@@ -65,6 +65,9 @@ namespace backend {
             void CopyBufferToTexture(BufferBase* buffer, uint32_t bufferOffset,
                                      TextureBase* texture, uint32_t x, uint32_t y, uint32_t z,
                                      uint32_t width, uint32_t height, uint32_t depth, uint32_t level);
+            void CopyTextureToBuffer(TextureBase* texture, uint32_t x, uint32_t y, uint32_t z,
+                                     uint32_t width, uint32_t height, uint32_t depth, uint32_t level,
+                                     BufferBase* buffer, uint32_t bufferOffset);
             void Dispatch(uint32_t x, uint32_t y, uint32_t z);
             void DrawArrays(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
             void DrawElements(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstIndex, uint32_t firstInstance);

--- a/src/backend/common/Commands.h
+++ b/src/backend/common/Commands.h
@@ -32,6 +32,7 @@ namespace backend {
         BeginRenderPass,
         CopyBufferToBuffer,
         CopyBufferToTexture,
+        CopyTextureToBuffer,
         Dispatch,
         DrawArrays,
         DrawElements,
@@ -75,6 +76,11 @@ namespace backend {
     struct CopyBufferToTextureCmd {
         BufferCopyLocation source;
         TextureCopyLocation destination;
+    };
+
+    struct CopyTextureToBufferCmd {
+        TextureCopyLocation source;
+        BufferCopyLocation destination;
     };
 
     struct DispatchCmd {

--- a/src/backend/common/Commands.h
+++ b/src/backend/common/Commands.h
@@ -54,21 +54,27 @@ namespace backend {
         Ref<FramebufferBase> framebuffer;
     };
 
-    struct CopyBufferToBufferCmd {
-        Ref<BufferBase> source;
-        Ref<BufferBase> destination;
-        uint32_t sourceOffset;
-        uint32_t destinationOffset;
-        uint32_t size;
+    struct BufferCopyLocation {
+        Ref<BufferBase> buffer;
+        uint32_t offset;
     };
 
-    struct CopyBufferToTextureCmd {
-        Ref<BufferBase> buffer;
-        uint32_t bufferOffset;
+    struct TextureCopyLocation {
         Ref<TextureBase> texture;
         uint32_t x, y, z;
         uint32_t width, height, depth;
         uint32_t level;
+    };
+
+    struct CopyBufferToBufferCmd {
+        BufferCopyLocation source;
+        BufferCopyLocation destination;
+        uint32_t size;
+    };
+
+    struct CopyBufferToTextureCmd {
+        BufferCopyLocation source;
+        TextureCopyLocation destination;
     };
 
     struct DispatchCmd {

--- a/src/backend/d3d12/CommandBufferD3D12.cpp
+++ b/src/backend/d3d12/CommandBufferD3D12.cpp
@@ -73,6 +73,7 @@ namespace d3d12 {
                         commandList->OMSetRenderTargets(1, &device->GetCurrentRenderTargetDescriptor(), FALSE, nullptr);
                     }
                     break;
+
                 case Command::CopyBufferToBuffer:
                     {
                         CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
@@ -82,6 +83,12 @@ namespace d3d12 {
                 case Command::CopyBufferToTexture:
                     {
                         CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();
+                    }
+                    break;
+
+                case Command::CopyTextureToBuffer:
+                    {
+                        CopyTextureToBufferCmd* copy = commands.NextCommand<CopyTextureToBufferCmd>();
                     }
                     break;
 

--- a/src/backend/metal/CommandBufferMTL.mm
+++ b/src/backend/metal/CommandBufferMTL.mm
@@ -163,13 +163,15 @@ namespace metal {
                 case Command::CopyBufferToBuffer:
                     {
                         CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
+                        auto& src = copy->source;
+                        auto& dst = copy->destination;
 
                         encoders.EnsureBlit(commandBuffer);
                         [encoders.blit
-                            copyFromBuffer:ToBackend(copy->source)->GetMTLBuffer()
-                            sourceOffset:copy->sourceOffset
-                            toBuffer:ToBackend(copy->destination)->GetMTLBuffer()
-                            destinationOffset:copy->destinationOffset
+                            copyFromBuffer:ToBackend(src.buffer)->GetMTLBuffer()
+                            sourceOffset:src.offset
+                            toBuffer:ToBackend(dst.buffer)->GetMTLBuffer()
+                            destinationOffset:dst.offset
                             size:copy->size];
                     }
                     break;
@@ -177,30 +179,32 @@ namespace metal {
                 case Command::CopyBufferToTexture:
                     {
                         CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();
-                        Buffer* buffer = ToBackend(copy->buffer.Get());
-                        Texture* texture = ToBackend(copy->texture.Get());
+                        auto& src = copy->source;
+                        auto& dst = copy->destination;
+                        Buffer* buffer = ToBackend(src.buffer.Get());
+                        Texture* texture = ToBackend(dst.texture.Get());
 
-                        unsigned rowSize = copy->width * TextureFormatPixelSize(texture->GetFormat());
+                        unsigned rowSize = dst.width * TextureFormatPixelSize(texture->GetFormat());
                         MTLOrigin origin;
-                        origin.x = copy->x;
-                        origin.y = copy->y;
-                        origin.z = copy->z;
+                        origin.x = dst.x;
+                        origin.y = dst.y;
+                        origin.z = dst.z;
 
                         MTLSize size;
-                        size.width = copy->width;
-                        size.height = copy->height;
-                        size.depth = copy->depth;
+                        size.width = dst.width;
+                        size.height = dst.height;
+                        size.depth = dst.depth;
 
                         encoders.EnsureBlit(commandBuffer);
                         [encoders.blit
                             copyFromBuffer:buffer->GetMTLBuffer()
-                            sourceOffset:copy->bufferOffset
+                            sourceOffset:src.offset
                             sourceBytesPerRow:rowSize
-                            sourceBytesPerImage:(rowSize * copy->height)
+                            sourceBytesPerImage:(rowSize * dst.height)
                             sourceSize:size
                             toTexture:texture->GetMTLTexture()
                             destinationSlice:0
-                            destinationLevel:copy->level
+                            destinationLevel:dst.level
                             destinationOrigin:origin];
                     }
                     break;

--- a/src/backend/metal/CommandBufferMTL.mm
+++ b/src/backend/metal/CommandBufferMTL.mm
@@ -209,6 +209,39 @@ namespace metal {
                     }
                     break;
 
+                case Command::CopyTextureToBuffer:
+                    {
+                        CopyTextureToBufferCmd* copy = commands.NextCommand<CopyTextureToBufferCmd>();
+                        auto& src = copy->source;
+                        auto& dst = copy->destination;
+                        Texture* texture = ToBackend(src.texture.Get());
+                        Buffer* buffer = ToBackend(dst.buffer.Get());
+
+                        unsigned rowSize = src.width * TextureFormatPixelSize(texture->GetFormat());
+                        MTLOrigin origin;
+                        origin.x = src.x;
+                        origin.y = src.y;
+                        origin.z = src.z;
+
+                        MTLSize size;
+                        size.width = src.width;
+                        size.height = src.height;
+                        size.depth = src.depth;
+
+                        encoders.EnsureBlit(commandBuffer);
+                        [encoders.blit
+                            copyFromTexture:texture->GetMTLTexture()
+                            sourceSlice:0
+                            sourceLevel:src.level
+                            sourceOrigin:origin
+                            sourceSize:size
+                            toBuffer:buffer->GetMTLBuffer()
+                            destinationOffset:dst.offset
+                            destinationBytesPerRow:rowSize
+                            destinationBytesPerImage:rowSize * src.height];
+                    }
+                    break;
+
                 case Command::Dispatch:
                     {
                         DispatchCmd* dispatch = commands.NextCommand<DispatchCmd>();

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -81,10 +81,12 @@ namespace opengl {
                 case Command::CopyBufferToBuffer:
                     {
                         CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
+                        auto& src = copy->source;
+                        auto& dst = copy->destination;
 
-                        glBindBuffer(GL_PIXEL_PACK_BUFFER, ToBackend(copy->source)->GetHandle());
-                        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, ToBackend(copy->destination)->GetHandle());
-                        glCopyBufferSubData(GL_PIXEL_PACK_BUFFER, GL_PIXEL_UNPACK_BUFFER, copy->sourceOffset, copy->destinationOffset, copy->size);
+                        glBindBuffer(GL_PIXEL_PACK_BUFFER, ToBackend(src.buffer)->GetHandle());
+                        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, ToBackend(dst.buffer)->GetHandle());
+                        glCopyBufferSubData(GL_PIXEL_PACK_BUFFER, GL_PIXEL_UNPACK_BUFFER, src.offset, dst.offset, copy->size);
 
                         glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
                         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
@@ -94,8 +96,10 @@ namespace opengl {
                 case Command::CopyBufferToTexture:
                     {
                         CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();
-                        Buffer* buffer = ToBackend(copy->buffer.Get());
-                        Texture* texture = ToBackend(copy->texture.Get());
+                        auto& src = copy->source;
+                        auto& dst = copy->destination;
+                        Buffer* buffer = ToBackend(src.buffer.Get());
+                        Texture* texture = ToBackend(dst.texture.Get());
                         GLenum target = texture->GetGLTarget();
                         auto format = texture->GetGLFormat();
 
@@ -103,9 +107,9 @@ namespace opengl {
                         glActiveTexture(GL_TEXTURE0);
                         glBindTexture(target, texture->GetHandle());
 
-                        glTexSubImage2D(target, copy->level, copy->x, copy->y, copy->width, copy->height,
+                        glTexSubImage2D(target, dst.level, dst.x, dst.y, dst.width, dst.height,
                                         format.format, format.type,
-                                        reinterpret_cast<void*>(static_cast<uintptr_t>(copy->bufferOffset)));
+                                        reinterpret_cast<void*>(static_cast<uintptr_t>(src.offset)));
                         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
                     }
                     break;

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -114,6 +114,13 @@ namespace opengl {
                     }
                     break;
 
+                case Command::CopyTextureToBuffer:
+                    {
+                        CopyTextureToBufferCmd* copy = commands.NextCommand<CopyTextureToBufferCmd>();
+                        // TODO(cwallez@chromium.org): implement using a temporary FBO and ReadPixels
+                    }
+                    break;
+
                 case Command::Dispatch:
                     {
                         DispatchCmd* dispatch = commands.NextCommand<DispatchCmd>();

--- a/src/tests/unittests/validation/CopyCommandsValidationTests.cpp
+++ b/src/tests/unittests/validation/CopyCommandsValidationTests.cpp
@@ -32,14 +32,25 @@ TEST_F(CopyCommandTest_B2B, Success) {
     destination.FreezeUsage(nxt::BufferUsageBit::TransferDst);
 
     // Copy different copies, including some that touch the OOB condition
-    nxt::CommandBuffer commands = AssertWillBeSuccess(device.CreateCommandBufferBuilder())
-        .CopyBufferToBuffer(source, 0, destination, 0, 16)
-        .CopyBufferToBuffer(source, 8, destination, 0, 8)
-        .CopyBufferToBuffer(source, 0, destination, 8, 8)
-        .GetResult();
+    {
+        nxt::CommandBuffer commands = AssertWillBeSuccess(device.CreateCommandBufferBuilder())
+            .CopyBufferToBuffer(source, 0, destination, 0, 16)
+            .CopyBufferToBuffer(source, 8, destination, 0, 8)
+            .CopyBufferToBuffer(source, 0, destination, 8, 8)
+            .GetResult();
+    }
+
+    // Empty copies are valid
+    {
+        nxt::CommandBuffer commands = AssertWillBeSuccess(device.CreateCommandBufferBuilder())
+            .CopyBufferToBuffer(source, 0, destination, 0, 0)
+            .CopyBufferToBuffer(source, 0, destination, 16, 0)
+            .CopyBufferToBuffer(source, 16, destination, 0, 0)
+            .GetResult();
+    }
 }
 
-// Test B2B copies with overflows
+// Test B2B copies with OOB
 TEST_F(CopyCommandTest_B2B, OutOfBounds) {
     nxt::Buffer source = device.CreateBufferBuilder()
         .SetSize(16)
@@ -68,7 +79,7 @@ TEST_F(CopyCommandTest_B2B, OutOfBounds) {
     }
 }
 
-// Test B2B copies with overflows
+// Test B2B copies with incorrect buffer usage
 TEST_F(CopyCommandTest_B2B, BadUsage) {
     nxt::Buffer source = device.CreateBufferBuilder()
         .SetSize(16)


### PR DESCRIPTION
PTAL, this will be important to be able to check pixel values in the end2end tests. I didn't actually test that the Metal implementation works though.

Part of #53.