### PR TITLE
D3D12: Add MapReadAsync and Resource Copies

### DIFF
--- a/src/backend/d3d12/BufferD3D12.cpp
+++ b/src/backend/d3d12/BufferD3D12.cpp
@@ -119,8 +119,8 @@ namespace d3d12 {
     }
 
 
-    BufferView::BufferView(Device* device, BufferViewBuilder* builder)
-        : BufferViewBase(builder), device(device) {
+    BufferView::BufferView(BufferViewBuilder* builder)
+        : BufferViewBase(builder) {
 
         cbvDesc.BufferLocation = ToBackend(GetBuffer())->GetVA() + GetOffset();
         cbvDesc.SizeInBytes = GetD3D12Size();

--- a/src/backend/d3d12/BufferD3D12.cpp
+++ b/src/backend/d3d12/BufferD3D12.cpp
@@ -100,7 +100,7 @@ namespace d3d12 {
     }
 
     void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
-        device->GetResourceUploader()->UploadToBuffer(resource, start * sizeof(uint32_t), count * sizeof(uint32_t), reinterpret_cast<const uint8_t*>(data));
+        device->GetResourceUploader()->BufferSubData(resource, start * sizeof(uint32_t), count * sizeof(uint32_t), data);
     }
 
     void Buffer::MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) {

--- a/src/backend/d3d12/BufferD3D12.h
+++ b/src/backend/d3d12/BufferD3D12.h
@@ -48,14 +48,13 @@ namespace d3d12 {
 
     class BufferView : public BufferViewBase {
         public:
-            BufferView(Device* device, BufferViewBuilder* builder);
+            BufferView(BufferViewBuilder* builder);
 
             uint32_t GetD3D12Size() const;
             const D3D12_CONSTANT_BUFFER_VIEW_DESC& GetCBVDescriptor() const;
             const D3D12_UNORDERED_ACCESS_VIEW_DESC& GetUAVDescriptor() const;
 
         private:
-            Device* device;
             D3D12_CONSTANT_BUFFER_VIEW_DESC cbvDesc;
             D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc;
     };

--- a/src/backend/d3d12/CommandAllocatorManager.cpp
+++ b/src/backend/d3d12/CommandAllocatorManager.cpp
@@ -30,7 +30,7 @@ namespace d3d12 {
         if (freeAllocators.none()) {
             const uint64_t firstSerial = inFlightCommandAllocators.FirstSerial();
             device->WaitForSerial(firstSerial);
-            ResetCompletedAllocators(firstSerial);
+            Tick(firstSerial);
         }
 
         ASSERT(freeAllocators.any());
@@ -53,7 +53,7 @@ namespace d3d12 {
         return commandAllocators[firstFreeIndex];
     }
 
-    void CommandAllocatorManager::ResetCompletedAllocators(uint64_t lastCompletedSerial) {
+    void CommandAllocatorManager::Tick(uint64_t lastCompletedSerial) {
         // Reset all command allocators that are no longer in flight
         for (auto it : inFlightCommandAllocators.IterateUpTo(lastCompletedSerial)) {
             ASSERT_SUCCESS(it.commandAllocator->Reset());

--- a/src/backend/d3d12/CommandAllocatorManager.h
+++ b/src/backend/d3d12/CommandAllocatorManager.h
@@ -33,7 +33,7 @@ namespace d3d12 {
             // A CommandAllocator that is reserved must be used on the next ExecuteCommandLists
             // otherwise its commands may be reset before execution has completed on the GPU
             ComPtr<ID3D12CommandAllocator> ReserveCommandAllocator();
-            void ResetCompletedAllocators(uint64_t lastCompletedSerial);
+            void Tick(uint64_t lastCompletedSerial);
 
         private:
             Device* device;

--- a/src/backend/d3d12/CommandBufferD3D12.cpp
+++ b/src/backend/d3d12/CommandBufferD3D12.cpp
@@ -26,6 +26,8 @@
 #include "SamplerD3D12.h"
 #include "TextureD3D12.h"
 
+#include "ResourceAllocator.h"
+
 namespace backend {
 namespace d3d12 {
 
@@ -188,6 +190,36 @@ namespace d3d12 {
                     D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
             }
         }
+    
+        D3D12_TEXTURE_COPY_LOCATION D3D12PlacedTextureCopyLocation(BufferCopyLocation& bufferLocation, Texture* texture, const TextureCopyLocation& textureLocation) {
+            D3D12_TEXTURE_COPY_LOCATION d3d12Location;
+            d3d12Location.pResource = ToBackend(bufferLocation.buffer.Get())->GetD3D12Resource().Get();
+            d3d12Location.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+            d3d12Location.PlacedFootprint.Offset = bufferLocation.offset;
+            d3d12Location.PlacedFootprint.Footprint.Format = texture->GetD3D12Format();
+            d3d12Location.PlacedFootprint.Footprint.Width = textureLocation.width;
+            d3d12Location.PlacedFootprint.Footprint.Height = textureLocation.height;
+            d3d12Location.PlacedFootprint.Footprint.Depth = textureLocation.depth;
+
+            uint32_t texelSize = 0;
+            switch (texture->GetFormat()) {
+				case nxt::TextureFormat::R8G8B8A8Unorm:
+					texelSize = 4;
+					break;
+            }
+            uint32_t rowSize = textureLocation.width * texelSize;
+            d3d12Location.PlacedFootprint.Footprint.RowPitch = ((rowSize - 1) / D3D12_TEXTURE_DATA_PITCH_ALIGNMENT + 1) * D3D12_TEXTURE_DATA_PITCH_ALIGNMENT;
+
+            return d3d12Location;
+        }
+
+        D3D12_TEXTURE_COPY_LOCATION D3D12TextureCopyLocation(TextureCopyLocation& textureLocation) {
+            D3D12_TEXTURE_COPY_LOCATION d3d12Location;
+            d3d12Location.pResource = ToBackend(textureLocation.texture.Get())->GetD3D12Resource().Get();
+            d3d12Location.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+            d3d12Location.SubresourceIndex = textureLocation.level;
+            return d3d12Location;
+        }
     }
 
     CommandBuffer::CommandBuffer(Device* device, CommandBufferBuilder* builder)
@@ -246,18 +278,52 @@ namespace d3d12 {
                 case Command::CopyBufferToBuffer:
                     {
                         CopyBufferToBufferCmd* copy = commands.NextCommand<CopyBufferToBufferCmd>();
+                        auto src = ToBackend(copy->source.buffer.Get())->GetD3D12Resource();
+                        auto dst = ToBackend(copy->destination.buffer.Get())->GetD3D12Resource();
+                        commandList->CopyBufferRegion(dst.Get(), copy->destination.offset, src.Get(), copy->source.offset, copy->size);
                     }
                     break;
 
                 case Command::CopyBufferToTexture:
                     {
                         CopyBufferToTextureCmd* copy = commands.NextCommand<CopyBufferToTextureCmd>();
+                        Buffer* buffer = ToBackend(copy->source.buffer.Get());
+                        Texture* texture = ToBackend(copy->destination.texture.Get());
+
+                        D3D12_TEXTURE_COPY_LOCATION srcLocation = D3D12PlacedTextureCopyLocation(copy->source, texture, copy->destination);
+                        D3D12_TEXTURE_COPY_LOCATION dstLocation = D3D12TextureCopyLocation(copy->destination);
+
+                        // TODO(enga@google.com): This assertion will not be true if the number of bytes in each row of the texture is not a multiple of 256
+                        // To resolve this we would need to create an intermediate resource or force all textures to be 256-byte aligned
+                        uint64_t totalBytes = srcLocation.PlacedFootprint.Footprint.RowPitch * copy->destination.height * copy->destination.depth;
+                        ASSERT(totalBytes <= buffer->GetD3D12Size());
+
+                        commandList->CopyTextureRegion(&dstLocation, copy->destination.x, copy->destination.y, copy->destination.z, &srcLocation, nullptr);
                     }
                     break;
 
                 case Command::CopyTextureToBuffer:
                     {
                         CopyTextureToBufferCmd* copy = commands.NextCommand<CopyTextureToBufferCmd>();
+                        Texture* texture = ToBackend(copy->source.texture.Get());
+                        Buffer* buffer = ToBackend(copy->destination.buffer.Get());
+
+                        D3D12_TEXTURE_COPY_LOCATION srcLocation = D3D12TextureCopyLocation(copy->source);
+                        D3D12_TEXTURE_COPY_LOCATION dstLocation = D3D12PlacedTextureCopyLocation(copy->destination, texture, copy->source);
+
+                        // TODO(enga@google.com): This assertion will not be true if the number of bytes in each row of the texture is not a multiple of 256
+                        // To resolve this we would need to create an intermediate resource or force all textures to be 256-byte aligned
+                        uint64_t totalBytes = dstLocation.PlacedFootprint.Footprint.RowPitch * copy->source.height * copy->source.depth;
+                        ASSERT(totalBytes <= buffer->GetD3D12Size());
+
+                        D3D12_BOX sourceRegion;
+                        sourceRegion.left = copy->source.x;
+                        sourceRegion.top = copy->source.y;
+                        sourceRegion.front = copy->source.z;
+                        sourceRegion.right = copy->source.x + copy->source.width;
+                        sourceRegion.bottom = copy->source.y + copy->source.height;
+                        sourceRegion.back = copy->source.z + copy->source.depth;
+                        commandList->CopyTextureRegion(&dstLocation, 0, 0, 0, &srcLocation, &sourceRegion);
                     }
                     break;
 

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -205,7 +205,7 @@ namespace d3d12 {
         return new Buffer(this, builder);
     }
     BufferViewBase* Device::CreateBufferView(BufferViewBuilder* builder) {
-        return new BufferView(this, builder);
+        return new BufferView(builder);
     }
     CommandBufferBase* Device::CreateCommandBuffer(CommandBufferBuilder* builder) {
         return new CommandBuffer(this, builder);
@@ -241,7 +241,7 @@ namespace d3d12 {
         return new Texture(this, builder);
     }
     TextureViewBase* Device::CreateTextureView(TextureViewBuilder* builder) {
-        return new TextureView(this, builder);
+        return new TextureView(builder);
     }
 
     void Device::Reference() {

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -86,6 +86,7 @@ namespace d3d12 {
         : d3d12Device(d3d12Device),
           commandAllocatorManager(new CommandAllocatorManager(this)),
           descriptorHeapAllocator(new DescriptorHeapAllocator(this)),
+          mapReadRequestTracker(new MapReadRequestTracker(this)),
           resourceAllocator(new ResourceAllocator(this)),
           resourceUploader(new ResourceUploader(this)) {
 
@@ -112,6 +113,10 @@ namespace d3d12 {
 
     DescriptorHeapAllocator* Device::GetDescriptorHeapAllocator() {
         return descriptorHeapAllocator;
+    }
+
+    MapReadRequestTracker* Device::GetMapReadRequestTracker() const {
+        return mapReadRequestTracker;
     }
 
     ResourceAllocator* Device::GetResourceAllocator() {
@@ -162,6 +167,9 @@ namespace d3d12 {
         resourceAllocator->Tick(lastCompletedSerial);
         commandAllocatorManager->Tick(lastCompletedSerial);
         descriptorHeapAllocator->Tick(lastCompletedSerial);
+        mapReadRequestTracker->Tick(lastCompletedSerial);
+        ExecuteCommandLists({});
+        NextSerial();
     }
 
     uint64_t Device::GetSerial() const {

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -159,9 +159,9 @@ namespace d3d12 {
     void Device::TickImpl() {
         // Perform cleanup operations to free unused objects
         const uint64_t lastCompletedSerial = fence->GetCompletedValue();
-        resourceAllocator->FreeUnusedResources(lastCompletedSerial);
-        commandAllocatorManager->ResetCompletedAllocators(lastCompletedSerial);
-        descriptorHeapAllocator->FreeDescriptorHeaps(lastCompletedSerial);
+        resourceAllocator->Tick(lastCompletedSerial);
+        commandAllocatorManager->Tick(lastCompletedSerial);
+        descriptorHeapAllocator->Tick(lastCompletedSerial);
     }
 
     uint64_t Device::GetSerial() const {

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -56,6 +56,7 @@ namespace d3d12 {
 
     class CommandAllocatorManager;
     class DescriptorHeapAllocator;
+    class MapReadRequestTracker;
     class ResourceAllocator;
     class ResourceUploader;
 
@@ -115,6 +116,7 @@ namespace d3d12 {
             ComPtr<ID3D12CommandQueue> GetCommandQueue();
 
             DescriptorHeapAllocator* GetDescriptorHeapAllocator();
+            MapReadRequestTracker* GetMapReadRequestTracker() const;
             ResourceAllocator* GetResourceAllocator();
             ResourceUploader* GetResourceUploader();
 
@@ -144,6 +146,7 @@ namespace d3d12 {
 
             CommandAllocatorManager* commandAllocatorManager;
             DescriptorHeapAllocator* descriptorHeapAllocator;
+            MapReadRequestTracker* mapReadRequestTracker;
             ResourceAllocator* resourceAllocator;
             ResourceUploader* resourceUploader;
 

--- a/src/backend/d3d12/DescriptorHeapAllocator.cpp
+++ b/src/backend/d3d12/DescriptorHeapAllocator.cpp
@@ -101,7 +101,7 @@ namespace d3d12 {
         return Allocate(type, count, heapSize, &gpuDescriptorHeapInfos[type], D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
     }
 
-    void DescriptorHeapAllocator::FreeDescriptorHeaps(uint64_t lastCompletedSerial) {
+    void DescriptorHeapAllocator::Tick(uint64_t lastCompletedSerial) {
         releasedHandles.ClearUpTo(lastCompletedSerial);
     }
 

--- a/src/backend/d3d12/DescriptorHeapAllocator.h
+++ b/src/backend/d3d12/DescriptorHeapAllocator.h
@@ -49,7 +49,7 @@ namespace d3d12 {
 
             DescriptorHeapHandle AllocateGPUHeap(D3D12_DESCRIPTOR_HEAP_TYPE type, uint32_t count);
             DescriptorHeapHandle AllocateCPUHeap(D3D12_DESCRIPTOR_HEAP_TYPE type, uint32_t count);
-            void FreeDescriptorHeaps(uint64_t lastCompletedSerial);
+            void Tick(uint64_t lastCompletedSerial);
 
         private:
             static constexpr unsigned int kMaxCbvUavSrvHeapSize = 1000000;
@@ -62,7 +62,7 @@ namespace d3d12 {
             };
 
             using DescriptorHeapInfo = std::pair<ComPtr<ID3D12DescriptorHeap>, AllocationInfo>;
-            
+
             DescriptorHeapHandle Allocate(D3D12_DESCRIPTOR_HEAP_TYPE type, uint32_t count, uint32_t allocationSize, DescriptorHeapInfo* heapInfo, D3D12_DESCRIPTOR_HEAP_FLAGS flags);
             void Release(DescriptorHeapHandle handle);
 

--- a/src/backend/d3d12/ResourceAllocator.cpp
+++ b/src/backend/d3d12/ResourceAllocator.cpp
@@ -84,7 +84,7 @@ namespace d3d12 {
         releasedResources.Enqueue(resource, device->GetSerial());
     }
 
-    void ResourceAllocator::FreeUnusedResources(uint64_t lastCompletedSerial) {
+    void ResourceAllocator::Tick(uint64_t lastCompletedSerial) {
         releasedResources.ClearUpTo(lastCompletedSerial);
     }
 

--- a/src/backend/d3d12/ResourceAllocator.h
+++ b/src/backend/d3d12/ResourceAllocator.h
@@ -31,7 +31,7 @@ namespace d3d12 {
 
             ComPtr<ID3D12Resource> Allocate(D3D12_HEAP_TYPE heapType, const D3D12_RESOURCE_DESC &resourceDescriptor, D3D12_RESOURCE_STATES initialUsage);
             void Release(ComPtr<ID3D12Resource> resource);
-            void FreeUnusedResources(uint64_t lastCompletedSerial);
+            void Tick(uint64_t lastCompletedSerial);
 
         private:
             Device* device;

--- a/src/backend/d3d12/ResourceUploader.cpp
+++ b/src/backend/d3d12/ResourceUploader.cpp
@@ -23,7 +23,7 @@ namespace d3d12 {
     ResourceUploader::ResourceUploader(Device* device) : device(device) {
     }
 
-    void ResourceUploader::UploadToBuffer(ComPtr<ID3D12Resource> resource, uint32_t start, uint32_t count, const uint8_t* data) {
+    void ResourceUploader::BufferSubData(ComPtr<ID3D12Resource> resource, uint32_t start, uint32_t count, const void* data) {
         // TODO(enga@google.com): Use a handle to a subset of a large ring buffer. On Release, decrease reference count on the ring buffer and free when 0.
         // Alternatively, the SerialQueue could be used to track which last point of the ringbuffer is in use, and start reusing chunks of it that aren't in flight.
         UploadHandle uploadHandle = GetUploadBuffer(count);

--- a/src/backend/d3d12/ResourceUploader.h
+++ b/src/backend/d3d12/ResourceUploader.h
@@ -28,7 +28,7 @@ namespace d3d12 {
         public:
             ResourceUploader(Device* device);
 
-            void UploadToBuffer(ComPtr<ID3D12Resource> resource, uint32_t start, uint32_t count, const uint8_t* data);
+            void BufferSubData(ComPtr<ID3D12Resource> resource, uint32_t start, uint32_t count, const void* data);
 
         private:
             struct UploadHandle {

--- a/src/backend/d3d12/TextureD3D12.cpp
+++ b/src/backend/d3d12/TextureD3D12.cpp
@@ -129,7 +129,7 @@ namespace d3d12 {
         }
     }
 
-    TextureView::TextureView(Device* device, TextureViewBuilder* builder)
+    TextureView::TextureView(TextureViewBuilder* builder)
         : TextureViewBase(builder) {
 
         srvDesc.Format = D3D12TextureFormat(GetTexture()->GetFormat());

--- a/src/backend/d3d12/TextureD3D12.cpp
+++ b/src/backend/d3d12/TextureD3D12.cpp
@@ -100,6 +100,10 @@ namespace d3d12 {
         device->GetResourceAllocator()->Release(resource);
     }
 
+    DXGI_FORMAT Texture::GetD3D12Format() const {
+        return D3D12TextureFormat(GetFormat());
+    }
+
     ComPtr<ID3D12Resource> Texture::GetD3D12Resource() {
         return resource;
     }

--- a/src/backend/d3d12/TextureD3D12.h
+++ b/src/backend/d3d12/TextureD3D12.h
@@ -29,6 +29,7 @@ namespace d3d12 {
             Texture(Device* device, TextureBuilder* builder);
             ~Texture();
 
+            DXGI_FORMAT GetD3D12Format() const;
             ComPtr<ID3D12Resource> GetD3D12Resource();
             bool GetResourceTransitionBarrier(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage, D3D12_RESOURCE_BARRIER* barrier);
 

--- a/src/backend/d3d12/TextureD3D12.h
+++ b/src/backend/d3d12/TextureD3D12.h
@@ -42,14 +42,13 @@ namespace d3d12 {
 
     class TextureView : public TextureViewBase {
         public:
-            TextureView(Device* device, TextureViewBuilder* builder);
+            TextureView(TextureViewBuilder* builder);
 
             const D3D12_SHADER_RESOURCE_VIEW_DESC& GetSRVDescriptor() const;
 
         private:
             D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc;
     };
-
 }
 }
 

--- a/src/tests/NXTTest.cpp
+++ b/src/tests/NXTTest.cpp
@@ -304,6 +304,11 @@ namespace detail {
     }
 
     template<typename T>
+    ExpectEq<T>::ExpectEq(const T* values, const unsigned int count) {
+        expected.assign(values, values + count);
+    }
+
+    template<typename T>
     testing::AssertionResult ExpectEq<T>::Check(const void* data, size_t size) {
         ASSERT(size == sizeof(T) * expected.size());
 

--- a/src/tests/NXTTest.cpp
+++ b/src/tests/NXTTest.cpp
@@ -278,6 +278,8 @@ namespace detail {
     bool IsBackendAvailable(BackendType type) {
         #if defined(__APPLE__)
             return type == MetalBackend;
+        #elif defined(_WIN32)
+            return type == D3D12Backend;
         #else
             return false;
         #endif

--- a/src/tests/NXTTest.h
+++ b/src/tests/NXTTest.h
@@ -22,6 +22,9 @@
 #define EXPECT_BUFFER_U32_EQ(expected, buffer, offset) \
     AddBufferExpectation(__FILE__, __LINE__, buffer, offset, sizeof(uint32_t), new detail::ExpectEq<uint32_t>(expected));
 
+#define EXPECT_BUFFER_U32_RANGE_EQ(expected, buffer, offset, count) \
+    AddBufferExpectation(__FILE__, __LINE__, buffer, offset, sizeof(uint32_t) * count, new detail::ExpectEq<uint32_t>(expected, count));
+
 // Test a pixel of the mip level 0 of a 2D texture.
 #define EXPECT_PIXEL_RGBA8_EQ(expected, texture, x, y) \
     AddTextureExpectation(__FILE__, __LINE__, texture, x, y, 1, 1, sizeof(RGBA8), new detail::ExpectEq<RGBA8>(expected));
@@ -133,6 +136,7 @@ namespace detail {
     class ExpectEq : public Expectation {
         public:
             ExpectEq(T singleValue);
+            ExpectEq(const T* values, const unsigned int count);
 
             testing::AssertionResult Check(const void* data, size_t size) override;
 

--- a/src/tests/end2end/BasicTests.cpp
+++ b/src/tests/end2end/BasicTests.cpp
@@ -56,4 +56,4 @@ TEST_P(BasicTests, ReadPixelsTest) {
     EXPECT_PIXEL_RGBA8_EQ(red, texture, 0, 0);
 }
 
-NXT_INSTANTIATE_TEST(BasicTests, MetalBackend)
+NXT_INSTANTIATE_TEST(BasicTests, MetalBackend, D3D12Backend)


### PR DESCRIPTION
This introduces Buffer->Buffer copies, Buffer->Texture copies, Texture->Buffer copies, and MapReadAsync to the D3D12 backend which will help bring us closer to automated testing.

Currently texture operations only work if the rows are 256-byte aligned, but this constraint is not enforced anywhere, so using textures of non-aligned sizes will cause errors.

Buffers with MapRead allowed are created on the READBACK heap and always add the D3D12_RESOURCE_STATE_COPY_DEST state (required by D3D12). Likewise MapWrite adds the D3D12_RESOURCE_STATE_GENERIC_READ state and places resources on the UPLOAD heap. Because these states are required, transitions for mapped buffers do nothing.

A small test which does a Buffer->Texture and then Texture->Buffer copy has been added and is currently working on the D3D12 backend. I have not tested this on Metal.

Device::TickImpl now also executes any pending commands and increments the Serial in order for the MapReadAsync requests to work.