### PR TITLE
Add reference counting to DeviceBase

### DIFF
--- a/src/backend/Device.cpp
+++ b/src/backend/Device.cpp
@@ -138,4 +138,17 @@ namespace backend {
         // TODO(cwallez@chromium.org): update state tracking then call the backend
     }
 
+    void DeviceBase::Reference() {
+        ASSERT(refCount != 0);
+        refCount++;
+    }
+
+    void DeviceBase::Release() {
+        ASSERT(refCount != 0);
+        refCount--;
+        if (refCount == 0) {
+            delete this;
+        }
+    }
+
 }

--- a/src/backend/Device.h
+++ b/src/backend/Device.h
@@ -27,7 +27,7 @@ namespace backend {
     class DeviceBase {
         public:
             DeviceBase();
-            ~DeviceBase();
+            virtual ~DeviceBase();
 
             void HandleError(const char* message);
 
@@ -90,6 +90,8 @@ namespace backend {
             void Tick();
             void CopyBindGroups(uint32_t start, uint32_t count, BindGroupBase* source, BindGroupBase* target);
             void SetErrorCallback(nxt::DeviceErrorCallback callback, nxt::CallbackUserdata userdata);
+            void Reference();
+            void Release();
 
         private:
             // The object caches aren't exposed in the header as they would require a lot of
@@ -99,6 +101,7 @@ namespace backend {
 
             nxt::DeviceErrorCallback errorCallback = nullptr;
             nxt::CallbackUserdata errorUserdata = 0;
+            uint32_t refCount = 1;
     };
 
 }

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -101,6 +101,10 @@ namespace d3d12 {
     }
 
     Device::~Device() {
+        // Wait for all in-flight commands to finish exeuting
+        const uint64_t currentSerial = GetSerial();
+        NextSerial();
+        WaitForSerial(currentSerial);
     }
 
     ComPtr<ID3D12Device> Device::GetD3D12Device() {

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -252,12 +252,6 @@ namespace d3d12 {
         return new TextureView(builder);
     }
 
-    void Device::Reference() {
-    }
-
-    void Device::Release() {
-    }
-
     // DepthStencilState
 
     DepthStencilState::DepthStencilState(Device* device, DepthStencilStateBuilder* builder)

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -132,10 +132,6 @@ namespace d3d12 {
 
             void ExecuteCommandLists(std::initializer_list<ID3D12CommandList*> commandLists);
 
-            // NXT API
-            void Reference();
-            void Release();
-
         private:
             uint64_t serial = 0;
             ComPtr<ID3D12Fence> fence;

--- a/src/backend/metal/MetalBackend.h
+++ b/src/backend/metal/MetalBackend.h
@@ -117,10 +117,6 @@ namespace metal {
             MapReadRequestTracker* GetMapReadTracker() const;
             ResourceUploader* GetResourceUploader() const;
 
-            // NXT API
-            void Reference();
-            void Release();
-
         private:
             void OnCompletedHandler();
 

--- a/src/backend/metal/MetalBackend.mm
+++ b/src/backend/metal/MetalBackend.mm
@@ -241,12 +241,6 @@ namespace metal {
         return resourceUploader;
     }
 
-    void Device::Reference() {
-    }
-
-    void Device::Release() {
-    }
-
     // Bind Group
 
     BindGroup::BindGroup(BindGroupBuilder* builder)

--- a/src/backend/null/NullBackend.cpp
+++ b/src/backend/null/NullBackend.cpp
@@ -99,12 +99,6 @@ namespace null {
         return std::move(pendingOperations);
     }
 
-    void Device::Reference() {
-    }
-
-    void Device::Release() {
-    }
-
     // Buffer
 
     struct BufferMapReadOperation : PendingOperation {

--- a/src/backend/null/NullBackend.h
+++ b/src/backend/null/NullBackend.h
@@ -112,10 +112,6 @@ namespace null {
             void AddPendingOperation(std::unique_ptr<PendingOperation> operation);
             std::vector<std::unique_ptr<PendingOperation>> AcquirePendingOperations();
 
-            // NXT API
-            void Reference();
-            void Release();
-
         private:
             std::vector<std::unique_ptr<PendingOperation>> pendingOperations;
     };

--- a/src/backend/opengl/OpenGLBackend.cpp
+++ b/src/backend/opengl/OpenGLBackend.cpp
@@ -100,12 +100,6 @@ namespace opengl {
     void Device::TickImpl() {
     }
 
-    void Device::Reference() {
-    }
-
-    void Device::Release() {
-    }
-
     // Bind Group
 
     BindGroup::BindGroup(BindGroupBuilder* builder)

--- a/src/backend/opengl/OpenGLBackend.h
+++ b/src/backend/opengl/OpenGLBackend.h
@@ -98,10 +98,6 @@ namespace opengl {
             TextureViewBase* CreateTextureView(TextureViewBuilder* builder) override;
 
             void TickImpl() override;
-
-            // NXT API
-            void Reference();
-            void Release();
     };
 
     class BindGroup : public BindGroupBase {


### PR DESCRIPTION
Adds reference counting to the device and deletes itself when it reaches 0
D3D12 backend waits for GPU execution to complete when destroyed