### PR TITLE
replace AdvanceSubpass with Begin/EndRenderSubpass

### DIFF
--- a/examples/Animometer.cpp
+++ b/examples/Animometer.cpp
@@ -133,6 +133,7 @@ void frame() {
 
         nxt::CommandBufferBuilder builder = device.CreateCommandBufferBuilder()
             .BeginRenderPass(renderpass, framebuffer)
+            .BeginRenderSubpass()
             .SetPipeline(pipeline)
             .Clone();
 
@@ -144,6 +145,7 @@ void frame() {
             i++;
         }
 
+        builder.EndRenderSubpass();
         builder.EndRenderPass();
         commands[j] = builder.GetResult();
     }

--- a/examples/ComputeBoids.cpp
+++ b/examples/ComputeBoids.cpp
@@ -271,11 +271,13 @@ void initCommandBuffers() {
             .Dispatch(kNumParticles, 1, 1)
 
             .BeginRenderPass(renderpass, framebuffer)
+            .BeginRenderSubpass()
                 .SetPipeline(renderPipeline)
                 .TransitionBufferUsage(bufferDst, nxt::BufferUsageBit::Vertex)
                 .SetVertexBuffers(0, 1, &bufferDst, zeroOffsets)
                 .SetVertexBuffers(1, 1, &modelBuffer, zeroOffsets)
                 .DrawArrays(3, kNumParticles, 0, 0)
+            .EndRenderSubpass()
             .EndRenderPass()
 
             .GetResult();

--- a/examples/HelloCompute.cpp
+++ b/examples/HelloCompute.cpp
@@ -132,10 +132,12 @@ void frame() {
         .Dispatch(1, 1, 1)
 
         .BeginRenderPass(renderpass, framebuffer)
+        .BeginRenderSubpass()
             .SetPipeline(renderPipeline)
             .TransitionBufferUsage(buffer, nxt::BufferUsageBit::Uniform)
             .SetBindGroup(0, renderBindGroup)
             .DrawArrays(3, 1, 0, 0)
+        .EndRenderSubpass()
         .EndRenderPass()
 
         .GetResult();

--- a/examples/HelloDepthStencil.cpp
+++ b/examples/HelloDepthStencil.cpp
@@ -272,6 +272,7 @@ void frame() {
 
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()
         .BeginRenderPass(renderpass, framebuffer)
+        .BeginRenderSubpass()
             .SetPipeline(pipeline)
             .TransitionBufferUsage(cameraBuffer, nxt::BufferUsageBit::Uniform)
             .SetBindGroup(0, bindGroup[0])
@@ -288,6 +289,7 @@ void frame() {
             .SetVertexBuffers(0, 1, &vertexBuffer, vertexBufferOffsets)
             .SetBindGroup(0, bindGroup[1])
             .DrawElements(36, 1, 0, 0)
+        .EndRenderSubpass()
         .EndRenderPass()
         .GetResult();
 

--- a/examples/HelloIndices.cpp
+++ b/examples/HelloIndices.cpp
@@ -83,10 +83,12 @@ void frame() {
     static const uint32_t vertexBufferOffsets[1] = {0};
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()
         .BeginRenderPass(renderpass, framebuffer)
+        .BeginRenderSubpass()
             .SetPipeline(pipeline)
             .SetVertexBuffers(0, 1, &vertexBuffer, vertexBufferOffsets)
             .SetIndexBuffer(indexBuffer, 0, nxt::IndexFormat::Uint32)
             .DrawElements(3, 1, 0, 0)
+        .EndRenderSubpass()
         .EndRenderPass()
         .GetResult();
 

--- a/examples/HelloInstancing.cpp
+++ b/examples/HelloInstancing.cpp
@@ -89,10 +89,12 @@ void frame() {
     static const uint32_t vertexBufferOffsets[1] = {0};
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()
         .BeginRenderPass(renderpass, framebuffer)
+        .BeginRenderSubpass()
             .SetPipeline(pipeline)
             .SetVertexBuffers(0, 1, &vertexBuffer, vertexBufferOffsets)
             .SetVertexBuffers(1, 1, &instanceBuffer, vertexBufferOffsets)
             .DrawArrays(3, 4, 0, 0)
+        .EndRenderSubpass()
         .EndRenderPass()
         .GetResult();
 

--- a/examples/HelloTriangle.cpp
+++ b/examples/HelloTriangle.cpp
@@ -144,11 +144,13 @@ void frame() {
     static const uint32_t vertexBufferOffsets[1] = {0};
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()
         .BeginRenderPass(renderpass, framebuffer)
+        .BeginRenderSubpass()
             .SetPipeline(pipeline)
             .SetBindGroup(0, bindGroup)
             .SetVertexBuffers(0, 1, &vertexBuffer, vertexBufferOffsets)
             .SetIndexBuffer(indexBuffer, 0, nxt::IndexFormat::Uint32)
             .DrawElements(3, 1, 0, 0)
+        .EndRenderSubpass()
         .EndRenderPass()
         .GetResult();
 

--- a/examples/HelloUBO.cpp
+++ b/examples/HelloUBO.cpp
@@ -94,10 +94,12 @@ void frame() {
 
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()
         .BeginRenderPass(renderpass, framebuffer)
+        .BeginRenderSubpass()
             .SetPipeline(pipeline)
             .TransitionBufferUsage(buffer, nxt::BufferUsageBit::Uniform)
             .SetBindGroup(0, bindGroup)
             .DrawArrays(3, 1, 0, 0)
+        .EndRenderSubpass()
         .EndRenderPass()
         .GetResult();
 

--- a/examples/HelloVertices.cpp
+++ b/examples/HelloVertices.cpp
@@ -77,9 +77,11 @@ void frame() {
     static const uint32_t vertexBufferOffsets[1] = {0};
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()
         .BeginRenderPass(renderpass, framebuffer)
+        .BeginRenderSubpass()
             .SetPipeline(pipeline)
             .SetVertexBuffers(0, 1, &vertexBuffer, vertexBufferOffsets)
             .DrawArrays(3, 1, 0, 0)
+        .EndRenderSubpass()
         .EndRenderPass()
         .GetResult();
 

--- a/examples/RenderToTexture.cpp
+++ b/examples/RenderToTexture.cpp
@@ -187,17 +187,20 @@ void frame() {
         .BeginRenderPass(renderpass, framebuffer)
             // renderTarget is not transitioned here because it's implicit in
             // BeginRenderPass or AdvanceSubpass.
-            .SetPipeline(pipeline)
-            .SetVertexBuffers(0, 1, &vertexBuffer, vertexBufferOffsets)
-            .DrawArrays(3, 1, 0, 0)
-        .AdvanceSubpass()
+            .BeginRenderSubpass()
+                .SetPipeline(pipeline)
+                .SetVertexBuffers(0, 1, &vertexBuffer, vertexBufferOffsets)
+                .DrawArrays(3, 1, 0, 0)
+            .EndRenderSubpass()
             // renderTarget must be transitioned here because it's Sampled, not
             // ColorAttachment or InputAttachment.
             .TransitionTextureUsage(renderTarget, nxt::TextureUsageBit::Sampled)
-            .SetPipeline(pipelinePost)
-            .SetBindGroup(0, bindGroup)
-            .SetVertexBuffers(0, 1, &vertexBufferQuad, vertexBufferOffsets)
-            .DrawArrays(6, 1, 0, 0)
+            .BeginRenderSubpass()
+                .SetPipeline(pipelinePost)
+                .SetBindGroup(0, bindGroup)
+                .SetVertexBuffers(0, 1, &vertexBufferQuad, vertexBufferOffsets)
+                .DrawArrays(6, 1, 0, 0)
+            .EndRenderSubpass()
         .EndRenderPass()
         .GetResult();
 

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -496,6 +496,7 @@ namespace {
                     sizeof(u_transform_block) / sizeof(uint32_t),
                     reinterpret_cast<const uint32_t*>(&transforms));
             cmd.BeginRenderPass(renderpass, framebuffer);
+            cmd.BeginRenderSubpass();
             cmd.SetPipeline(material.pipeline);
             cmd.TransitionBufferUsage(material.uniformBuffer, nxt::BufferUsageBit::Uniform);
             cmd.SetBindGroup(0, material.bindGroup0);
@@ -539,6 +540,7 @@ namespace {
                 // DrawArrays
                 cmd.DrawArrays(vertexCount, 1, 0, 0);
             }
+            cmd.EndRenderSubpass();
             cmd.EndRenderPass();
         }
         auto commands = cmd.GetResult();

--- a/next.json
+++ b/next.json
@@ -255,10 +255,7 @@
                 ]
             },
             {
-                "name": "advance subpass"
-            },
-            {
-                "name": "end render pass"
+                "name": "begin render subpass"
             },
             {
                 "name": "copy buffer to buffer",
@@ -342,6 +339,12 @@
                     {"name": "first index", "type": "uint32_t"},
                     {"name": "first instance", "type": "uint32_t"}
                 ]
+            },
+            {
+                "name": "end render pass"
+            },
+            {
+                "name": "end render subpass"
             },
             {
                 "name": "set stencil reference",

--- a/src/backend/CommandBuffer.h
+++ b/src/backend/CommandBuffer.h
@@ -59,8 +59,8 @@ namespace backend {
             CommandIterator AcquireCommands();
 
             // NXT API
-            void AdvanceSubpass();
             void BeginRenderPass(RenderPassBase* renderPass, FramebufferBase* framebuffer);
+            void BeginRenderSubpass();
             void CopyBufferToBuffer(BufferBase* source, uint32_t sourceOffset, BufferBase* destination, uint32_t destinationOffset, uint32_t size);
             void CopyBufferToTexture(BufferBase* buffer, uint32_t bufferOffset,
                                      TextureBase* texture, uint32_t x, uint32_t y, uint32_t z,
@@ -72,6 +72,7 @@ namespace backend {
             void DrawArrays(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
             void DrawElements(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstIndex, uint32_t firstInstance);
             void EndRenderPass();
+            void EndRenderSubpass();
             void SetPushConstants(nxt::ShaderStageBit stage, uint32_t offset, uint32_t count, const void* data);
             void SetPipeline(PipelineBase* pipeline);
             void SetStencilReference(uint32_t reference);

--- a/src/backend/CommandBufferStateTracker.h
+++ b/src/backend/CommandBufferStateTracker.h
@@ -41,7 +41,6 @@ namespace backend {
             bool BeginSubpass();
             bool EndSubpass();
             bool BeginRenderPass(RenderPassBase* renderPass, FramebufferBase* framebuffer);
-            bool AdvanceSubpass();
             bool EndRenderPass();
             bool SetPipeline(PipelineBase* pipeline);
             bool SetBindGroup(uint32_t index, BindGroupBase* bindgroup);
@@ -63,6 +62,7 @@ namespace backend {
                 VALIDATION_ASPECT_BIND_GROUPS,
                 VALIDATION_ASPECT_VERTEX_BUFFERS,
                 VALIDATION_ASPECT_INDEX_BUFFER,
+                VALIDATION_ASPECT_RENDER_SUBPASS,
 
                 VALIDATION_ASPECT_COUNT
             };
@@ -96,7 +96,6 @@ namespace backend {
 
             RenderPassBase* currentRenderPass = nullptr;
             FramebufferBase* currentFramebuffer = nullptr;
-            bool subpassActive = false;
             uint32_t currentSubpass = 0;
     };
 }

--- a/src/backend/Commands.h
+++ b/src/backend/Commands.h
@@ -28,8 +28,8 @@ namespace backend {
     // dependencies: Ref<Object> needs Object to be defined.
 
     enum class Command {
-        AdvanceSubpass,
         BeginRenderPass,
+        BeginRenderSubpass,
         CopyBufferToBuffer,
         CopyBufferToTexture,
         CopyTextureToBuffer,
@@ -37,6 +37,7 @@ namespace backend {
         DrawArrays,
         DrawElements,
         EndRenderPass,
+        EndRenderSubpass,
         SetPipeline,
         SetPushConstants,
         SetStencilReference,
@@ -47,12 +48,12 @@ namespace backend {
         TransitionTextureUsage,
     };
 
-    struct AdvanceSubpassCmd {
-    };
-
     struct BeginRenderPassCmd {
         Ref<RenderPassBase> renderPass;
         Ref<FramebufferBase> framebuffer;
+    };
+
+    struct BeginRenderSubpassCmd {
     };
 
     struct BufferCopyLocation {
@@ -104,6 +105,9 @@ namespace backend {
     };
 
     struct EndRenderPassCmd {
+    };
+
+    struct EndRenderSubpassCmd {
     };
 
     struct SetPipelineCmd {

--- a/src/backend/d3d12/CommandBufferD3D12.cpp
+++ b/src/backend/d3d12/CommandBufferD3D12.cpp
@@ -253,12 +253,6 @@ namespace d3d12 {
 
         while(commands.NextCommandId(&type)) {
             switch (type) {
-                case Command::AdvanceSubpass:
-                    {
-                        commands.NextCommand<AdvanceSubpassCmd>();
-                    }
-                    break;
-
                 case Command::BeginRenderPass:
                     {
                         BeginRenderPassCmd* beginRenderPassCmd = commands.NextCommand<BeginRenderPassCmd>();
@@ -272,6 +266,12 @@ namespace d3d12 {
                         commandList->RSSetViewports(1, &viewport);
                         commandList->RSSetScissorRects(1, &scissorRect);
                         commandList->OMSetRenderTargets(1, &device->GetCurrentRenderTargetDescriptor(), FALSE, nullptr);
+                    }
+                    break;
+
+                case Command::BeginRenderSubpass:
+                    {
+                        commands.NextCommand<BeginRenderSubpassCmd>();
                     }
                     break;
 
@@ -368,6 +368,12 @@ namespace d3d12 {
                 case Command::EndRenderPass:
                     {
                         EndRenderPassCmd* cmd = commands.NextCommand<EndRenderPassCmd>();
+                    }
+                    break;
+
+                case Command::EndRenderSubpass:
+                    {
+                        commands.NextCommand<EndRenderSubpassCmd>();
                     }
                     break;
 

--- a/src/backend/metal/CommandBufferMTL.mm
+++ b/src/backend/metal/CommandBufferMTL.mm
@@ -141,14 +141,6 @@ namespace metal {
         uint32_t currentSubpass = 0;
         while (commands.NextCommandId(&type)) {
             switch (type) {
-                case Command::AdvanceSubpass:
-                    {
-                        commands.NextCommand<AdvanceSubpassCmd>();
-                        currentSubpass += 1;
-                        encoders.BeginSubpass(commandBuffer, currentSubpass);
-                    }
-                    break;
-
                 case Command::BeginRenderPass:
                     {
                         BeginRenderPassCmd* beginRenderPassCmd = commands.NextCommand<BeginRenderPassCmd>();
@@ -156,6 +148,12 @@ namespace metal {
                         encoders.currentFramebuffer = ToBackend(beginRenderPassCmd->framebuffer.Get());
                         encoders.FinishEncoders();
                         currentSubpass = 0;
+                    }
+                    break;
+
+                case Command::BeginRenderSubpass:
+                    {
+                        commands.NextCommand<BeginRenderSubpassCmd>();
                         encoders.BeginSubpass(commandBuffer, currentSubpass);
                     }
                     break;
@@ -288,6 +286,13 @@ namespace metal {
                     {
                         commands.NextCommand<EndRenderPassCmd>();
                         encoders.EndRenderPass();
+                    }
+                    break;
+
+                case Command::EndRenderSubpass:
+                    {
+                        commands.NextCommand<EndRenderSubpassCmd>();
+                        currentSubpass += 1;
                     }
                     break;
 

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -65,16 +65,16 @@ namespace opengl {
 
         while(commands.NextCommandId(&type)) {
             switch (type) {
-                case Command::AdvanceSubpass:
+                case Command::BeginRenderPass:
                     {
-                        commands.NextCommand<AdvanceSubpassCmd>();
+                        commands.NextCommand<BeginRenderPassCmd>();
                         // TODO(kainino@chromium.org): implement
                     }
                     break;
 
-                case Command::BeginRenderPass:
+                case Command::BeginRenderSubpass:
                     {
-                        commands.NextCommand<BeginRenderPassCmd>();
+                        commands.NextCommand<BeginRenderSubpassCmd>();
                         // TODO(kainino@chromium.org): implement
                     }
                     break;
@@ -169,6 +169,13 @@ namespace opengl {
                 case Command::EndRenderPass:
                     {
                         commands.NextCommand<EndRenderPassCmd>();
+                        // TODO(kainino@chromium.org): implement
+                    }
+                    break;
+
+                case Command::EndRenderSubpass:
+                    {
+                        commands.NextCommand<EndRenderSubpassCmd>();
                         // TODO(kainino@chromium.org): implement
                     }
                     break;


### PR DESCRIPTION
This change is motivated by usage transitions: if there are usage transitions in between subpasses, AdvanceSubpass makes it unnatural. Plus, if we go the route of all-explicit attachment transitions, they have to be done between subpasses.

TODO:

* [x] Should the first BeginRenderSubpass and the last EndRenderSubpass be implicit? A little asymmetrical, but it doesn't seem like a problem. - decided not to do this for now
* [x] Fix D3D12 code (still a no-op on D3D12 backend)