### PR TITLE
Fix shaderc not finding python when inside VS

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -41,6 +41,9 @@ set(SHADERC_SKIP_TESTS ON)
 set(SHADERC_GOOGLE_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/googletest CACHE STRING "Location of googletest source")
 set(SHADERC_GLSLANG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/glslang" CACHE STRING "Location of glslang source")
 set(SHADERC_SPIRV_TOOLS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spirv-tools CACHE STRING "Location of spirv-tools source")
+# Help shaderc find the python executable when run inside VS.
+find_package(PythonInterp REQUIRED)
+set(PYTHON_EXE ${PYTHON_EXECUTABLE})
 # Need to include this for spirv-tools to find it
 add_subdirectory(spirv-headers)
 add_subdirectory(shaderc)


### PR DESCRIPTION
Visual Studio 2017 is able to build CMake-based projects directly be
opening the folder containing the CMakeLists.txt. However when doing
this shaderc is not able to find the Python executable (it uses
find_program instead of the special Python CMake module). Help shaderc
by setting the PYTHON_EXE variable before including its CMakeLists.txt