### PR TITLE
Add primitive topology

### DIFF
--- a/next.json
+++ b/next.json
@@ -691,6 +691,16 @@
             }
         ]
     },
+    "primitive topology": {
+        "category": "enum",
+        "values": [
+            {"value": 0, "name": "point"},
+            {"value": 1, "name": "line"},
+            {"value": 2, "name": "line strip"},
+            {"value": 3, "name": "triangle"},
+            {"value": 4, "name": "triangle strip"}
+        ]
+    },
     "queue": {
         "category": "object",
         "methods": [
@@ -774,16 +784,27 @@
                 "returns": "render pipeline"
             },
             {
+                "name": "set depth stencil state",
+                "args": [
+                    {"name": "depth stencil state", "type": "depth stencil state"}
+                ]
+            },
+            {
+                "name": "set input state",
+                "args": [
+                    {"name": "input", "type": "input state"}
+                ]
+            },
+            {
                 "name": "set layout",
                 "args": [
                     {"name": "layout", "type": "pipeline layout"}
                 ]
             },
             {
-                "name": "set subpass",
+                "name": "set primitive topology",
                 "args": [
-                    {"name": "render pass", "type": "render pass"},
-                    {"name": "subpass", "type": "uint32_t"}
+                    {"name": "primitive topology", "type": "primitive topology"}
                 ]
             },
             {
@@ -795,15 +816,10 @@
                 ]
             },
             {
-                "name": "set input state",
+                "name": "set subpass",
                 "args": [
-                    {"name": "input", "type": "input state"}
-                ]
-            },
-            {
-                "name": "set depth stencil state",
-                "args": [
-                    {"name": "depth stencil state", "type": "depth stencil state"}
+                    {"name": "render pass", "type": "render pass"},
+                    {"name": "subpass", "type": "uint32_t"}
                 ]
             }
         ]

--- a/next.json
+++ b/next.json
@@ -694,10 +694,10 @@
     "primitive topology": {
         "category": "enum",
         "values": [
-            {"value": 0, "name": "point"},
-            {"value": 1, "name": "line"},
+            {"value": 0, "name": "point list"},
+            {"value": 1, "name": "line list"},
             {"value": 2, "name": "line strip"},
-            {"value": 3, "name": "triangle"},
+            {"value": 3, "name": "triangle list"},
             {"value": 4, "name": "triangle strip"}
         ]
     },

--- a/src/backend/RenderPipeline.cpp
+++ b/src/backend/RenderPipeline.cpp
@@ -24,8 +24,11 @@ namespace backend {
     // RenderPipelineBase
 
     RenderPipelineBase::RenderPipelineBase(RenderPipelineBuilder* builder)
-        : PipelineBase(builder), renderPass(std::move(builder->renderPass)), subpass(builder->subpass),
-          inputState(std::move(builder->inputState)), depthStencilState(std::move(builder->depthStencilState)) {
+        : PipelineBase(builder),
+          depthStencilState(std::move(builder->depthStencilState)),
+          inputState(std::move(builder->inputState)),
+          primitiveTopology(builder->primitiveTopology),
+          renderPass(std::move(builder->renderPass)), subpass(builder->subpass) {
 
         if (GetStageMask() != (nxt::ShaderStageBit::Vertex | nxt::ShaderStageBit::Fragment)) {
             builder->HandleError("Render pipeline should have exactly a vertex and fragment stage");
@@ -45,20 +48,24 @@ namespace backend {
         }
     }
 
-    RenderPassBase* RenderPipelineBase::GetRenderPass() {
-        return renderPass.Get();
-    }
-
-    uint32_t RenderPipelineBase::GetSubPass() {
-        return subpass;
+    DepthStencilStateBase* RenderPipelineBase::GetDepthStencilState() {
+        return depthStencilState.Get();
     }
 
     InputStateBase* RenderPipelineBase::GetInputState() {
         return inputState.Get();
     }
 
-    DepthStencilStateBase* RenderPipelineBase::GetDepthStencilState() {
-        return depthStencilState.Get();
+    nxt::PrimitiveTopology RenderPipelineBase::GetPrimitiveTopology() const {
+        return primitiveTopology;
+    }
+
+    RenderPassBase* RenderPipelineBase::GetRenderPass() {
+        return renderPass.Get();
+    }
+
+    uint32_t RenderPipelineBase::GetSubPass() {
+        return subpass;
     }
 
     // RenderPipelineBuilder
@@ -79,17 +86,21 @@ namespace backend {
         return device->CreateRenderPipeline(this);
     }
 
-    void RenderPipelineBuilder::SetSubpass(RenderPassBase* renderPass, uint32_t subpass) {
-        this->renderPass = renderPass;
-        this->subpass = subpass;
+    void RenderPipelineBuilder::SetDepthStencilState(DepthStencilStateBase* depthStencilState) {
+        this->depthStencilState = depthStencilState;
     }
 
     void RenderPipelineBuilder::SetInputState(InputStateBase* inputState) {
         this->inputState = inputState;
     }
 
-    void RenderPipelineBuilder::SetDepthStencilState(DepthStencilStateBase* depthStencilState) {
-        this->depthStencilState = depthStencilState;
+    void RenderPipelineBuilder::SetPrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
+        this->primitiveTopology = primitiveTopology;
+    }
+
+    void RenderPipelineBuilder::SetSubpass(RenderPassBase* renderPass, uint32_t subpass) {
+        this->renderPass = renderPass;
+        this->subpass = subpass;
     }
 
 }

--- a/src/backend/RenderPipeline.h
+++ b/src/backend/RenderPipeline.h
@@ -57,7 +57,7 @@ namespace backend {
             Ref<DepthStencilStateBase> depthStencilState;
             Ref<InputStateBase> inputState;
             // TODO(enga@google.com): Remove default when we validate that all required properties are set
-            nxt::PrimitiveTopology primitiveTopology = nxt::PrimitiveTopology::Triangle;
+            nxt::PrimitiveTopology primitiveTopology = nxt::PrimitiveTopology::TriangleList;
             Ref<RenderPassBase> renderPass;
             uint32_t subpass;
     };

--- a/src/backend/RenderPipeline.h
+++ b/src/backend/RenderPipeline.h
@@ -25,16 +25,18 @@ namespace backend {
         public:
             RenderPipelineBase(RenderPipelineBuilder* builder);
 
+            DepthStencilStateBase* GetDepthStencilState();
+            InputStateBase* GetInputState();
+            nxt::PrimitiveTopology GetPrimitiveTopology() const;
             RenderPassBase* GetRenderPass();
             uint32_t GetSubPass();
-            InputStateBase* GetInputState();
-            DepthStencilStateBase* GetDepthStencilState();
 
         private:
+            Ref<DepthStencilStateBase> depthStencilState;
+            Ref<InputStateBase> inputState;
+            nxt::PrimitiveTopology primitiveTopology;
             Ref<RenderPassBase> renderPass;
             uint32_t subpass;
-            Ref<InputStateBase> inputState;
-            Ref<DepthStencilStateBase> depthStencilState;
     };
 
     class RenderPipelineBuilder : public Builder<RenderPipelineBase>, public PipelineBuilder {
@@ -42,19 +44,22 @@ namespace backend {
             RenderPipelineBuilder(DeviceBase* device);
 
             // NXT API
-            void SetSubpass(RenderPassBase* renderPass, uint32_t subpass);
-            void SetInputState(InputStateBase* inputState);
             void SetDepthStencilState(DepthStencilStateBase* depthStencilState);
+            void SetPrimitiveTopology(nxt::PrimitiveTopology primitiveTopology);
+            void SetInputState(InputStateBase* inputState);
+            void SetSubpass(RenderPassBase* renderPass, uint32_t subpass);
 
         private:
             friend class RenderPipelineBase;
 
             RenderPipelineBase* GetResultImpl() override;
 
+            Ref<DepthStencilStateBase> depthStencilState;
+            Ref<InputStateBase> inputState;
+            // TODO(enga@google.com): Remove default when we validate that all required properties are set
+            nxt::PrimitiveTopology primitiveTopology = nxt::PrimitiveTopology::Triangle;
             Ref<RenderPassBase> renderPass;
             uint32_t subpass;
-            Ref<InputStateBase> inputState;
-            Ref<DepthStencilStateBase> depthStencilState;
     };
 
 }

--- a/src/backend/d3d12/CommandBufferD3D12.cpp
+++ b/src/backend/d3d12/CommandBufferD3D12.cpp
@@ -399,7 +399,6 @@ namespace d3d12 {
                     {
                         DrawArraysCmd* draw = commands.NextCommand<DrawArraysCmd>();
 
-                        commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
                         commandList->DrawInstanced(
                             draw->vertexCount,
                             draw->instanceCount,
@@ -413,7 +412,6 @@ namespace d3d12 {
                     {
                         DrawElementsCmd* draw = commands.NextCommand<DrawElementsCmd>();
 
-                        commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
                         commandList->DrawIndexedInstanced(
                             draw->indexCount,
                             draw->instanceCount,
@@ -464,6 +462,7 @@ namespace d3d12 {
 
                         commandList->SetGraphicsRootSignature(layout->GetRootSignature().Get());
                         commandList->SetPipelineState(pipeline->GetPipelineState().Get());
+                        commandList->IASetPrimitiveTopology(pipeline->GetD3D12PrimitiveTopology());
 
                         bindingTracker.SetInheritedBindGroups(commandList, lastLayout, layout);
 

--- a/src/backend/d3d12/RenderPipelineD3D12.cpp
+++ b/src/backend/d3d12/RenderPipelineD3D12.cpp
@@ -25,8 +25,27 @@
 namespace backend {
 namespace d3d12 {
 
+    namespace {
+        D3D12_PRIMITIVE_TOPOLOGY D3D12PrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
+            switch (primitiveTopology) {
+                case nxt::PrimitiveTopology::Point:
+                    return D3D_PRIMITIVE_TOPOLOGY_POINTLIST;
+                case nxt::PrimitiveTopology::Line:
+                    return D3D_PRIMITIVE_TOPOLOGY_LINELIST;
+                case nxt::PrimitiveTopology::LineStrip:
+                    return D3D_PRIMITIVE_TOPOLOGY_LINESTRIP;
+                case nxt::PrimitiveTopology::Triangle:
+                    return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+                case nxt::PrimitiveTopology::TriangleStrip:
+                    return D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
+                default:
+                    UNREACHABLE();
+            }
+        }
+    }
+
     RenderPipeline::RenderPipeline(RenderPipelineBuilder* builder)
-        : RenderPipelineBase(builder) {
+        : RenderPipelineBase(builder), d3d12PrimitiveTopology(D3D12PrimitiveTopology(GetPrimitiveTopology())) {
         uint32_t compileFlags = 0;
 #if defined(_DEBUG)
         // Enable better shader debugging with the graphics debugging tools.
@@ -130,6 +149,10 @@ namespace d3d12 {
 
         Device* device = ToBackend(builder->GetDevice());
         ASSERT_SUCCESS(device->GetD3D12Device()->CreateGraphicsPipelineState(&descriptor, IID_PPV_ARGS(&pipelineState)));
+    }
+
+    D3D12_PRIMITIVE_TOPOLOGY RenderPipeline::GetD3D12PrimitiveTopology() const {
+        return d3d12PrimitiveTopology;
     }
 
     ComPtr<ID3D12PipelineState> RenderPipeline::GetPipelineState() {

--- a/src/backend/d3d12/RenderPipelineD3D12.cpp
+++ b/src/backend/d3d12/RenderPipelineD3D12.cpp
@@ -42,6 +42,21 @@ namespace d3d12 {
                     UNREACHABLE();
             }
         }
+
+        D3D12_PRIMITIVE_TOPOLOGY_TYPE D3D12PrimitiveTopologyType(nxt::PrimitiveTopology primitiveTopology) {
+            switch (primitiveTopology) {
+                case nxt::PrimitiveTopology::Point:
+                    return D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
+                case nxt::PrimitiveTopology::Line:
+                case nxt::PrimitiveTopology::LineStrip:
+                    return D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE;
+                case nxt::PrimitiveTopology::Triangle:
+                case nxt::PrimitiveTopology::TriangleStrip:
+                    return D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+                default:
+                    UNREACHABLE();
+            }
+        }
     }
 
     RenderPipeline::RenderPipeline(RenderPipelineBuilder* builder)
@@ -142,7 +157,7 @@ namespace d3d12 {
         descriptor.DepthStencilState.DepthEnable = false;
         descriptor.DepthStencilState.StencilEnable = false;
         descriptor.SampleMask = UINT_MAX;
-        descriptor.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+        descriptor.PrimitiveTopologyType = D3D12PrimitiveTopologyType(GetPrimitiveTopology());
         descriptor.NumRenderTargets = 1;
         descriptor.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
         descriptor.SampleDesc.Count = 1;

--- a/src/backend/d3d12/RenderPipelineD3D12.cpp
+++ b/src/backend/d3d12/RenderPipelineD3D12.cpp
@@ -28,13 +28,13 @@ namespace d3d12 {
     namespace {
         D3D12_PRIMITIVE_TOPOLOGY D3D12PrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
             switch (primitiveTopology) {
-                case nxt::PrimitiveTopology::Point:
+                case nxt::PrimitiveTopology::PointList:
                     return D3D_PRIMITIVE_TOPOLOGY_POINTLIST;
-                case nxt::PrimitiveTopology::Line:
+                case nxt::PrimitiveTopology::LineList:
                     return D3D_PRIMITIVE_TOPOLOGY_LINELIST;
                 case nxt::PrimitiveTopology::LineStrip:
                     return D3D_PRIMITIVE_TOPOLOGY_LINESTRIP;
-                case nxt::PrimitiveTopology::Triangle:
+                case nxt::PrimitiveTopology::TriangleList:
                     return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
                 case nxt::PrimitiveTopology::TriangleStrip:
                     return D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
@@ -45,12 +45,12 @@ namespace d3d12 {
 
         D3D12_PRIMITIVE_TOPOLOGY_TYPE D3D12PrimitiveTopologyType(nxt::PrimitiveTopology primitiveTopology) {
             switch (primitiveTopology) {
-                case nxt::PrimitiveTopology::Point:
+                case nxt::PrimitiveTopology::PointList:
                     return D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
-                case nxt::PrimitiveTopology::Line:
+                case nxt::PrimitiveTopology::LineList:
                 case nxt::PrimitiveTopology::LineStrip:
                     return D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE;
-                case nxt::PrimitiveTopology::Triangle:
+                case nxt::PrimitiveTopology::TriangleList:
                 case nxt::PrimitiveTopology::TriangleStrip:
                     return D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
                 default:

--- a/src/backend/d3d12/RenderPipelineD3D12.h
+++ b/src/backend/d3d12/RenderPipelineD3D12.h
@@ -26,9 +26,11 @@ namespace d3d12 {
         public:
             RenderPipeline(RenderPipelineBuilder* builder);
 
+            D3D12_PRIMITIVE_TOPOLOGY GetD3D12PrimitiveTopology() const;
             ComPtr<ID3D12PipelineState> GetPipelineState();
 
         private:
+            D3D12_PRIMITIVE_TOPOLOGY d3d12PrimitiveTopology;
             ComPtr<ID3D12PipelineState> pipelineState;
     };
 

--- a/src/backend/metal/CommandBufferMTL.mm
+++ b/src/backend/metal/CommandBufferMTL.mm
@@ -279,7 +279,7 @@ namespace metal {
 
                         ASSERT(encoders.render);
                         [encoders.render
-                            drawPrimitives:MTLPrimitiveTypeTriangle
+                            drawPrimitives:lastRenderPipeline->GetMTLPrimitiveTopology()
                             vertexStart:draw->firstVertex
                             vertexCount:draw->vertexCount
                             instanceCount:draw->instanceCount
@@ -293,7 +293,7 @@ namespace metal {
 
                         ASSERT(encoders.render);
                         [encoders.render
-                            drawIndexedPrimitives:MTLPrimitiveTypeTriangle
+                            drawIndexedPrimitives:lastRenderPipeline->GetMTLPrimitiveTopology()
                             indexCount:draw->indexCount
                             indexType:indexType
                             indexBuffer:indexBuffer

--- a/src/backend/metal/RenderPipelineMTL.h
+++ b/src/backend/metal/RenderPipelineMTL.h
@@ -27,9 +27,12 @@ namespace metal {
             RenderPipeline(RenderPipelineBuilder* builder);
             ~RenderPipeline();
 
+            MTLPrimitiveType GetMTLPrimitiveTopology() const;
+
             void Encode(id<MTLRenderCommandEncoder> encoder);
 
         private:
+            MTLPrimitiveType mtlPrimitiveTopology;
             id<MTLRenderPipelineState> mtlRenderPipelineState = nil;
     };
 

--- a/src/backend/metal/RenderPipelineMTL.mm
+++ b/src/backend/metal/RenderPipelineMTL.mm
@@ -23,8 +23,25 @@
 namespace backend {
 namespace metal {
 
+    namespace {
+        MTLPrimitiveType MTLPrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
+            switch (primitiveTopology) {
+                case nxt::PrimitiveTopology::Point:
+                    return MTLPrimitiveTypePoint;
+                case nxt::PrimitiveTopology::Line:
+                    return MTLPrimitiveTypeLine;
+                case nxt::PrimitiveTopology::LineStrip:
+                    return MTLPrimitiveTypeLineStrip;
+                case nxt::PrimitiveTopology::Triangle:
+                    return MTLPrimitiveTypeTriangle;
+                case nxt::PrimitiveTopology::TriangleStrip:
+                    return MTLPrimitiveTypeTriangleStrip;
+            }
+        }
+    }
+
     RenderPipeline::RenderPipeline(RenderPipelineBuilder* builder)
-        : RenderPipelineBase(builder) {
+        : RenderPipelineBase(builder), mtlPrimitiveTopology(MTLPrimitiveTopology(GetPrimitiveTopology())) {
 
         auto mtlDevice = ToBackend(builder->GetDevice())->GetMTLDevice();
 
@@ -71,6 +88,10 @@ namespace metal {
 
     RenderPipeline::~RenderPipeline() {
         [mtlRenderPipelineState release];
+    }
+
+    MTLPrimitiveType RenderPipeline::GetMTLPrimitiveTopology() const {
+        return mtlPrimitiveTopology;
     }
 
     void RenderPipeline::Encode(id<MTLRenderCommandEncoder> encoder) {

--- a/src/backend/metal/RenderPipelineMTL.mm
+++ b/src/backend/metal/RenderPipelineMTL.mm
@@ -26,13 +26,13 @@ namespace metal {
     namespace {
         MTLPrimitiveType MTLPrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
             switch (primitiveTopology) {
-                case nxt::PrimitiveTopology::Point:
+                case nxt::PrimitiveTopology::PointList:
                     return MTLPrimitiveTypePoint;
-                case nxt::PrimitiveTopology::Line:
+                case nxt::PrimitiveTopology::LineList:
                     return MTLPrimitiveTypeLine;
                 case nxt::PrimitiveTopology::LineStrip:
                     return MTLPrimitiveTypeLineStrip;
-                case nxt::PrimitiveTopology::Triangle:
+                case nxt::PrimitiveTopology::TriangleList:
                     return MTLPrimitiveTypeTriangle;
                 case nxt::PrimitiveTopology::TriangleStrip:
                     return MTLPrimitiveTypeTriangleStrip;
@@ -41,12 +41,12 @@ namespace metal {
 
         MTLPrimitiveTopologyClass MTLInputPrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
             switch (primitiveTopology) {
-                case nxt::PrimitiveTopology::Point:
+                case nxt::PrimitiveTopology::PointList:
                     return MTLPrimitiveTopologyClassPoint;
-                case nxt::PrimitiveTopology::Line:
+                case nxt::PrimitiveTopology::LineList:
                 case nxt::PrimitiveTopology::LineStrip:
                     return MTLPrimitiveTopologyClassLine;
-                case nxt::PrimitiveTopology::Triangle:
+                case nxt::PrimitiveTopology::TriangleList:
                 case nxt::PrimitiveTopology::TriangleStrip:
                     return MTLPrimitiveTopologyClassTriangle;
             }

--- a/src/backend/metal/RenderPipelineMTL.mm
+++ b/src/backend/metal/RenderPipelineMTL.mm
@@ -38,6 +38,19 @@ namespace metal {
                     return MTLPrimitiveTypeTriangleStrip;
             }
         }
+
+        MTLPrimitiveTopologyClass MTLInputPrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
+            switch (primitiveTopology) {
+                case nxt::PrimitiveTopology::Point:
+                    return MTLPrimitiveTopologyClassPoint;
+                case nxt::PrimitiveTopology::Line:
+                case nxt::PrimitiveTopology::LineStrip:
+                    return MTLPrimitiveTopologyClassLine;
+                case nxt::PrimitiveTopology::Triangle:
+                case nxt::PrimitiveTopology::TriangleStrip:
+                    return MTLPrimitiveTopologyClassTriangle;
+            }
+        }
     }
 
     RenderPipeline::RenderPipeline(RenderPipelineBuilder* builder)
@@ -68,6 +81,7 @@ namespace metal {
         // TODO(cwallez@chromium.org): get the attachment formats from the subpass
         descriptor.colorAttachments[0].pixelFormat = MTLPixelFormatRGBA8Unorm;
         descriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+        descriptor.inputPrimitiveTopology = MTLInputPrimitiveTopology(GetPrimitiveTopology());
 
         InputState* inputState = ToBackend(GetInputState());
         descriptor.vertexDescriptor = inputState->GetMTLVertexDescriptor();

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -236,11 +236,11 @@ namespace opengl {
                     {
                         DrawArraysCmd* draw = commands.NextCommand<DrawArraysCmd>();
                         if (draw->firstInstance > 0) {
-                            glDrawArraysInstancedBaseInstance(GL_TRIANGLES,
+                            glDrawArraysInstancedBaseInstance(lastRenderPipeline->GetGLPrimitiveTopology(),
                                 draw->firstVertex, draw->vertexCount, draw->instanceCount, draw->firstInstance);
                         } else {
                             // This branch is only needed on OpenGL < 4.2
-                            glDrawArraysInstanced(GL_TRIANGLES,
+                            glDrawArraysInstanced(lastRenderPipeline->GetGLPrimitiveTopology(),
                                 draw->firstVertex, draw->vertexCount, draw->instanceCount);
                         }
                     }
@@ -253,13 +253,13 @@ namespace opengl {
                         GLenum formatType = IndexFormatType(indexBufferFormat);
 
                         if (draw->firstInstance > 0) {
-                            glDrawElementsInstancedBaseInstance(GL_TRIANGLES,
+                            glDrawElementsInstancedBaseInstance(lastRenderPipeline->GetGLPrimitiveTopology(),
                                 draw->indexCount, formatType,
                                 reinterpret_cast<void*>(draw->firstIndex * formatSize + indexBufferOffset),
                                 draw->instanceCount, draw->firstInstance);
                         } else {
                             // This branch is only needed on OpenGL < 4.2
-                            glDrawElementsInstanced(GL_TRIANGLES,
+                            glDrawElementsInstanced(lastRenderPipeline->GetGLPrimitiveTopology(),
                                 draw->indexCount, formatType,
                                 reinterpret_cast<void*>(draw->firstIndex * formatSize + indexBufferOffset),
                                 draw->instanceCount);

--- a/src/backend/opengl/RenderPipelineGL.cpp
+++ b/src/backend/opengl/RenderPipelineGL.cpp
@@ -21,8 +21,32 @@
 namespace backend {
 namespace opengl {
 
+    namespace {
+        GLenum GLPrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
+            switch (primitiveTopology) {
+                case nxt::PrimitiveTopology::Point:
+                    return GL_POINTS;
+                case nxt::PrimitiveTopology::Line:
+                    return GL_LINES;
+                case nxt::PrimitiveTopology::LineStrip:
+                    return GL_LINE_STRIP;
+                case nxt::PrimitiveTopology::Triangle:
+                    return GL_TRIANGLES;
+                case nxt::PrimitiveTopology::TriangleStrip:
+                    return GL_TRIANGLE_STRIP;
+                default:
+                    UNREACHABLE();
+            }
+        }
+    }
+
     RenderPipeline::RenderPipeline(RenderPipelineBuilder* builder)
-        : RenderPipelineBase(builder), PipelineGL(this, builder) {
+        : RenderPipelineBase(builder), PipelineGL(this, builder),
+          glPrimitiveTopology(GLPrimitiveTopology(GetPrimitiveTopology())) {
+    }
+
+    GLenum RenderPipeline::GetGLPrimitiveTopology() const {
+        return glPrimitiveTopology;
     }
 
     void RenderPipeline::ApplyNow(PersistentPipelineState &persistentPipelineState) {

--- a/src/backend/opengl/RenderPipelineGL.cpp
+++ b/src/backend/opengl/RenderPipelineGL.cpp
@@ -24,13 +24,13 @@ namespace opengl {
     namespace {
         GLenum GLPrimitiveTopology(nxt::PrimitiveTopology primitiveTopology) {
             switch (primitiveTopology) {
-                case nxt::PrimitiveTopology::Point:
+                case nxt::PrimitiveTopology::PointList:
                     return GL_POINTS;
-                case nxt::PrimitiveTopology::Line:
+                case nxt::PrimitiveTopology::LineList:
                     return GL_LINES;
                 case nxt::PrimitiveTopology::LineStrip:
                     return GL_LINE_STRIP;
-                case nxt::PrimitiveTopology::Triangle:
+                case nxt::PrimitiveTopology::TriangleList:
                     return GL_TRIANGLES;
                 case nxt::PrimitiveTopology::TriangleStrip:
                     return GL_TRIANGLE_STRIP;

--- a/src/backend/opengl/RenderPipelineGL.h
+++ b/src/backend/opengl/RenderPipelineGL.h
@@ -32,7 +32,12 @@ namespace opengl {
         public:
             RenderPipeline(RenderPipelineBuilder* builder);
 
+            GLenum GetGLPrimitiveTopology() const;
+
             void ApplyNow(PersistentPipelineState &persistentPipelineState);
+
+        private:
+            GLenum glPrimitiveTopology;
     };
 
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ list(APPEND UNITTEST_SOURCES
     ${VALIDATION_TESTS_DIR}/InputStateValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/PushConstantsValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/RenderPassValidationTests.cpp
+    ${VALIDATION_TESTS_DIR}/RenderPipelineValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/UsageValidationTests.cpp
     ${VALIDATION_TESTS_DIR}/ValidationTest.cpp
     ${VALIDATION_TESTS_DIR}/ValidationTest.h

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -68,9 +68,10 @@ NXTInternalTarget("tests" nxt_unittests)
 add_executable(nxt_end2end_tests
     ${END2END_TESTS_DIR}/BasicTests.cpp
     ${END2END_TESTS_DIR}/BufferTests.cpp
-    ${END2END_TESTS_DIR}/InputStateTests.cpp
     ${END2END_TESTS_DIR}/CopyTests.cpp
     ${END2END_TESTS_DIR}/DepthStencilStateTests.cpp
+    ${END2END_TESTS_DIR}/InputStateTests.cpp
+    ${END2END_TESTS_DIR}/PrimitiveTopologyTests.cpp
     ${TESTS_DIR}/End2EndTestsMain.cpp
     ${TESTS_DIR}/NXTTest.cpp
     ${TESTS_DIR}/NXTTest.h

--- a/src/tests/end2end/PrimitiveTopologyTests.cpp
+++ b/src/tests/end2end/PrimitiveTopologyTests.cpp
@@ -1,0 +1,310 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/NXTTest.h"
+
+#include "common/Assert.h"
+#include "utils/NXTHelpers.h"
+
+// Primitive topology tests work by drawing the following vertices with all the different primitive topology states:
+// -------------------------------------
+// |                                   |
+// |        1        2        5        |
+// |                                   |
+// |                                   |
+// |                                   |
+// |                                   |
+// |        0        3        4        |
+// |                                   |
+// -------------------------------------
+//
+// Points: This case looks exactly like above
+//
+// Lines
+// -------------------------------------
+// |                                   |
+// |        1        2        5        |
+// |        |        |        |        |
+// |        |        |        |        |
+// |        |        |        |        |
+// |        |        |        |        |
+// |        0        3        4        |
+// |                                   |
+// -------------------------------------
+//
+// Line Strip
+// -------------------------------------
+// |                                   |
+// |        1--------2        5        |
+// |        |        |        |        |
+// |        |        |        |        |
+// |        |        |        |        |
+// |        |        |        |        |
+// |        0        3--------4        |
+// |                                   |
+// -------------------------------------
+//
+// Triangle
+// -------------------------------------
+// |                                   |
+// |        1--------2        5        |
+// |        |xxxxxxx         x|        |
+// |        |xxxxx         xxx|        |
+// |        |xxx         xxxxx|        |
+// |        |x         xxxxxxx|        |
+// |        0        3--------4        |
+// |                                   |
+// -------------------------------------
+//
+// Triangle Strip
+// -------------------------------------
+// |                                   |
+// |        1--------2        5        |
+// |        |xxxxxxxxx       x|        |
+// |        |xxxxxxxxxxx   xxx|        |
+// |        |xxx   xxxxxxxxxxx|        |
+// |        |x      xxxxxxxxxx|        |
+// |        0        3--------4        |
+// |                                   |
+// -------------------------------------
+//
+// Each of these different states is a superset of some of the previous states,
+// so for every state, we check any new added test locations that are not contained in previous states
+// We also check that the test locations of subsequent states are untouched
+
+constexpr static unsigned int kRTSize = 32;
+
+struct TestLocation {
+    unsigned int x, y;
+};
+
+constexpr TestLocation GetMidpoint(const TestLocation& a, const TestLocation& b) noexcept {
+    return { (a.x + b.x) / 2, (a.y + b.y) / 2 };
+}
+
+constexpr TestLocation GetCentroid(const TestLocation& a, const TestLocation& b, const TestLocation& c) noexcept {
+    return { (a.x + b.x + c.x) / 3, (a.y + b.y + c.y) / 3 };
+}
+
+// Offset towards one corner to avoid x or y symmetry false positives
+constexpr static unsigned int kOffset = kRTSize / 8;
+
+constexpr static TestLocation kPointTestLocations[] = {
+    { kRTSize * 1 / 4 + kOffset, kRTSize * 1 / 4 + kOffset },
+    { kRTSize * 1 / 4 + kOffset, kRTSize * 3 / 4 + kOffset },
+    { kRTSize * 2 / 4 + kOffset, kRTSize * 3 / 4 + kOffset },
+    { kRTSize * 2 / 4 + kOffset, kRTSize * 1 / 4 + kOffset },
+    { kRTSize * 3 / 4 + kOffset, kRTSize * 1 / 4 + kOffset },
+    { kRTSize * 3 / 4 + kOffset, kRTSize * 3 / 4 + kOffset },
+};
+
+constexpr static TestLocation kLineTestLocations[] = {
+    GetMidpoint(kPointTestLocations[0], kPointTestLocations[1]),
+    GetMidpoint(kPointTestLocations[2], kPointTestLocations[3]),
+    GetMidpoint(kPointTestLocations[4], kPointTestLocations[5]),
+};
+
+constexpr static TestLocation kLineStripTestLocations[] = {
+    GetMidpoint(kPointTestLocations[1], kPointTestLocations[2]),
+    GetMidpoint(kPointTestLocations[3], kPointTestLocations[4]),
+};
+
+constexpr static TestLocation kTriangleTestLocations[] = {
+    GetCentroid(kPointTestLocations[0], kPointTestLocations[1], kPointTestLocations[2]),
+    GetCentroid(kPointTestLocations[3], kPointTestLocations[4], kPointTestLocations[5]),
+};
+
+constexpr static TestLocation kTriangleStripTestLocations[] = {
+    GetCentroid(kPointTestLocations[1], kPointTestLocations[2], kPointTestLocations[3]),
+    GetCentroid(kPointTestLocations[2], kPointTestLocations[3], kPointTestLocations[4]),
+};
+
+constexpr static float kRTSizef = static_cast<float>(kRTSize);
+constexpr static float kVertices[] = {
+    2.f * (kPointTestLocations[0].x + 0.5f) / kRTSizef - 1.f, 1.f - 2.f * (kPointTestLocations[0].y + 0.5f) / kRTSizef, 0.f, 1.f,
+    2.f * (kPointTestLocations[1].x + 0.5f) / kRTSizef - 1.f, 1.f - 2.f * (kPointTestLocations[1].y + 0.5f) / kRTSizef, 0.f, 1.f,
+    2.f * (kPointTestLocations[2].x + 0.5f) / kRTSizef - 1.f, 1.f - 2.f * (kPointTestLocations[2].y + 0.5f) / kRTSizef, 0.f, 1.f,
+    2.f * (kPointTestLocations[3].x + 0.5f) / kRTSizef - 1.f, 1.f - 2.f * (kPointTestLocations[3].y + 0.5f) / kRTSizef, 0.f, 1.f,
+    2.f * (kPointTestLocations[4].x + 0.5f) / kRTSizef - 1.f, 1.f - 2.f * (kPointTestLocations[4].y + 0.5f) / kRTSizef, 0.f, 1.f,
+    2.f * (kPointTestLocations[5].x + 0.5f) / kRTSizef - 1.f, 1.f - 2.f * (kPointTestLocations[5].y + 0.5f) / kRTSizef, 0.f, 1.f,
+};
+
+class PrimitiveTopologyTest : public NXTTest {
+    protected:
+        void SetUp() override {
+            NXTTest::SetUp();
+
+            renderpass = device.CreateRenderPassBuilder()
+                .SetAttachmentCount(1)
+                .AttachmentSetFormat(0, nxt::TextureFormat::R8G8B8A8Unorm)
+                .SetSubpassCount(1)
+                .SubpassSetColorAttachment(0, 0, 0)
+                .GetResult();
+
+            renderTarget = device.CreateTextureBuilder()
+                .SetDimension(nxt::TextureDimension::e2D)
+                .SetExtent(kRTSize, kRTSize, 1)
+                .SetFormat(nxt::TextureFormat::R8G8B8A8Unorm)
+                .SetMipLevels(1)
+                .SetAllowedUsage(nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::TransferSrc)
+                .SetInitialUsage(nxt::TextureUsageBit::OutputAttachment)
+                .GetResult();
+
+            renderTargetView = renderTarget.CreateTextureViewBuilder().GetResult();
+
+            framebuffer = device.CreateFramebufferBuilder()
+                .SetRenderPass(renderpass)
+                .SetAttachment(0, renderTargetView)
+                .SetDimensions(kRTSize, kRTSize)
+                .GetResult();
+
+            vsModule = utils::CreateShaderModule(device, nxt::ShaderStage::Vertex, R"(
+                #version 450
+                layout(location = 0) in vec4 pos;
+                void main() {
+                    gl_Position = pos;
+                })"
+            );
+
+            fsModule = utils::CreateShaderModule(device, nxt::ShaderStage::Fragment, R"(
+                #version 450
+                out vec4 fragColor;
+                void main() {
+                    fragColor = vec4(0.0, 1.0, 0.0, 1.0);
+                })"
+            );
+
+            inputState = device.CreateInputStateBuilder()
+                .SetAttribute(0, 0, nxt::VertexFormat::FloatR32G32B32A32, 0)
+                .SetInput(0, 4 * sizeof(float), nxt::InputStepMode::Vertex)
+                .GetResult();
+
+            vertexBuffer = utils::CreateFrozenBufferFromData(device, kVertices, sizeof(kVertices), nxt::BufferUsageBit::Vertex);
+        }
+
+        struct LocationSpec {
+            const TestLocation* locations;
+            size_t count;
+            bool include;
+        };
+
+        template <std::size_t N>
+        constexpr LocationSpec TestPoints(TestLocation const (&points)[N], bool include) noexcept {
+            return { points, N, include };
+        }
+
+        // Draw the vertices with the given primitive topology and check the pixel values of the test locations
+        void DoTest(nxt::PrimitiveTopology primitiveTopology, const std::vector<LocationSpec> &locationSpecs) {
+            nxt::RenderPipeline pipeline = device.CreateRenderPipelineBuilder()
+                .SetSubpass(renderpass, 0)
+                .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
+                .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
+                .SetInputState(inputState)
+                .SetPrimitiveTopology(primitiveTopology)
+                .GetResult();
+
+            renderTarget.TransitionUsage(nxt::TextureUsageBit::OutputAttachment);
+            static const uint32_t zeroOffset = 0;
+            nxt::CommandBuffer commands = device.CreateCommandBufferBuilder()
+                .BeginRenderPass(renderpass, framebuffer)
+                .BeginRenderSubpass()
+                    .SetRenderPipeline(pipeline)
+                    .SetVertexBuffers(0, 1, &vertexBuffer, &zeroOffset)
+                    .DrawArrays(6, 1, 0, 0)
+                .EndRenderSubpass()
+                .EndRenderPass()
+                .GetResult();
+
+            queue.Submit(1, &commands);
+
+            for (auto& locationSpec : locationSpecs) {
+                for (size_t i = 0; i < locationSpec.count; ++i) {
+                    // If this pixel is included, check that it is green. Otherwise, check that it is black
+                    RGBA8 color = locationSpec.include ? RGBA8(0, 255, 0, 255) : RGBA8(0, 0, 0, 0);
+                    EXPECT_PIXEL_RGBA8_EQ(color, renderTarget, locationSpec.locations[i].x, locationSpec.locations[i].y)
+                        << "Expected (" << locationSpec.locations[i].x << ", " << locationSpec.locations[i].y << ") to be " << color;
+                }
+            }
+        }
+
+        nxt::RenderPass renderpass;
+        nxt::Texture renderTarget;
+        nxt::TextureView renderTargetView;
+        nxt::Framebuffer framebuffer;
+        nxt::ShaderModule vsModule;
+        nxt::ShaderModule fsModule;
+        nxt::InputState inputState;
+        nxt::Buffer vertexBuffer;
+};
+
+// Test Point primitive topology
+TEST_P(PrimitiveTopologyTest, Point) {
+    DoTest(nxt::PrimitiveTopology::Point, {
+        // Check that the points are drawn
+        TestPoints(kPointTestLocations, true),
+
+        // Check that line and triangle locations are untouched
+        TestPoints(kLineTestLocations, false),
+        TestPoints(kLineStripTestLocations, false),
+        TestPoints(kTriangleTestLocations, false),
+        TestPoints(kTriangleStripTestLocations, false),
+    });
+}
+
+// Test Line primitive topology
+TEST_P(PrimitiveTopologyTest, Line) {
+    DoTest(nxt::PrimitiveTopology::Line, {
+        // Check that lines are drawn
+        TestPoints(kLineTestLocations, true),
+
+        // Check that line strip and triangle locations are untouched
+        TestPoints(kLineStripTestLocations, false),
+        TestPoints(kTriangleTestLocations, false),
+        TestPoints(kTriangleStripTestLocations, false),
+    });
+}
+
+// Test LineStrip primitive topology
+TEST_P(PrimitiveTopologyTest, LineStrip) {
+    DoTest(nxt::PrimitiveTopology::LineStrip, {
+        // Check that lines are drawn
+        TestPoints(kLineTestLocations, true),
+        TestPoints(kLineStripTestLocations, true),
+
+        // Check that triangle locations are untouched
+        TestPoints(kTriangleTestLocations, false),
+        TestPoints(kTriangleStripTestLocations, false),
+    });
+}
+
+// Test Triangle primitive topology
+TEST_P(PrimitiveTopologyTest, Triangle) {
+    DoTest(nxt::PrimitiveTopology::Triangle, {
+        // Check that triangles are drawn
+        TestPoints(kTriangleTestLocations, true),
+
+        // Check that triangle strip locations are untouched
+        TestPoints(kTriangleStripTestLocations, false),
+    });
+}
+
+// Test TriangleStrip primitive topology
+TEST_P(PrimitiveTopologyTest, TriangleStrip) {
+    DoTest(nxt::PrimitiveTopology::TriangleStrip, {
+        TestPoints(kTriangleTestLocations, true),
+        TestPoints(kTriangleStripTestLocations, true),
+    });
+}
+
+NXT_INSTANTIATE_TEST(PrimitiveTopologyTest, D3D12Backend, MetalBackend)

--- a/src/tests/end2end/PrimitiveTopologyTests.cpp
+++ b/src/tests/end2end/PrimitiveTopologyTests.cpp
@@ -249,8 +249,8 @@ class PrimitiveTopologyTest : public NXTTest {
 };
 
 // Test Point primitive topology
-TEST_P(PrimitiveTopologyTest, Point) {
-    DoTest(nxt::PrimitiveTopology::Point, {
+TEST_P(PrimitiveTopologyTest, PointList) {
+    DoTest(nxt::PrimitiveTopology::PointList, {
         // Check that the points are drawn
         TestPoints(kPointTestLocations, true),
 
@@ -263,8 +263,8 @@ TEST_P(PrimitiveTopologyTest, Point) {
 }
 
 // Test Line primitive topology
-TEST_P(PrimitiveTopologyTest, Line) {
-    DoTest(nxt::PrimitiveTopology::Line, {
+TEST_P(PrimitiveTopologyTest, LineList) {
+    DoTest(nxt::PrimitiveTopology::LineList, {
         // Check that lines are drawn
         TestPoints(kLineTestLocations, true),
 
@@ -289,8 +289,8 @@ TEST_P(PrimitiveTopologyTest, LineStrip) {
 }
 
 // Test Triangle primitive topology
-TEST_P(PrimitiveTopologyTest, Triangle) {
-    DoTest(nxt::PrimitiveTopology::Triangle, {
+TEST_P(PrimitiveTopologyTest, TriangleList) {
+    DoTest(nxt::PrimitiveTopology::TriangleList, {
         // Check that triangles are drawn
         TestPoints(kTriangleTestLocations, true),
 

--- a/src/tests/unittests/validation/RenderPipelineValidationTests.cpp
+++ b/src/tests/unittests/validation/RenderPipelineValidationTests.cpp
@@ -1,0 +1,161 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/unittests/validation/ValidationTest.h"
+
+#include "utils/NXTHelpers.h"
+
+class RenderPipelineValidationTest : public ValidationTest {
+    protected:
+        void SetUp() override {
+            ValidationTest::SetUp();
+
+            utils::CreateDefaultRenderPass(device, &renderpass, &framebuffer);
+
+            pipelineLayout = device.CreatePipelineLayoutBuilder().GetResult();
+
+            inputState = device.CreateInputStateBuilder().GetResult();
+
+            vsModule = utils::CreateShaderModule(device, nxt::ShaderStage::Vertex, R"(
+                #version 450
+                void main() {
+                    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+                })"
+            );
+
+            fsModule = utils::CreateShaderModule(device, nxt::ShaderStage::Fragment, R"(
+                #version 450
+                out vec4 fragColor;
+                void main() {
+                    fragColor = vec4(0.0, 1.0, 0.0, 1.0);
+                })"
+            );
+        }
+
+        nxt::RenderPipelineBuilder& AddDefaultStates(nxt::RenderPipelineBuilder&& builder) {
+            builder.SetSubpass(renderpass, 0)
+                .SetLayout(pipelineLayout)
+                .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
+                .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
+                .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle);
+            return builder;
+        }
+
+        nxt::RenderPass renderpass;
+        nxt::Framebuffer framebuffer;
+        nxt::ShaderModule vsModule;
+        nxt::ShaderModule fsModule;
+        nxt::InputState inputState;
+        nxt::PipelineLayout pipelineLayout;
+};
+
+// Test cases where creation should succeed
+TEST_F(RenderPipelineValidationTest, CreationSuccess) {
+    AddDefaultStates(AssertWillBeSuccess(device.CreateRenderPipelineBuilder()))
+        .GetResult();
+}
+
+// Test creation failure when properties are missing
+TEST_F(RenderPipelineValidationTest, CreationMissingProperty) {
+    // Vertex stage not set
+    {
+        AssertWillBeError(device.CreateRenderPipelineBuilder())
+            .SetSubpass(renderpass, 0)
+            .SetLayout(pipelineLayout)
+            .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .GetResult();
+    }
+
+    // Fragment stage not set
+    {
+        AssertWillBeError(device.CreateRenderPipelineBuilder())
+            .SetSubpass(renderpass, 0)
+            .SetLayout(pipelineLayout)
+            .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .GetResult();
+    }
+
+    // Subpass not set
+    {
+        AssertWillBeError(device.CreateRenderPipelineBuilder())
+            .SetLayout(pipelineLayout)
+            .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
+            .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .GetResult();
+    }
+}
+
+// TODO(enga@google.com): These should be added to the test above when validation is implemented
+TEST_F(RenderPipelineValidationTest, DISABLED_TodoCreationMissingProperty) {
+    // Fails because pipeline layout is not set
+    {
+        AssertWillBeError(device.CreateRenderPipelineBuilder())
+            .SetSubpass(renderpass, 0)
+            .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
+            .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .GetResult();
+    }
+
+    // Fails because primitive topology is not set
+    {
+        AssertWillBeError(device.CreateRenderPipelineBuilder())
+            .SetSubpass(renderpass, 0)
+            .SetLayout(pipelineLayout)
+            .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
+            .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
+            .GetResult();
+    }
+}
+
+// Test creation failure when specifying properties multiple times
+TEST_F(RenderPipelineValidationTest, DISABLED_CreationDuplicates) {
+    // Fails because input state is set twice
+    {
+        AddDefaultStates(AssertWillBeError(device.CreateRenderPipelineBuilder()))
+            .SetInputState(inputState)
+            .GetResult();
+    }
+
+    // Fails because primitive topology is set twice
+    {
+        AddDefaultStates(AssertWillBeError(device.CreateRenderPipelineBuilder()))
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .GetResult();
+    }
+
+    // Fails because vertex stage is set twice
+    {
+        AddDefaultStates(AssertWillBeError(device.CreateRenderPipelineBuilder()))
+            .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
+            .GetResult();
+    }
+
+    // Fails because fragment stage is set twice
+    {
+        AddDefaultStates(AssertWillBeError(device.CreateRenderPipelineBuilder()))
+            .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
+            .GetResult();
+    }
+
+    // Fails because subpass is set twice
+    {
+        AddDefaultStates(AssertWillBeError(device.CreateRenderPipelineBuilder()))
+            .SetSubpass(renderpass, 0)
+            .GetResult();
+    }
+}

--- a/src/tests/unittests/validation/RenderPipelineValidationTests.cpp
+++ b/src/tests/unittests/validation/RenderPipelineValidationTests.cpp
@@ -48,7 +48,7 @@ class RenderPipelineValidationTest : public ValidationTest {
                 .SetLayout(pipelineLayout)
                 .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
                 .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
-                .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle);
+                .SetPrimitiveTopology(nxt::PrimitiveTopology::TriangleList);
             return builder;
         }
 
@@ -74,7 +74,7 @@ TEST_F(RenderPipelineValidationTest, CreationMissingProperty) {
             .SetSubpass(renderpass, 0)
             .SetLayout(pipelineLayout)
             .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
-            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::TriangleList)
             .GetResult();
     }
 
@@ -84,7 +84,7 @@ TEST_F(RenderPipelineValidationTest, CreationMissingProperty) {
             .SetSubpass(renderpass, 0)
             .SetLayout(pipelineLayout)
             .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
-            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::TriangleList)
             .GetResult();
     }
 
@@ -94,7 +94,7 @@ TEST_F(RenderPipelineValidationTest, CreationMissingProperty) {
             .SetLayout(pipelineLayout)
             .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
             .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
-            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::TriangleList)
             .GetResult();
     }
 }
@@ -107,7 +107,7 @@ TEST_F(RenderPipelineValidationTest, DISABLED_TodoCreationMissingProperty) {
             .SetSubpass(renderpass, 0)
             .SetStage(nxt::ShaderStage::Vertex, vsModule, "main")
             .SetStage(nxt::ShaderStage::Fragment, fsModule, "main")
-            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::TriangleList)
             .GetResult();
     }
 
@@ -134,7 +134,7 @@ TEST_F(RenderPipelineValidationTest, DISABLED_CreationDuplicates) {
     // Fails because primitive topology is set twice
     {
         AddDefaultStates(AssertWillBeError(device.CreateRenderPipelineBuilder()))
-            .SetPrimitiveTopology(nxt::PrimitiveTopology::Triangle)
+            .SetPrimitiveTopology(nxt::PrimitiveTopology::TriangleList)
             .GetResult();
     }
 


### PR DESCRIPTION
Can someone test this on Metal? Not sure they have the same point/line/triangle rasterization rules.
This also alphabetizes some stuff for the RenderPipeline