### PR TITLE
D3D12: Improve live object reporting and actually clean up resources

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -197,11 +197,16 @@ if (NXT_ENABLE_D3D12)
     find_library(DXGI_LIBRARY NAMES dxgi.lib HINTS ${WIN10_SDK_LIB_PATH})
     find_library(D3DCOMPILER_LIBRARY NAMES d3dcompiler.lib HINTS ${WIN10_SDK_LIB_PATH})
 
-    set(D3D12_LIBRARIES
+    list(APPEND D3D12_LIBRARIES
         ${D3D12_LIBRARY}
         ${DXGI_LIBRARY}
         ${D3DCOMPILER_LIBRARY}
     )
+
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        find_library(DXGUID_LIBRARY NAMES dxguid.lib HINTS ${WIN10_SDK_LIB_PATH})
+        list(APPEND D3D12_LIBRARIES ${DXGUID_LIBRARY})
+    endif()
 
     target_link_libraries(d3d12_autogen glfw nxtcpp ${D3D12_LIBRARIES})
     target_include_directories(d3d12_autogen SYSTEM PRIVATE ${D3D12_INCLUDE_DIR} ${DXGI_INCLUDE_DIR})

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -104,10 +104,15 @@ namespace d3d12 {
     }
 
     Device::~Device() {
-        // Wait for all in-flight commands to finish exeuting
         const uint64_t currentSerial = GetSerial();
         NextSerial();
-        WaitForSerial(currentSerial);
+        WaitForSerial(currentSerial); // Wait for all in-flight commands to finish executing
+        TickImpl(); // Call tick one last time so resources are cleaned up
+        delete commandAllocatorManager;
+        delete descriptorHeapAllocator;
+        delete mapReadRequestTracker;
+        delete resourceAllocator;
+        delete resourceUploader;
     }
 
     ComPtr<ID3D12Device> Device::GetD3D12Device() {

--- a/src/utils/D3D12Binding.cpp
+++ b/src/utils/D3D12Binding.cpp
@@ -24,6 +24,9 @@
 #include <wrl.h>
 #include <d3d12.h>
 #include <dxgi1_4.h>
+#ifdef _DEBUG
+#include <dxgidebug.h>
+#endif
 
 using Microsoft::WRL::ComPtr;
 
@@ -55,12 +58,16 @@ namespace utils {
                 // NOTE: Enabling the debug layer after device creation will invalidate the active device.
                 {
                     ComPtr<ID3D12Debug> debugController;
-                    if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
-                    {
+                    if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController)))) {
                         debugController->EnableDebugLayer();
 
                         // Enable additional debug layers.
                         dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+                    }
+
+                    ComPtr<IDXGIDebug1> dxgiDebug;
+                    if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiDebug)))) {
+                        dxgiDebug->ReportLiveObjects(DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_FLAGS(DXGI_DEBUG_RLO_ALL));
                     }
                 }
 #endif


### PR DESCRIPTION
This adds better live object reporting in debug mode and fixes a bunch of memory leaks which were happening because I never properly deleted things. Now there are no longer 927 live objects after running the end2end tests :P

I think there are still a couple problems though. It's reporting a ID3D12RootSignature as live when some of the tests exit.