### PR TITLE
Add D3D12 Buffer, Texture, and Sampler binding

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -237,6 +237,10 @@ if (WIN32)
     SetPIC(d3d12_autogen)
 
     list(APPEND BACKEND_SOURCES
+        ${D3D12_DIR}/BindGroupD3D12.cpp
+        ${D3D12_DIR}/BindGroupD3D12.h
+        ${D3D12_DIR}/BindGroupLayoutD3D12.cpp
+        ${D3D12_DIR}/BindGroupLayoutD3D12.h
         ${D3D12_DIR}/BufferD3D12.cpp
         ${D3D12_DIR}/BufferD3D12.h
         ${D3D12_DIR}/CommandAllocatorManager.cpp

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -243,6 +243,8 @@ if (WIN32)
         ${D3D12_DIR}/CommandAllocatorManager.h
         ${D3D12_DIR}/CommandBufferD3D12.cpp
         ${D3D12_DIR}/CommandBufferD3D12.h
+        ${D3D12_DIR}/DescriptorHeapAllocator.cpp
+        ${D3D12_DIR}/DescriptorHeapAllocator.h
         ${D3D12_DIR}/D3D12Backend.cpp
         ${D3D12_DIR}/D3D12Backend.h
         ${D3D12_DIR}/InputStateD3D12.cpp
@@ -257,8 +259,12 @@ if (WIN32)
         ${D3D12_DIR}/ResourceAllocator.h
         ${D3D12_DIR}/ResourceUploader.cpp
         ${D3D12_DIR}/ResourceUploader.h
+        ${D3D12_DIR}/SamplerD3D12.cpp
+        ${D3D12_DIR}/SamplerD3D12.h
         ${D3D12_DIR}/ShaderModuleD3D12.cpp
         ${D3D12_DIR}/ShaderModuleD3D12.h
+        ${D3D12_DIR}/TextureD3D12.cpp
+        ${D3D12_DIR}/TextureD3D12.h
     )
 endif()
 

--- a/src/backend/common/CommandBuffer.cpp
+++ b/src/backend/common/CommandBuffer.cpp
@@ -218,6 +218,85 @@ namespace backend {
         commands->DataWasDestroyed();
     }
 
+    void SkipCommand(CommandIterator* commands, Command type) {
+        switch (type) {
+            case Command::AdvanceSubpass:
+                commands->NextCommand<AdvanceSubpassCmd>();
+                break;
+
+            case Command::BeginRenderPass:
+                commands->NextCommand<BeginRenderPassCmd>();
+                break;
+
+            case Command::CopyBufferToBuffer:
+                commands->NextCommand<CopyBufferToBufferCmd>();
+                break;
+
+            case Command::CopyBufferToTexture:
+                commands->NextCommand<CopyBufferToTextureCmd>();
+                break;
+
+            case Command::CopyTextureToBuffer:
+                commands->NextCommand<CopyTextureToBufferCmd>();
+                break;
+
+            case Command::Dispatch:
+                commands->NextCommand<DispatchCmd>();
+                break;
+
+            case Command::DrawArrays:
+                commands->NextCommand<DrawArraysCmd>();
+                break;
+
+            case Command::DrawElements:
+                commands->NextCommand<DrawElementsCmd>();
+                break;
+
+            case Command::EndRenderPass:
+                commands->NextCommand<EndRenderPassCmd>();
+                break;
+
+            case Command::SetPipeline:
+                commands->NextCommand<SetPipelineCmd>();
+                break;
+
+            case Command::SetPushConstants:
+                {
+                    auto* cmd = commands->NextCommand<SetPushConstantsCmd>();
+                    commands->NextData<uint32_t>(cmd->count);
+                }
+                break;
+
+            case Command::SetStencilReference:
+                commands->NextCommand<SetStencilReferenceCmd>();
+                break;
+
+            case Command::SetBindGroup:
+                commands->NextCommand<SetBindGroupCmd>();
+                break;
+
+            case Command::SetIndexBuffer:
+                commands->NextCommand<SetIndexBufferCmd>();
+                break;
+
+            case Command::SetVertexBuffers:
+                {
+                    auto* cmd = commands->NextCommand<SetVertexBuffersCmd>();
+                    commands->NextData<Ref<BufferBase>>(cmd->count);
+                    commands->NextData<uint32_t>(cmd->count);
+                }
+                break;
+
+            case Command::TransitionBufferUsage:
+                commands->NextCommand<TransitionBufferUsageCmd>();
+                break;
+
+            case Command::TransitionTextureUsage:
+                commands->NextCommand<TransitionTextureUsageCmd>();
+                break;
+        }
+    }
+
     CommandBufferBuilder::CommandBufferBuilder(DeviceBase* device) : Builder(device), state(std::make_unique<CommandBufferStateTracker>(this)) {
     }
 

--- a/src/backend/common/CommandBufferStateTracker.cpp
+++ b/src/backend/common/CommandBufferStateTracker.cpp
@@ -280,6 +280,8 @@ namespace backend {
             for (uint32_t i = 0; i < kMaxBindGroups; ++i) {
                 if (lastLayout->GetBindGroupLayout(i) == layout->GetBindGroupLayout(i)) {
                     bindgroupsSet |= uint64_t(1) << i;
+                } else {
+                    break;
                 }
             }
         }

--- a/src/backend/common/Commands.h
+++ b/src/backend/common/Commands.h
@@ -151,6 +151,7 @@ namespace backend {
     // This needs to be called before the CommandIterator is freed so that the Ref<> present in
     // the commands have a chance to run their destructor and remove internal references.
     void FreeCommands(CommandIterator* commands);
+    void SkipCommand(CommandIterator* commands, Command type);
 
 }
 

--- a/src/backend/d3d12/BindGroupD3D12.cpp
+++ b/src/backend/d3d12/BindGroupD3D12.cpp
@@ -1,0 +1,95 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/BitSetIterator.h"
+#include "BindGroupD3D12.h"
+#include "BindGroupLayoutD3D12.h"
+#include "BufferD3D12.h"
+#include "SamplerD3D12.h"
+#include "TextureD3D12.h"
+
+#include "D3D12Backend.h"
+
+namespace backend {
+namespace d3d12 {
+
+    BindGroup::BindGroup(Device* device, BindGroupBuilder* builder)
+        : BindGroupBase(builder), device(device) {
+    }
+
+    void BindGroup::RecordDescriptors(const DescriptorHeapHandle &cbvUavSrvHeapStart, uint32_t* cbvUavSrvHeapOffset, const DescriptorHeapHandle &samplerHeapStart, uint32_t* samplerHeapOffset, uint64_t serial) {
+        heapSerial = serial;
+
+        const auto* bgl = ToBackend(GetLayout());
+        const auto& layout = bgl->GetBindingInfo();
+
+        // Save the offset to the start of the descriptor table in the heap
+        this->cbvUavSrvHeapOffset = *cbvUavSrvHeapOffset;
+        this->samplerHeapOffset = *samplerHeapOffset;
+
+        const auto& bindingOffsets = bgl->GetBindingOffsets();
+
+        auto d3d12Device = device->GetD3D12Device();
+        for (uint32_t binding : IterateBitSet(layout.mask)) {
+            switch (layout.types[binding]) {
+                case nxt::BindingType::UniformBuffer:
+                    {
+                        auto* view = ToBackend(GetBindingAsBufferView(binding));
+                        auto& cbv = view->GetCBVDescriptor();
+                        d3d12Device->CreateConstantBufferView(&cbv, cbvUavSrvHeapStart.GetCPUHandle(*cbvUavSrvHeapOffset + bindingOffsets[binding]));
+                    }
+                    break;
+                case nxt::BindingType::StorageBuffer:
+                    {
+                        auto* view = ToBackend(GetBindingAsBufferView(binding));
+                        auto& uav = view->GetUAVDescriptor();
+                        d3d12Device->CreateUnorderedAccessView(ToBackend(view->GetBuffer())->GetD3D12Resource().Get(), nullptr, &uav, cbvUavSrvHeapStart.GetCPUHandle(*cbvUavSrvHeapOffset + bindingOffsets[binding]));
+                    }
+                    break;
+                case nxt::BindingType::SampledTexture:
+                    {
+                        auto* view = ToBackend(GetBindingAsTextureView(binding));
+                        auto& srv = view->GetSRVDescriptor();
+                        d3d12Device->CreateShaderResourceView(ToBackend(view->GetTexture())->GetD3D12Resource().Get(), &srv, cbvUavSrvHeapStart.GetCPUHandle(*cbvUavSrvHeapOffset + bindingOffsets[binding]));
+                    }
+                    break;
+                case nxt::BindingType::Sampler:
+                    {
+                        auto* sampler = ToBackend(GetBindingAsSampler(binding));
+                        auto& samplerDesc = sampler->GetSamplerDescriptor();
+                        d3d12Device->CreateSampler(&samplerDesc, samplerHeapStart.GetCPUHandle(*samplerHeapOffset + bindingOffsets[binding]));
+                    }
+                    break;
+            }
+        }
+
+        // Offset by the number of descriptors created
+        *cbvUavSrvHeapOffset += bgl->GetCbvUavSrvDescriptorCount();
+        *samplerHeapOffset += bgl->GetSamplerDescriptorCount();
+    }
+
+    uint32_t BindGroup::GetCbvUavSrvHeapOffset() const {
+        return cbvUavSrvHeapOffset;
+    }
+
+    uint32_t BindGroup::GetSamplerHeapOffset() const {
+        return samplerHeapOffset;
+    }
+
+    uint64_t BindGroup::GetHeapSerial() const {
+        return heapSerial;
+    }
+
+}
+}

--- a/src/backend/d3d12/BindGroupD3D12.h
+++ b/src/backend/d3d12/BindGroupD3D12.h
@@ -1,0 +1,50 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_D3D12_BINDGROUPD3D12_H_
+#define BACKEND_D3D12_BINDGROUPD3D12_H_
+
+#include "common/BindGroup.h"
+
+#include "d3d12_platform.h"
+
+#include "DescriptorHeapAllocator.h"
+
+namespace backend {
+namespace d3d12 {
+
+    class Device;
+
+    class BindGroup : public BindGroupBase {
+        public:
+            BindGroup(Device* device, BindGroupBuilder* builder);
+
+            void RecordDescriptors(const DescriptorHeapHandle &cbvSrvUavHeapStart, uint32_t* cbvUavSrvHeapOffset, const DescriptorHeapHandle &samplerHeapStart, uint32_t* samplerHeapOffset, uint64_t serial);
+            uint32_t GetCbvUavSrvHeapOffset() const;
+            uint32_t GetSamplerHeapOffset() const;
+            uint64_t GetHeapSerial() const;
+
+        private:
+            Device* device;
+            uint32_t cbvUavSrvHeapOffset;
+            uint32_t samplerHeapOffset;
+            uint32_t cbvUavSrvCount = 0;
+            uint32_t samplerCount = 0;
+            uint64_t heapSerial = 0;
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_BINDGROUPD3D12_H_

--- a/src/backend/d3d12/BindGroupLayoutD3D12.cpp
+++ b/src/backend/d3d12/BindGroupLayoutD3D12.cpp
@@ -1,0 +1,132 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BindGroupLayoutD3D12.h"
+
+#include "common/BitSetIterator.h"
+#include "D3D12Backend.h"
+
+namespace backend {
+namespace d3d12 {
+
+    BindGroupLayout::BindGroupLayout(Device* device, BindGroupLayoutBuilder* builder)
+        : BindGroupLayoutBase(builder), device(device), descriptorCounts {}  {
+
+        const auto& groupInfo = GetBindingInfo();
+
+        for (uint32_t binding : IterateBitSet(groupInfo.mask)) {
+            switch (groupInfo.types[binding]) {
+                case nxt::BindingType::UniformBuffer:
+                    bindingOffsets[binding] = descriptorCounts[CBV]++;
+                    break;
+                case nxt::BindingType::StorageBuffer:
+                    bindingOffsets[binding] = descriptorCounts[UAV]++;
+                    break;
+                case nxt::BindingType::SampledTexture:
+                    bindingOffsets[binding] = descriptorCounts[SRV]++;
+                    break;
+                case nxt::BindingType::Sampler:
+                    bindingOffsets[binding] = descriptorCounts[Sampler]++;
+                    break;
+            }
+        }
+
+        auto SetDescriptorRange = [&](uint32_t index, uint32_t count, D3D12_DESCRIPTOR_RANGE_TYPE type) -> bool {
+            if (count == 0) {
+                return false;
+            }
+
+            auto& range = ranges[index];
+            range.RangeType = type;
+            range.NumDescriptors = count;
+            range.RegisterSpace = 0;
+            range.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+            // These ranges will be copied and range.BaseShaderRegister will be set in d3d12::PipelineLayout to account for bind group register offsets
+            return true;
+        };
+
+        uint32_t rangeIndex = 0;
+
+        // Ranges 0-2 contain the CBV, UAV, and SRV ranges, if they exist, tightly packed
+        // Range 3 contains the Sampler range, if there is one
+        if (SetDescriptorRange(rangeIndex, descriptorCounts[CBV], D3D12_DESCRIPTOR_RANGE_TYPE_CBV)) {
+            rangeIndex++;
+        }
+        if (SetDescriptorRange(rangeIndex, descriptorCounts[UAV], D3D12_DESCRIPTOR_RANGE_TYPE_UAV)) {
+            rangeIndex++;
+        }
+        if (SetDescriptorRange(rangeIndex, descriptorCounts[SRV], D3D12_DESCRIPTOR_RANGE_TYPE_SRV)) {
+            rangeIndex++;
+        }
+        SetDescriptorRange(Sampler, descriptorCounts[Sampler], D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER);
+
+        // descriptors ranges are offset by the offset + size of the previous range
+        std::array<uint32_t, DescriptorType::Count> descriptorOffsets;
+        descriptorOffsets[CBV] = 0;
+        descriptorOffsets[UAV] = descriptorOffsets[CBV] + descriptorCounts[CBV];
+        descriptorOffsets[SRV] = descriptorOffsets[UAV] + descriptorCounts[UAV];
+        descriptorOffsets[Sampler] = 0; // samplers are in a different heap
+
+        for (uint32_t binding : IterateBitSet(groupInfo.mask)) {
+            switch (groupInfo.types[binding]) {
+                case nxt::BindingType::UniformBuffer:
+                    bindingOffsets[binding] += descriptorOffsets[CBV];
+                    break;
+                case nxt::BindingType::StorageBuffer:
+                    bindingOffsets[binding] += descriptorOffsets[UAV];
+                    break;
+                case nxt::BindingType::SampledTexture:
+                    bindingOffsets[binding] += descriptorOffsets[SRV];
+                    break;
+                case nxt::BindingType::Sampler:
+                    bindingOffsets[binding] += descriptorOffsets[Sampler];
+                    break;
+            }
+        }
+    }
+
+    const std::array<uint32_t, kMaxBindingsPerGroup>& BindGroupLayout::GetBindingOffsets() const {
+        return bindingOffsets;
+    }
+
+    uint32_t BindGroupLayout::GetCbvUavSrvDescriptorTableSize() const {
+        return (
+            static_cast<uint32_t>(descriptorCounts[CBV] > 0) +
+            static_cast<uint32_t>(descriptorCounts[UAV] > 0) +
+            static_cast<uint32_t>(descriptorCounts[SRV] > 0)
+        );
+    }
+
+    uint32_t BindGroupLayout::GetSamplerDescriptorTableSize() const {
+        return descriptorCounts[Sampler] > 0;
+    }
+
+    uint32_t BindGroupLayout::GetCbvUavSrvDescriptorCount() const {
+        return descriptorCounts[CBV] + descriptorCounts[UAV] + descriptorCounts[SRV];
+    }
+
+    uint32_t BindGroupLayout::GetSamplerDescriptorCount() const {
+        return descriptorCounts[Sampler];
+    }
+
+    const D3D12_DESCRIPTOR_RANGE* BindGroupLayout::GetCbvUavSrvDescriptorRanges() const {
+        return ranges;
+    }
+
+    const D3D12_DESCRIPTOR_RANGE* BindGroupLayout::GetSamplerDescriptorRanges() const {
+        return &ranges[Sampler];
+    }
+
+}
+}

--- a/src/backend/d3d12/BindGroupLayoutD3D12.h
+++ b/src/backend/d3d12/BindGroupLayoutD3D12.h
@@ -1,0 +1,57 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_D3D12_BINDGROUPLAYOUTD3D12_H_
+#define BACKEND_D3D12_BINDGROUPLAYOUTD3D12_H_
+
+#include "common/BindGroupLayout.h"
+
+#include "d3d12_platform.h"
+
+namespace backend {
+namespace d3d12 {
+
+    class Device;
+
+    class BindGroupLayout : public BindGroupLayoutBase {
+        public:
+            BindGroupLayout(Device* device, BindGroupLayoutBuilder* builder);
+
+            enum DescriptorType {
+                CBV,
+                UAV,
+                SRV,
+                Sampler,
+                Count,
+            };
+
+            const std::array<uint32_t, kMaxBindingsPerGroup>& GetBindingOffsets() const;
+            uint32_t GetCbvUavSrvDescriptorTableSize() const;
+            uint32_t GetSamplerDescriptorTableSize() const;
+            uint32_t GetCbvUavSrvDescriptorCount() const;
+            uint32_t GetSamplerDescriptorCount() const;
+            const D3D12_DESCRIPTOR_RANGE* GetCbvUavSrvDescriptorRanges() const;
+            const D3D12_DESCRIPTOR_RANGE* GetSamplerDescriptorRanges() const;
+
+        private:
+            Device* device;
+            std::array<uint32_t, kMaxBindingsPerGroup> bindingOffsets;
+            std::array<uint32_t, DescriptorType::Count> descriptorCounts;
+            D3D12_DESCRIPTOR_RANGE ranges[DescriptorType::Count];
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_BINDGROUPLAYOUTD3D12_H_

--- a/src/backend/d3d12/BufferD3D12.h
+++ b/src/backend/d3d12/BufferD3D12.h
@@ -29,6 +29,7 @@ namespace d3d12 {
             Buffer(Device* device, BufferBuilder* builder);
             ~Buffer();
 
+            uint32_t GetD3D12Size() const;
             ComPtr<ID3D12Resource> GetD3D12Resource();
             D3D12_GPU_VIRTUAL_ADDRESS GetVA() const;
             bool GetResourceTransitionBarrier(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage, D3D12_RESOURCE_BARRIER* barrier);
@@ -43,6 +44,20 @@ namespace d3d12 {
             void UnmapImpl() override;
             void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) override;
 
+    };
+
+    class BufferView : public BufferViewBase {
+        public:
+            BufferView(Device* device, BufferViewBuilder* builder);
+
+            uint32_t GetD3D12Size() const;
+            const D3D12_CONSTANT_BUFFER_VIEW_DESC& GetCBVDescriptor() const;
+            const D3D12_UNORDERED_ACCESS_VIEW_DESC& GetUAVDescriptor() const;
+
+        private:
+            Device* device;
+            D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc;
+            D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc;
     };
 
 }

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -14,6 +14,8 @@
 
 #include "D3D12Backend.h"
 
+#include "BindGroupD3D12.h"
+#include "BindGroupLayoutD3D12.h"
 #include "BufferD3D12.h"
 #include "CommandBufferD3D12.h"
 #include "InputStateD3D12.h"
@@ -246,18 +248,6 @@ namespace d3d12 {
     }
 
     void Device::Release() {
-    }
-
-    // Bind Group
-
-    BindGroup::BindGroup(Device* device, BindGroupBuilder* builder)
-        : BindGroupBase(builder), device(device) {
-    }
-
-    // Bind Group Layout
-
-    BindGroupLayout::BindGroupLayout(Device* device, BindGroupLayoutBuilder* builder)
-        : BindGroupLayoutBase(builder), device(device) {
     }
 
     // DepthStencilState

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -155,23 +155,6 @@ namespace d3d12 {
             D3D12_CPU_DESCRIPTOR_HANDLE renderTargetDescriptor;
     };
 
-
-    class BindGroup : public BindGroupBase {
-        public:
-            BindGroup(Device* device, BindGroupBuilder* builder);
-
-        private:
-            Device* device;
-    };
-
-    class BindGroupLayout : public BindGroupLayoutBase {
-        public:
-            BindGroupLayout(Device* device, BindGroupLayoutBuilder* builder);
-
-        private:
-            Device* device;
-    };
-
     class Framebuffer : public FramebufferBase {
         public:
             Framebuffer(Device* device, FramebufferBuilder* builder);

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -55,6 +55,7 @@ namespace d3d12 {
     class RenderPass;
 
     class CommandAllocatorManager;
+    class DescriptorHeapAllocator;
     class ResourceAllocator;
     class ResourceUploader;
 
@@ -113,6 +114,7 @@ namespace d3d12 {
             ComPtr<ID3D12Device> GetD3D12Device();
             ComPtr<ID3D12CommandQueue> GetCommandQueue();
 
+            DescriptorHeapAllocator* GetDescriptorHeapAllocator();
             ResourceAllocator* GetResourceAllocator();
             ResourceUploader* GetResourceUploader();
 
@@ -141,6 +143,7 @@ namespace d3d12 {
             ComPtr<ID3D12CommandQueue> commandQueue;
 
             CommandAllocatorManager* commandAllocatorManager;
+            DescriptorHeapAllocator* descriptorHeapAllocator;
             ResourceAllocator* resourceAllocator;
             ResourceUploader* resourceUploader;
 
@@ -169,14 +172,6 @@ namespace d3d12 {
             Device* device;
     };
 
-    class BufferView : public BufferViewBase {
-        public:
-            BufferView(Device* device, BufferViewBuilder* builder);
-
-        private:
-            Device* device;
-    };
-
     class Framebuffer : public FramebufferBase {
         public:
             Framebuffer(Device* device, FramebufferBuilder* builder);
@@ -196,32 +191,6 @@ namespace d3d12 {
     class RenderPass : public RenderPassBase {
         public:
             RenderPass(Device* device, RenderPassBuilder* builder);
-
-        private:
-            Device* device;
-    };
-
-    class Sampler : public SamplerBase {
-        public:
-            Sampler(Device* device, SamplerBuilder* builder);
-
-        private:
-            Device* device;
-    };
-
-    class Texture : public TextureBase {
-        public:
-            Texture(Device* device, TextureBuilder* builder);
-
-        private:
-            void TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) override;
-
-            Device* device;
-    };
-
-    class TextureView : public TextureViewBase {
-        public:
-            TextureView(Device* device, TextureViewBuilder* builder);
 
         private:
             Device* device;

--- a/src/backend/d3d12/DescriptorHeapAllocator.cpp
+++ b/src/backend/d3d12/DescriptorHeapAllocator.cpp
@@ -1,0 +1,100 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "DescriptorHeapAllocator.h"
+
+#include "D3D12Backend.h"
+
+namespace backend {
+namespace d3d12 {
+
+    DescriptorHeapHandle::DescriptorHeapHandle() {
+    }
+
+    DescriptorHeapHandle::DescriptorHeapHandle(ComPtr<ID3D12DescriptorHeap> descriptorHeap, uint32_t sizeIncrement, uint32_t offset)
+        : device(device), descriptorHeap(descriptorHeap), sizeIncrement(sizeIncrement), offset(offset) {
+    }
+
+    ID3D12DescriptorHeap* DescriptorHeapHandle::Get() const {
+        return descriptorHeap.Get();
+    }
+
+    D3D12_CPU_DESCRIPTOR_HANDLE DescriptorHeapHandle::GetCPUHandle(uint32_t index) const {
+        ASSERT(descriptorHeap);
+        auto handle = descriptorHeap->GetCPUDescriptorHandleForHeapStart();
+        handle.ptr += sizeIncrement * (index + offset);
+        return handle;
+    }
+
+    D3D12_GPU_DESCRIPTOR_HANDLE DescriptorHeapHandle::GetGPUHandle(uint32_t index) const {
+        ASSERT(descriptorHeap);
+        auto handle = descriptorHeap->GetGPUDescriptorHandleForHeapStart();
+        handle.ptr += sizeIncrement * (index + offset);
+        return handle;
+    }
+
+
+    DescriptorHeapAllocator::DescriptorHeapAllocator(Device* device)
+        : device(device),
+          sizeIncrements {
+            device->GetD3D12Device()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV),
+            device->GetD3D12Device()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER),
+            device->GetD3D12Device()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV),
+            device->GetD3D12Device()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV),
+          } {
+    }
+
+    DescriptorHeapHandle DescriptorHeapAllocator::Allocate(D3D12_DESCRIPTOR_HEAP_TYPE type, uint32_t count) {
+        if (count == 0) {
+            return DescriptorHeapHandle();
+        }
+
+        auto& pools = descriptorHeapPools[type];
+        for (auto it : pools) {
+            auto& allocationInfo = it.second;
+            if (allocationInfo.remaining >= count) {
+                DescriptorHeapHandle handle(it.first, sizeIncrements[type], allocationInfo.size - allocationInfo.remaining);
+                allocationInfo.remaining -= count;
+                Release(handle);
+                return handle;
+            }
+        }
+
+        ASSERT(count <= 2048); // TODO(enga@google.com): Have a very large CPU heap that's copied to GPU-visible heaps
+        uint32_t descriptorHeapSize = 2048; // TODO(enga@google.com): Allocate much more and use this as a pool
+
+        D3D12_DESCRIPTOR_HEAP_DESC heapDescriptor;
+        heapDescriptor.Type = type;
+        heapDescriptor.NumDescriptors = descriptorHeapSize;
+        heapDescriptor.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+        heapDescriptor.NodeMask = 0;
+        ComPtr<ID3D12DescriptorHeap> heap;
+        ASSERT_SUCCESS(device->GetD3D12Device()->CreateDescriptorHeap(&heapDescriptor, IID_PPV_ARGS(&heap)));
+        AllocationInfo allocationInfo = { descriptorHeapSize, descriptorHeapSize - count };
+        pools.emplace_back(std::make_pair(heap, allocationInfo));
+
+        DescriptorHeapHandle handle(heap, sizeIncrements[type], 0);
+        Release(handle);
+        return handle;
+    }
+
+    void DescriptorHeapAllocator::FreeDescriptorHeaps(uint64_t lastCompletedSerial) {
+        releasedHandles.ClearUpTo(lastCompletedSerial);
+    }
+
+    void DescriptorHeapAllocator::Release(DescriptorHeapHandle handle) {
+        releasedHandles.Enqueue(handle, device->GetSerial());
+    }
+}
+}

--- a/src/backend/d3d12/DescriptorHeapAllocator.h
+++ b/src/backend/d3d12/DescriptorHeapAllocator.h
@@ -1,0 +1,76 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_D3D12_DESCRIPTORHEAPALLOCATOR_H_
+#define BACKEND_D3D12_DESCRIPTORHEAPALLOCATOR_H_
+
+#include "d3d12_platform.h"
+
+#include "common/SerialQueue.h"
+#include <array>
+#include <vector>
+
+namespace backend {
+namespace d3d12 {
+
+    class Device;
+
+    class DescriptorHeapHandle {
+        public:
+            DescriptorHeapHandle();
+            DescriptorHeapHandle(ComPtr<ID3D12DescriptorHeap> descriptorHeap, uint32_t sizeIncrement, uint32_t offset);
+
+            ID3D12DescriptorHeap* Get() const;
+            D3D12_CPU_DESCRIPTOR_HANDLE GetCPUHandle(uint32_t index) const;
+            D3D12_GPU_DESCRIPTOR_HANDLE GetGPUHandle(uint32_t index) const;
+
+        private:
+            Device* device;
+            ComPtr<ID3D12DescriptorHeap> descriptorHeap;
+            uint32_t sizeIncrement;
+            uint32_t offset;
+    };
+
+    class DescriptorHeapAllocator {
+        public:
+            DescriptorHeapAllocator(Device* device);
+
+            DescriptorHeapHandle Allocate(D3D12_DESCRIPTOR_HEAP_TYPE type, uint32_t count);
+            void FreeDescriptorHeaps(uint64_t lastCompletedSerial);
+
+        private:
+            void Release(DescriptorHeapHandle handle);
+
+            Device* device;
+
+            static constexpr unsigned int kDescriptorHeapTypes = D3D12_DESCRIPTOR_HEAP_TYPE::D3D12_DESCRIPTOR_HEAP_TYPE_NUM_TYPES;
+
+            struct AllocationInfo {
+                uint32_t size;
+                uint32_t remaining;
+            };
+
+            using DescriptorHeapPool = std::pair<ComPtr<ID3D12DescriptorHeap>, AllocationInfo>;
+
+            using DescriptorHeapPoolList = std::vector<DescriptorHeapPool>;
+
+            std::array<uint32_t, kDescriptorHeapTypes> sizeIncrements;
+            std::array<DescriptorHeapPoolList, kDescriptorHeapTypes> descriptorHeapPools;
+            SerialQueue<DescriptorHeapHandle> releasedHandles;
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_DESCRIPTORHEAPALLOCATOR_H_

--- a/src/backend/d3d12/GeneratedCodeIncludes.h
+++ b/src/backend/d3d12/GeneratedCodeIncludes.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "D3D12Backend.h"
+#include "BindGroupD3D12.h"
+#include "BindGroupLayoutD3D12.h"
 #include "BufferD3D12.h"
 #include "CommandBufferD3D12.h"
 #include "InputStateD3D12.h"

--- a/src/backend/d3d12/PipelineLayoutD3D12.cpp
+++ b/src/backend/d3d12/PipelineLayoutD3D12.cpp
@@ -48,14 +48,16 @@ namespace d3d12 {
             // Set the root descriptor table parameter and copy ranges. Ranges are offset by the bind group index
             // Returns whether or not the parameter was set. A root parameter is not set if the number of ranges is 0
             auto SetRootDescriptorTable = [&](uint32_t rangeCount, const D3D12_DESCRIPTOR_RANGE* descriptorRanges) -> bool {
-                if (rangeCount > 0) {
-                    auto& rootParameter = rootParameters[parameterIndex];
-                    rootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
-                    rootParameter.DescriptorTable = rootParameterValues[parameterIndex].DescriptorTable;
-                    rootParameter.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
-                    rootParameter.DescriptorTable.NumDescriptorRanges = rangeCount;
-                    rootParameter.DescriptorTable.pDescriptorRanges = &ranges[rangeIndex];
+                if (rangeCount == 0) {
+                    return false;
                 }
+
+                auto& rootParameter = rootParameters[parameterIndex];
+                rootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+                rootParameter.DescriptorTable = rootParameterValues[parameterIndex].DescriptorTable;
+                rootParameter.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+                rootParameter.DescriptorTable.NumDescriptorRanges = rangeCount;
+                rootParameter.DescriptorTable.pDescriptorRanges = &ranges[rangeIndex];
 
                 for (uint32_t i = 0; i < rangeCount; ++i) {
                     ranges[rangeIndex] = descriptorRanges[i];
@@ -63,7 +65,7 @@ namespace d3d12 {
                     rangeIndex++;
                 }
 
-                return (rangeCount > 0);
+                return true;
             };
 
             if (SetRootDescriptorTable(bindGroupLayout->GetCbvUavSrvDescriptorTableSize(), bindGroupLayout->GetCbvUavSrvDescriptorRanges())) {

--- a/src/backend/d3d12/PipelineLayoutD3D12.h
+++ b/src/backend/d3d12/PipelineLayoutD3D12.h
@@ -28,10 +28,34 @@ namespace d3d12 {
         public:
             PipelineLayout(Device* device, PipelineLayoutBuilder* builder);
 
+            class Descriptor {
+                public:
+                    enum class Type {
+                        CBV,
+                        UAV,
+                        SRV,
+                        Sampler,
+                        Count
+                    };
+                    static constexpr unsigned int TypeCount = static_cast<typename std::underlying_type<Type>::type>(Type::Count);
+            };
+
+            uint32_t GetCbvUavSrvRootParameterIndex(uint32_t group) const;
+            uint32_t GetSamplerRootParameterIndex(uint32_t group) const;
+
             ComPtr<ID3D12RootSignature> GetRootSignature();
 
         private:
+
+            static constexpr unsigned int ToIndex(Descriptor::Type type) {
+                return static_cast<typename std::underlying_type<Descriptor::Type>::type>(type);
+            }
+
             Device* device;
+
+            std::array<uint32_t, kMaxBindGroups> cbvUavSrvRootParameterInfo;
+            std::array<uint32_t, kMaxBindGroups> samplerRootParameterInfo;
+            std::array<std::array<uint32_t, Descriptor::TypeCount>, kMaxBindGroups> descriptorCountInfo;
 
             ComPtr<ID3D12RootSignature> rootSignature;
     };

--- a/src/backend/d3d12/PipelineLayoutD3D12.h
+++ b/src/backend/d3d12/PipelineLayoutD3D12.h
@@ -28,34 +28,16 @@ namespace d3d12 {
         public:
             PipelineLayout(Device* device, PipelineLayoutBuilder* builder);
 
-            class Descriptor {
-                public:
-                    enum class Type {
-                        CBV,
-                        UAV,
-                        SRV,
-                        Sampler,
-                        Count
-                    };
-                    static constexpr unsigned int TypeCount = static_cast<typename std::underlying_type<Type>::type>(Type::Count);
-            };
-
             uint32_t GetCbvUavSrvRootParameterIndex(uint32_t group) const;
             uint32_t GetSamplerRootParameterIndex(uint32_t group) const;
 
             ComPtr<ID3D12RootSignature> GetRootSignature();
 
         private:
-
-            static constexpr unsigned int ToIndex(Descriptor::Type type) {
-                return static_cast<typename std::underlying_type<Descriptor::Type>::type>(type);
-            }
-
             Device* device;
 
             std::array<uint32_t, kMaxBindGroups> cbvUavSrvRootParameterInfo;
             std::array<uint32_t, kMaxBindGroups> samplerRootParameterInfo;
-            std::array<std::array<uint32_t, Descriptor::TypeCount>, kMaxBindGroups> descriptorCountInfo;
 
             ComPtr<ID3D12RootSignature> rootSignature;
     };

--- a/src/backend/d3d12/SamplerD3D12.cpp
+++ b/src/backend/d3d12/SamplerD3D12.cpp
@@ -1,0 +1,83 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "SamplerD3D12.h"
+
+#include "D3D12Backend.h"
+
+namespace backend {
+namespace d3d12 {
+
+    Sampler::Sampler(SamplerBuilder* builder)
+        : SamplerBase(builder) {
+
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/dn770367(v=vs.85).aspx
+        // D3D12_FILTER_MIN_MAG_MIP_POINT                       = 0       0     0 0 0   // hex value, decimal value, min linear, mag linear, mip linear
+        // D3D12_FILTER_MIN_MAG_POINT_MIP_LINEAR                = 0x1     1     0 0 1
+        // D3D12_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT          = 0x4     4     0 1 0
+        // D3D12_FILTER_MIN_POINT_MAG_MIP_LINEAR                = 0x5     5     0 1 1
+        // D3D12_FILTER_MIN_LINEAR_MAG_MIP_POINT                = 0x10   16     1 0 0
+        // D3D12_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR         = 0x11   17     1 0 1
+        // D3D12_FILTER_MIN_MAG_LINEAR_MIP_POINT                = 0x14   20     1 1 0
+        // D3D12_FILTER_MIN_MAG_MIP_LINEAR                      = 0x15   21     1 1 1
+
+        // if mip mode is linear, add 1
+        // if mag mode is linear, add 4
+        // if min mode is linear, add 16
+
+        uint8_t mode = 0;
+
+        switch (builder->GetMinFilter()) {
+            case nxt::FilterMode::Nearest:
+                break;
+            case nxt::FilterMode::Linear:
+                mode += 16;
+                break;
+        }
+
+        switch (builder->GetMagFilter()) {
+            case nxt::FilterMode::Nearest:
+                break;
+            case nxt::FilterMode::Linear:
+                mode += 4;
+                break;
+        }
+
+        switch (builder->GetMipMapFilter()) {
+            case nxt::FilterMode::Nearest:
+                break;
+            case nxt::FilterMode::Linear:
+                mode += 1;
+                break;
+        }
+
+        samplerDesc.Filter = static_cast<D3D12_FILTER>(mode);
+        samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+        samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+        samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+        samplerDesc.MipLODBias = 0.f;
+        samplerDesc.MaxAnisotropy = 1;
+        samplerDesc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+        samplerDesc.BorderColor[0] = samplerDesc.BorderColor[1] = samplerDesc.BorderColor[2] = samplerDesc.BorderColor[3] = 0;
+        samplerDesc.MinLOD = 0;
+        samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
+
+    }
+
+    const D3D12_SAMPLER_DESC& Sampler::GetSamplerDescriptor() const {
+        return samplerDesc;
+    }
+
+}
+}

--- a/src/backend/d3d12/SamplerD3D12.h
+++ b/src/backend/d3d12/SamplerD3D12.h
@@ -12,13 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "D3D12Backend.h"
-#include "BufferD3D12.h"
-#include "CommandBufferD3D12.h"
-#include "InputStateD3D12.h"
-#include "PipelineD3D12.h"
-#include "PipelineLayoutD3D12.h"
-#include "QueueD3D12.h"
-#include "SamplerD3D12.h"
-#include "ShaderModuleD3D12.h"
-#include "TextureD3D12.h"
+#ifndef BACKEND_D3D12_SAMPLERD3D12_H_
+#define BACKEND_D3D12_SAMPLERD3D12_H_
+
+#include "common/Sampler.h"
+
+#include "d3d12_platform.h"
+
+namespace backend {
+namespace d3d12 {
+
+    class Sampler : public SamplerBase {
+        public:
+            Sampler(SamplerBuilder* builder);
+
+            const D3D12_SAMPLER_DESC& GetSamplerDescriptor() const;
+
+        private:
+            D3D12_SAMPLER_DESC samplerDesc;
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_SAMPLERD3D12_H_

--- a/src/backend/d3d12/ShaderModuleD3D12.cpp
+++ b/src/backend/d3d12/ShaderModuleD3D12.cpp
@@ -59,18 +59,6 @@ namespace d3d12 {
         RenumberBindings(resources.separate_samplers);  // s
 
         hlslSource = compiler.compile();
-
-        {
-            // pending https://github.com/KhronosGroup/SPIRV-Cross/issues/216
-            // rename ": register(cN)" to ": register(bN)"
-            std::string::size_type pos = 0;
-            const std::string search = ": register(c";
-            const std::string replace = ": register(b";
-            while ((pos = hlslSource.find(search, pos)) != std::string::npos) {
-                hlslSource.replace(pos, search.length(), replace);
-                pos += replace.length();
-            }
-        }
     }
 
     const std::string& ShaderModule::GetHLSLSource() const {

--- a/src/backend/d3d12/TextureD3D12.cpp
+++ b/src/backend/d3d12/TextureD3D12.cpp
@@ -1,0 +1,153 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "TextureD3D12.h"
+
+#include "D3D12Backend.h"
+#include "ResourceAllocator.h"
+
+namespace backend {
+namespace d3d12 {
+
+    namespace {
+        D3D12_RESOURCE_STATES D3D12TextureUsage(nxt::TextureUsageBit usage) {
+            D3D12_RESOURCE_STATES resourceState = D3D12_RESOURCE_STATE_COMMON;
+
+            if (usage & nxt::TextureUsageBit::TransferSrc) {
+                resourceState |= D3D12_RESOURCE_STATE_COPY_SOURCE;
+            }
+            if (usage & nxt::TextureUsageBit::TransferDst) {
+                resourceState |= D3D12_RESOURCE_STATE_COPY_DEST;
+            }
+            if (usage & nxt::TextureUsageBit::Sampled) {
+                resourceState |= (D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+            }
+            if (usage & nxt::TextureUsageBit::Storage) {
+                resourceState |= D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+            }
+            if (usage & nxt::TextureUsageBit::ColorAttachment) {
+                resourceState |= D3D12_RESOURCE_STATE_RENDER_TARGET;
+            }
+            if (usage & nxt::TextureUsageBit::DepthStencilAttachment) {
+                resourceState |= D3D12_RESOURCE_STATE_DEPTH_WRITE;
+            }
+
+            return resourceState;
+        }
+
+        D3D12_RESOURCE_FLAGS D3D12ResourceFlags(nxt::TextureUsageBit usage) {
+            D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE;
+
+            if (usage & nxt::TextureUsageBit::Storage) {
+                flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+            }
+            if (usage & nxt::TextureUsageBit::ColorAttachment) {
+                flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+            }
+            if (usage & nxt::TextureUsageBit::DepthStencilAttachment) {
+                flags |= D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
+            }
+
+            return flags;
+        }
+
+        D3D12_RESOURCE_DIMENSION D3D12TextureDimension(nxt::TextureDimension dimension) {
+            switch (dimension) {
+                case nxt::TextureDimension::e2D:
+                    return D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+            }
+        }
+
+        DXGI_FORMAT D3D12TextureFormat(nxt::TextureFormat format) {
+            switch (format) {
+                case nxt::TextureFormat::R8G8B8A8Unorm:
+                    return DXGI_FORMAT_R8G8B8A8_UNORM;
+            }
+        }
+    }
+
+    Texture::Texture(Device* device, TextureBuilder* builder)
+        : TextureBase(builder), device(device) {
+
+        D3D12_RESOURCE_DESC resourceDescriptor;
+        resourceDescriptor.Dimension = D3D12TextureDimension(GetDimension());
+        resourceDescriptor.Alignment = 0;
+        resourceDescriptor.Width = GetWidth();
+        resourceDescriptor.Height = GetHeight();
+        resourceDescriptor.DepthOrArraySize = GetDepth();
+        resourceDescriptor.MipLevels = GetNumMipLevels();
+        resourceDescriptor.Format = D3D12TextureFormat(GetFormat());
+        resourceDescriptor.SampleDesc.Count = 1;
+        resourceDescriptor.SampleDesc.Quality = 0;
+        resourceDescriptor.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        resourceDescriptor.Flags = D3D12ResourceFlags(GetUsage());
+
+        resource = device->GetResourceAllocator()->Allocate(D3D12_HEAP_TYPE_DEFAULT, resourceDescriptor, D3D12TextureUsage(GetUsage()));
+    }
+
+    Texture::~Texture() {
+        device->GetResourceAllocator()->Release(resource);
+    }
+
+    ComPtr<ID3D12Resource> Texture::GetD3D12Resource() {
+        return resource;
+    }
+
+    bool Texture::GetResourceTransitionBarrier(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage, D3D12_RESOURCE_BARRIER* barrier) {
+        D3D12_RESOURCE_STATES stateBefore = D3D12TextureUsage(currentUsage);
+        D3D12_RESOURCE_STATES stateAfter = D3D12TextureUsage(targetUsage);
+
+        if (stateBefore == stateAfter) {
+            return false;
+        }
+
+        barrier->Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier->Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+        barrier->Transition.pResource = resource.Get();
+        barrier->Transition.StateBefore = stateBefore;
+        barrier->Transition.StateAfter = stateAfter;
+        barrier->Transition.Subresource = 0;
+
+        return true;
+    }
+
+    void Texture::TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) {
+        D3D12_RESOURCE_BARRIER barrier;
+        if (GetResourceTransitionBarrier(currentUsage, targetUsage, &barrier)) {
+            device->GetPendingCommandList()->ResourceBarrier(1, &barrier);
+        }
+    }
+
+    TextureView::TextureView(Device* device, TextureViewBuilder* builder)
+        : TextureViewBase(builder) {
+
+        srvDesc.Format = D3D12TextureFormat(GetTexture()->GetFormat());
+        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        switch (GetTexture()->GetDimension()) {
+            case nxt::TextureDimension::e2D:
+                srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+                srvDesc.Texture2D.MostDetailedMip = 0;
+                srvDesc.Texture2D.MipLevels = GetTexture()->GetNumMipLevels();
+                srvDesc.Texture2D.PlaneSlice = 0;
+                srvDesc.Texture2D.ResourceMinLODClamp = 0;
+                break;
+        }
+    }
+
+    const D3D12_SHADER_RESOURCE_VIEW_DESC& TextureView::GetSRVDescriptor() const {
+        return srvDesc;
+    }
+
+}
+}

--- a/src/backend/d3d12/TextureD3D12.h
+++ b/src/backend/d3d12/TextureD3D12.h
@@ -1,0 +1,56 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_D3D12_TEXTURED3D12_H_
+#define BACKEND_D3D12_TEXTURED3D12_H_
+
+#include "common/Texture.h"
+
+#include "d3d12_platform.h"
+
+namespace backend {
+namespace d3d12 {
+
+    class Device;
+
+    class Texture : public TextureBase {
+        public:
+            Texture(Device* device, TextureBuilder* builder);
+            ~Texture();
+
+            ComPtr<ID3D12Resource> GetD3D12Resource();
+            bool GetResourceTransitionBarrier(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage, D3D12_RESOURCE_BARRIER* barrier);
+
+        private:
+            Device* device;
+            ComPtr<ID3D12Resource> resource;
+
+            // NXT API
+            void TransitionUsageImpl(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage) override;
+    };
+
+    class TextureView : public TextureViewBase {
+        public:
+            TextureView(Device* device, TextureViewBuilder* builder);
+
+            const D3D12_SHADER_RESOURCE_VIEW_DESC& GetSRVDescriptor() const;
+
+        private:
+            D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc;
+    };
+
+}
+}
+
+#endif // BACKEND_D3D12_TEXTURED3D12_H_


### PR DESCRIPTION
This is mostly one commit because I couldn't really test anything until all the parts were in place, but if it's easier, I can split it up

- Textures and samplers are currently untested because buffer->texture copies are not yet implemented.
- Allocation of descriptor heaps is currently only does a simple linear allocation and all heaps are both CPU and GPU visible. This will need to be changed in the future.