### PR TITLE
Freeze texture transitions while attached

### DIFF
--- a/examples/RenderToTexture.cpp
+++ b/examples/RenderToTexture.cpp
@@ -185,20 +185,18 @@ void frame() {
     static const uint32_t vertexBufferOffsets[1] = {0};
     nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()
         .BeginRenderPass(renderpass, framebuffer)
-            // renderTarget is not transitioned here because it's implicit in
-            // BeginRenderPass or AdvanceSubpass.
             .BeginRenderSubpass()
+                // renderTarget implicitly locked to to Attachment usage (if not already frozen)
                 .SetPipeline(pipeline)
                 .SetVertexBuffers(0, 1, &vertexBuffer, vertexBufferOffsets)
                 .DrawArrays(3, 1, 0, 0)
             .EndRenderSubpass()
-            // renderTarget must be transitioned here because it's Sampled, not
-            // ColorAttachment or InputAttachment.
-            .TransitionTextureUsage(renderTarget, nxt::TextureUsageBit::Sampled)
+            // renderTarget usage unlocked, but left in Attachment usage
             .BeginRenderSubpass()
                 .SetPipeline(pipelinePost)
-                .SetBindGroup(0, bindGroup)
                 .SetVertexBuffers(0, 1, &vertexBufferQuad, vertexBufferOffsets)
+                .TransitionTextureUsage(renderTarget, nxt::TextureUsageBit::Sampled)
+                .SetBindGroup(0, bindGroup)
                 .DrawArrays(6, 1, 0, 0)
             .EndRenderSubpass()
         .EndRenderPass()

--- a/examples/RenderToTexture.cpp
+++ b/examples/RenderToTexture.cpp
@@ -59,8 +59,8 @@ void initTextures() {
         .SetExtent(640, 480, 1)
         .SetFormat(nxt::TextureFormat::R8G8B8A8Unorm)
         .SetMipLevels(1)
-        .SetAllowedUsage(nxt::TextureUsageBit::ColorAttachment | nxt::TextureUsageBit::Sampled)
-        .SetInitialUsage(nxt::TextureUsageBit::ColorAttachment)
+        .SetAllowedUsage(nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Sampled)
+        .SetInitialUsage(nxt::TextureUsageBit::OutputAttachment)
         .GetResult();
     renderTargetView = renderTarget.CreateTextureViewBuilder().GetResult();
 

--- a/next.json
+++ b/next.json
@@ -921,8 +921,8 @@
             {"value": 2, "name": "transfer dst"},
             {"value": 4, "name": "sampled"},
             {"value": 8, "name": "storage"},
-            {"value": 16, "name": "color attachment"},
-            {"value": 32, "name": "depth stencil attachment"}
+            {"value": 16, "name": "output attachment"},
+            {"value": 32, "name": "input attachment"}
         ]
     },
     "texture view": {

--- a/next.json
+++ b/next.json
@@ -921,8 +921,7 @@
             {"value": 2, "name": "transfer dst"},
             {"value": 4, "name": "sampled"},
             {"value": 8, "name": "storage"},
-            {"value": 16, "name": "output attachment"},
-            {"value": 32, "name": "input attachment"}
+            {"value": 16, "name": "output attachment"}
         ]
     },
     "texture view": {

--- a/src/backend/CommandBufferStateTracker.cpp
+++ b/src/backend/CommandBufferStateTracker.cpp
@@ -148,8 +148,8 @@ namespace backend {
             }
 
             auto* texture = tv->GetTexture();
-            if (!EnsureTextureUsage(texture, nxt::TextureUsageBit::ColorAttachment)) {
-                builder->HandleError("Unable to ensure texture has ColorAttachment usage");
+            if (!EnsureTextureUsage(texture, nxt::TextureUsageBit::OutputAttachment)) {
+                builder->HandleError("Unable to ensure texture has OutputAttachment usage");
                 return false;
             }
             texturesAttached.insert(texture);
@@ -355,13 +355,13 @@ namespace backend {
     }
 
     bool CommandBufferStateTracker::EnsureTextureUsage(TextureBase* texture, nxt::TextureUsageBit usage) {
-        if (texture->HasFrozenUsage(nxt::TextureUsageBit::ColorAttachment)) {
+        if (texture->HasFrozenUsage(nxt::TextureUsageBit::OutputAttachment)) {
             return true;
         }
-        if (!IsInternalTextureTransitionPossible(texture, nxt::TextureUsageBit::ColorAttachment)) {
+        if (!IsInternalTextureTransitionPossible(texture, nxt::TextureUsageBit::OutputAttachment)) {
             return false;
         }
-        mostRecentTextureUsages[texture] = nxt::TextureUsageBit::ColorAttachment;
+        mostRecentTextureUsages[texture] = nxt::TextureUsageBit::OutputAttachment;
         texturesTransitioned.insert(texture);
         return true;
     }
@@ -394,8 +394,8 @@ namespace backend {
 
     bool CommandBufferStateTracker::IsExplicitTextureTransitionPossible(TextureBase* texture, nxt::TextureUsageBit usage) const {
         const nxt::TextureUsageBit attachmentUsages =
-            nxt::TextureUsageBit::ColorAttachment |
-            nxt::TextureUsageBit::DepthStencilAttachment;
+            nxt::TextureUsageBit::OutputAttachment |
+            nxt::TextureUsageBit::InputAttachment;
         if (usage & attachmentUsages) {
             return false;
         }

--- a/src/backend/CommandBufferStateTracker.h
+++ b/src/backend/CommandBufferStateTracker.h
@@ -48,12 +48,14 @@ namespace backend {
             bool SetVertexBuffer(uint32_t index, BufferBase* buffer);
             bool TransitionBufferUsage(BufferBase* buffer, nxt::BufferUsageBit usage);
             bool TransitionTextureUsage(TextureBase* texture, nxt::TextureUsageBit usage);
+            bool EnsureTextureUsage(TextureBase* texture, nxt::TextureUsageBit usage);
 
             // These collections are copied to the CommandBuffer at build time.
             // These pointers will remain valid since they are referenced by
             // the bind groups which are referenced by this command buffer.
             std::set<BufferBase*> buffersTransitioned;
             std::set<TextureBase*> texturesTransitioned;
+            std::set<TextureBase*> texturesAttached;
 
         private:
             enum ValidationAspect {
@@ -71,7 +73,8 @@ namespace backend {
             // Usage helper functions
             bool BufferHasGuaranteedUsageBit(BufferBase* buffer, nxt::BufferUsageBit usage) const;
             bool TextureHasGuaranteedUsageBit(TextureBase* texture, nxt::TextureUsageBit usage) const;
-            bool IsTextureTransitionPossible(TextureBase* texture, nxt::TextureUsageBit usage) const;
+            bool IsInternalTextureTransitionPossible(TextureBase* texture, nxt::TextureUsageBit usage) const;
+            bool IsExplicitTextureTransitionPossible(TextureBase* texture, nxt::TextureUsageBit usage) const;
 
             // Queries for lazily evaluated aspects
             bool RecomputeHaveAspectBindGroups();

--- a/src/backend/CommandBufferStateTracker.h
+++ b/src/backend/CommandBufferStateTracker.h
@@ -18,6 +18,7 @@
 #include "backend/CommandBuffer.h"
 #include "common/Constants.h"
 
+#include <array>
 #include <bitset>
 #include <map>
 #include <set>
@@ -91,6 +92,7 @@ namespace backend {
             ValidationAspects aspects;
 
             std::bitset<kMaxBindGroups> bindgroupsSet;
+            std::array<BindGroupBase*, kMaxBindGroups> bindgroups = {};
             std::bitset<kMaxVertexInputs> inputsSet;
             PipelineBase* lastPipeline = nullptr;
 

--- a/src/backend/Texture.cpp
+++ b/src/backend/Texture.cpp
@@ -92,6 +92,13 @@ namespace backend {
         currentUsage = usage;
     }
 
+    bool TextureBase::IsDepthFormat(nxt::TextureFormat format) {
+        switch (format) {
+            case nxt::TextureFormat::R8G8B8A8Unorm:
+                return false;
+        }
+    }
+
     void TextureBase::TransitionUsage(nxt::TextureUsageBit usage) {
         if (!IsTransitionPossible(usage)) {
             device->HandleError("Texture frozen or usage not allowed");

--- a/src/backend/Texture.h
+++ b/src/backend/Texture.h
@@ -43,6 +43,8 @@ namespace backend {
             bool IsTransitionPossible(nxt::TextureUsageBit usage) const;
             void UpdateUsageInternal(nxt::TextureUsageBit usage);
 
+            static bool IsDepthFormat(nxt::TextureFormat format);
+
             DeviceBase* GetDevice();
 
             // NXT API

--- a/src/backend/d3d12/TextureD3D12.cpp
+++ b/src/backend/d3d12/TextureD3D12.cpp
@@ -42,12 +42,6 @@ namespace d3d12 {
                     resourceState |= D3D12_RESOURCE_STATE_DEPTH_WRITE;
                 }
             }
-            if (usage & nxt::TextureUsageBit::InputAttachment) {
-                resourceState |= D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-                if (TextureBase::IsDepthFormat(format)) {
-                    resourceState |= D3D12_RESOURCE_STATE_DEPTH_READ;
-                }
-            }
 
             return resourceState;
         }

--- a/src/backend/d3d12/TextureD3D12.cpp
+++ b/src/backend/d3d12/TextureD3D12.cpp
@@ -21,7 +21,7 @@ namespace backend {
 namespace d3d12 {
 
     namespace {
-        D3D12_RESOURCE_STATES D3D12TextureUsage(nxt::TextureUsageBit usage) {
+        D3D12_RESOURCE_STATES D3D12TextureUsage(nxt::TextureUsageBit usage, nxt::TextureFormat format) {
             D3D12_RESOURCE_STATES resourceState = D3D12_RESOURCE_STATE_COMMON;
 
             if (usage & nxt::TextureUsageBit::TransferSrc) {
@@ -36,11 +36,17 @@ namespace d3d12 {
             if (usage & nxt::TextureUsageBit::Storage) {
                 resourceState |= D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
             }
-            if (usage & nxt::TextureUsageBit::ColorAttachment) {
+            if (usage & nxt::TextureUsageBit::OutputAttachment) {
                 resourceState |= D3D12_RESOURCE_STATE_RENDER_TARGET;
+                if (TextureBase::IsDepthFormat(format)) {
+                    resourceState |= D3D12_RESOURCE_STATE_DEPTH_WRITE;
+                }
             }
-            if (usage & nxt::TextureUsageBit::DepthStencilAttachment) {
-                resourceState |= D3D12_RESOURCE_STATE_DEPTH_WRITE;
+            if (usage & nxt::TextureUsageBit::InputAttachment) {
+                resourceState |= D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+                if (TextureBase::IsDepthFormat(format)) {
+                    resourceState |= D3D12_RESOURCE_STATE_DEPTH_READ;
+                }
             }
 
             return resourceState;
@@ -93,7 +99,7 @@ namespace d3d12 {
         resourceDescriptor.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
         resourceDescriptor.Flags = D3D12ResourceFlags(GetUsage());
 
-        resource = device->GetResourceAllocator()->Allocate(D3D12_HEAP_TYPE_DEFAULT, resourceDescriptor, D3D12TextureUsage(GetUsage()));
+        resource = device->GetResourceAllocator()->Allocate(D3D12_HEAP_TYPE_DEFAULT, resourceDescriptor, D3D12TextureUsage(GetUsage(), GetFormat()));
     }
 
     Texture::~Texture() {
@@ -109,8 +115,8 @@ namespace d3d12 {
     }
 
     bool Texture::GetResourceTransitionBarrier(nxt::TextureUsageBit currentUsage, nxt::TextureUsageBit targetUsage, D3D12_RESOURCE_BARRIER* barrier) {
-        D3D12_RESOURCE_STATES stateBefore = D3D12TextureUsage(currentUsage);
-        D3D12_RESOURCE_STATES stateAfter = D3D12TextureUsage(targetUsage);
+        D3D12_RESOURCE_STATES stateBefore = D3D12TextureUsage(currentUsage, GetFormat());
+        D3D12_RESOURCE_STATES stateAfter = D3D12TextureUsage(targetUsage, GetFormat());
 
         if (stateBefore == stateAfter) {
             return false;

--- a/src/backend/d3d12/TextureD3D12.cpp
+++ b/src/backend/d3d12/TextureD3D12.cpp
@@ -46,17 +46,17 @@ namespace d3d12 {
             return resourceState;
         }
 
-        D3D12_RESOURCE_FLAGS D3D12ResourceFlags(nxt::TextureUsageBit usage) {
+        D3D12_RESOURCE_FLAGS D3D12ResourceFlags(nxt::TextureUsageBit usage, nxt::TextureFormat format) {
             D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE;
 
             if (usage & nxt::TextureUsageBit::Storage) {
                 flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
             }
-            if (usage & nxt::TextureUsageBit::ColorAttachment) {
+            if (usage & nxt::TextureUsageBit::OutputAttachment) {
                 flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
-            }
-            if (usage & nxt::TextureUsageBit::DepthStencilAttachment) {
-                flags |= D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
+                if (TextureBase::IsDepthFormat(format)) {
+                    flags |= D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
+                }
             }
 
             return flags;
@@ -91,7 +91,7 @@ namespace d3d12 {
         resourceDescriptor.SampleDesc.Count = 1;
         resourceDescriptor.SampleDesc.Quality = 0;
         resourceDescriptor.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-        resourceDescriptor.Flags = D3D12ResourceFlags(GetUsage());
+        resourceDescriptor.Flags = D3D12ResourceFlags(GetUsage(), GetFormat());
 
         resource = device->GetResourceAllocator()->Allocate(D3D12_HEAP_TYPE_DEFAULT, resourceDescriptor, D3D12TextureUsage(GetUsage(), GetFormat()));
     }

--- a/src/backend/metal/TextureMTL.mm
+++ b/src/backend/metal/TextureMTL.mm
@@ -38,8 +38,12 @@ namespace metal {
                 result |= MTLTextureUsageShaderRead;
             }
 
-            if (usage & (nxt::TextureUsageBit::ColorAttachment | nxt::TextureUsageBit::DepthStencilAttachment)) {
+            if (usage & (nxt::TextureUsageBit::OutputAttachment)) {
                 result |= MTLTextureUsageRenderTarget;
+            }
+
+            if (usage & (nxt::TextureUsageBit::InputAttachment)) {
+                result |= MTLTextureUsageShaderRead;
             }
 
             return result;

--- a/src/backend/metal/TextureMTL.mm
+++ b/src/backend/metal/TextureMTL.mm
@@ -42,10 +42,6 @@ namespace metal {
                 result |= MTLTextureUsageRenderTarget;
             }
 
-            if (usage & (nxt::TextureUsageBit::InputAttachment)) {
-                result |= MTLTextureUsageShaderRead;
-            }
-
             return result;
         }
 

--- a/src/tests/end2end/InputStateTests.cpp
+++ b/src/tests/end2end/InputStateTests.cpp
@@ -48,8 +48,8 @@ class InputStateTest : public NXTTest {
                 .SetExtent(kRTSize, kRTSize, 1)
                 .SetFormat(nxt::TextureFormat::R8G8B8A8Unorm)
                 .SetMipLevels(1)
-                .SetAllowedUsage(nxt::TextureUsageBit::ColorAttachment | nxt::TextureUsageBit::TransferSrc)
-                .SetInitialUsage(nxt::TextureUsageBit::ColorAttachment)
+                .SetAllowedUsage(nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::TransferSrc)
+                .SetInitialUsage(nxt::TextureUsageBit::OutputAttachment)
                 .GetResult();
 
             renderTargetView = renderTarget.CreateTextureViewBuilder().GetResult();


### PR DESCRIPTION
Also changes the attachment usages to OutputAttachment and InputAttachment instead of ColorAttachment, DepthStencilAttachment, etc.

~~Based on top of #64, so there's an extra commit in here.~~