### PR TITLE
Add RGBA8Uint texture format

### DIFF
--- a/next.json
+++ b/next.json
@@ -1183,7 +1183,8 @@
         "category": "enum",
         "values": [
             {"value": 0, "name": "r8 g8 b8 a8 unorm"},
-            {"value": 1, "name": "d32 float s8 uint"}
+            {"value": 1, "name": "r8 g8 b8 a8 uint"},
+            {"value": 2, "name": "d32 float s8 uint"}
         ]
     },
     "vertex format": {

--- a/src/backend/Texture.cpp
+++ b/src/backend/Texture.cpp
@@ -22,6 +22,7 @@ namespace backend {
     uint32_t TextureFormatPixelSize(nxt::TextureFormat format) {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
+            case nxt::TextureFormat::R8G8B8A8Uint:
                 return 4;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return 8;
@@ -33,6 +34,7 @@ namespace backend {
     bool TextureFormatHasDepth(nxt::TextureFormat format) {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
+            case nxt::TextureFormat::R8G8B8A8Uint:
                 return false;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return true;
@@ -44,6 +46,7 @@ namespace backend {
     bool TextureFormatHasStencil(nxt::TextureFormat format) {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
+            case nxt::TextureFormat::R8G8B8A8Uint:
                 return false;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return true;

--- a/src/backend/d3d12/TextureD3D12.cpp
+++ b/src/backend/d3d12/TextureD3D12.cpp
@@ -81,6 +81,8 @@ namespace d3d12 {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
                 return DXGI_FORMAT_R8G8B8A8_UNORM;
+            case nxt::TextureFormat::R8G8B8A8Uint:
+                return DXGI_FORMAT_R8G8B8A8_UINT;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
             default:

--- a/src/backend/metal/TextureMTL.mm
+++ b/src/backend/metal/TextureMTL.mm
@@ -23,6 +23,8 @@ namespace metal {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
                 return MTLPixelFormatRGBA8Unorm;
+            case nxt::TextureFormat::R8G8B8A8Uint:
+                return MTLPixelFormatRGBA8Uint;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return MTLPixelFormatDepth32Float_Stencil8;
         }


### PR DESCRIPTION
Adds support for RGBA8 integer textures. This is useful for packing data in a g-buffer without risking loss of precision when outputting floats in a fragment shader.