### PR TITLE
Configure texture usage for Swap Chains

### DIFF
--- a/examples/Animometer.cpp
+++ b/examples/Animometer.cpp
@@ -49,7 +49,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     nxt::ShaderModule vsModule = utils::CreateShaderModule(device, nxt::ShaderStage::Vertex, R"(
         #version 450

--- a/examples/Animometer.cpp
+++ b/examples/Animometer.cpp
@@ -49,7 +49,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     nxt::ShaderModule vsModule = utils::CreateShaderModule(device, nxt::ShaderStage::Vertex, R"(
         #version 450

--- a/examples/CHelloTriangle.cpp
+++ b/examples/CHelloTriangle.cpp
@@ -39,7 +39,7 @@ void init() {
         swapchain = nxtSwapChainBuilderGetResult(builder);
         nxtSwapChainBuilderRelease(builder);
     }
-    nxtSwapChainConfigure(swapchain, NXT_TEXTURE_FORMAT_R8_G8_B8_A8_UNORM, 640, 480);
+    nxtSwapChainConfigure(swapchain, NXT_TEXTURE_FORMAT_R8_G8_B8_A8_UNORM, static_cast<nxtTextureUsageBit>(NXT_TEXTURE_USAGE_BIT_OUTPUT_ATTACHMENT | NXT_TEXTURE_USAGE_BIT_PRESENT), NXT_TEXTURE_USAGE_BIT_OUTPUT_ATTACHMENT, 640, 480);
 
     const char* vs =
         "#version 450\n"

--- a/examples/CHelloTriangle.cpp
+++ b/examples/CHelloTriangle.cpp
@@ -39,7 +39,7 @@ void init() {
         swapchain = nxtSwapChainBuilderGetResult(builder);
         nxtSwapChainBuilderRelease(builder);
     }
-    nxtSwapChainConfigure(swapchain, NXT_TEXTURE_FORMAT_R8_G8_B8_A8_UNORM, static_cast<nxtTextureUsageBit>(NXT_TEXTURE_USAGE_BIT_OUTPUT_ATTACHMENT | NXT_TEXTURE_USAGE_BIT_PRESENT), NXT_TEXTURE_USAGE_BIT_OUTPUT_ATTACHMENT, 640, 480);
+    nxtSwapChainConfigure(swapchain, NXT_TEXTURE_FORMAT_R8_G8_B8_A8_UNORM, NXT_TEXTURE_USAGE_BIT_OUTPUT_ATTACHMENT, NXT_TEXTURE_USAGE_BIT_OUTPUT_ATTACHMENT, 640, 480);
 
     const char* vs =
         "#version 450\n"

--- a/examples/ComputeBoids.cpp
+++ b/examples/ComputeBoids.cpp
@@ -291,7 +291,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
     initRender();

--- a/examples/ComputeBoids.cpp
+++ b/examples/ComputeBoids.cpp
@@ -291,7 +291,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
     initRender();

--- a/examples/HelloCompute.cpp
+++ b/examples/HelloCompute.cpp
@@ -35,7 +35,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     struct {uint32_t a; float b;} s;
     memset(&s, 0, sizeof(s));

--- a/examples/HelloCompute.cpp
+++ b/examples/HelloCompute.cpp
@@ -35,7 +35,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     struct {uint32_t a; float b;} s;
     memset(&s, 0, sizeof(s));

--- a/examples/HelloDepthStencil.cpp
+++ b/examples/HelloDepthStencil.cpp
@@ -116,7 +116,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
 

--- a/examples/HelloDepthStencil.cpp
+++ b/examples/HelloDepthStencil.cpp
@@ -116,7 +116,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
 

--- a/examples/HelloIndices.cpp
+++ b/examples/HelloIndices.cpp
@@ -49,7 +49,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
 

--- a/examples/HelloIndices.cpp
+++ b/examples/HelloIndices.cpp
@@ -49,7 +49,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
 

--- a/examples/HelloInstancing.cpp
+++ b/examples/HelloInstancing.cpp
@@ -52,7 +52,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
 

--- a/examples/HelloInstancing.cpp
+++ b/examples/HelloInstancing.cpp
@@ -52,7 +52,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
 

--- a/examples/HelloTriangle.cpp
+++ b/examples/HelloTriangle.cpp
@@ -83,7 +83,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
     initTextures();

--- a/examples/HelloTriangle.cpp
+++ b/examples/HelloTriangle.cpp
@@ -83,7 +83,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
     initTextures();

--- a/examples/HelloUBO.cpp
+++ b/examples/HelloUBO.cpp
@@ -33,7 +33,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     nxt::ShaderModule vsModule = utils::CreateShaderModule(device, nxt::ShaderStage::Vertex, R"(
         #version 450

--- a/examples/HelloUBO.cpp
+++ b/examples/HelloUBO.cpp
@@ -33,7 +33,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     nxt::ShaderModule vsModule = utils::CreateShaderModule(device, nxt::ShaderStage::Vertex, R"(
         #version 450

--- a/examples/HelloVertices.cpp
+++ b/examples/HelloVertices.cpp
@@ -43,7 +43,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
 

--- a/examples/HelloVertices.cpp
+++ b/examples/HelloVertices.cpp
@@ -43,7 +43,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
 

--- a/examples/RenderToTexture.cpp
+++ b/examples/RenderToTexture.cpp
@@ -167,7 +167,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
     initTextures();

--- a/examples/RenderToTexture.cpp
+++ b/examples/RenderToTexture.cpp
@@ -167,7 +167,7 @@ void init() {
 
     queue = device.CreateQueueBuilder().GetResult();
     swapchain = GetSwapChain(device);
-    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+    swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
     initBuffers();
     initTextures();

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -464,7 +464,7 @@ namespace {
 
         queue = device.CreateQueueBuilder().GetResult();
         swapchain = GetSwapChain(device);
-        swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, 640, 480);
+        swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
         renderpass = CreateDefaultRenderPass(device);
         depthStencilView = CreateDefaultDepthStencilView(device);

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -464,7 +464,7 @@ namespace {
 
         queue = device.CreateQueueBuilder().GetResult();
         swapchain = GetSwapChain(device);
-        swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present, nxt::TextureUsageBit::OutputAttachment, 640, 480);
+        swapchain.Configure(nxt::TextureFormat::R8G8B8A8Unorm, nxt::TextureUsageBit::OutputAttachment, nxt::TextureUsageBit::OutputAttachment, 640, 480);
 
         renderpass = CreateDefaultRenderPass(device);
         depthStencilView = CreateDefaultDepthStencilView(device);

--- a/next.json
+++ b/next.json
@@ -1050,6 +1050,8 @@
                 "name": "configure",
                 "args": [
                     {"name": "format", "type": "texture format"},
+                    {"name": "allowedUsage", "type": "texture usage bit"},
+                    {"name": "initialUsage", "type": "texture usage bit"},
                     {"name": "width", "type": "uint32_t"},
                     {"name": "height", "type": "uint32_t"}
                 ]

--- a/src/backend/SwapChain.cpp
+++ b/src/backend/SwapChain.cpp
@@ -39,6 +39,7 @@ namespace backend {
             device->HandleError("Swap chain cannot be configured to zero size");
             return;
         }
+        allowedUsage |= nxt::TextureUsageBit::Present;
         if (!(HasZeroOrOneBits(initialUsage) && (initialUsage & allowedUsage))) {
             device->HandleError("Swap chain configured with invalid texture usage");
             return;

--- a/src/backend/SwapChain.cpp
+++ b/src/backend/SwapChain.cpp
@@ -34,17 +34,23 @@ namespace backend {
         return device;
     }
 
-    void SwapChainBase::Configure(nxt::TextureFormat format, uint32_t width, uint32_t height) {
+    void SwapChainBase::Configure(nxt::TextureFormat format, nxt::TextureUsageBit allowedUsage, nxt::TextureUsageBit initialUsage, uint32_t width, uint32_t height) {
         if (width == 0 || height == 0) {
             device->HandleError("Swap chain cannot be configured to zero size");
             return;
         }
+        if (!(HasZeroOrOneBits(initialUsage) && (initialUsage & allowedUsage))) {
+            device->HandleError("Swap chain configured with invalid texture usage");
+            return;
+        }
 
         this->format = format;
+        this->allowedUsage = allowedUsage;
+        this->initialUsage = initialUsage;
         this->width = width;
         this->height = height;
         implementation.Configure(implementation.userData,
-                static_cast<nxtTextureFormat>(format), width, height);
+                static_cast<nxtTextureFormat>(format), static_cast<nxtTextureUsageBit>(allowedUsage), static_cast<nxtTextureUsageBit>(initialUsage), width, height);
     }
 
     TextureBase* SwapChainBase::GetNextTexture() {
@@ -59,8 +65,8 @@ namespace backend {
         builder->SetExtent(width, height, 1);
         builder->SetFormat(format);
         builder->SetMipLevels(1);
-        builder->SetAllowedUsage(nxt::TextureUsageBit::OutputAttachment | nxt::TextureUsageBit::Present);
-        builder->SetInitialUsage(nxt::TextureUsageBit::OutputAttachment);
+        builder->SetAllowedUsage(allowedUsage);
+        builder->SetInitialUsage(initialUsage);
 
         auto* texture = GetNextTextureImpl(builder);
         lastNextTexture = texture;

--- a/src/backend/SwapChain.h
+++ b/src/backend/SwapChain.h
@@ -32,7 +32,7 @@ namespace backend {
             DeviceBase* GetDevice();
 
             // NXT API
-            void Configure(nxt::TextureFormat format, uint32_t width, uint32_t height);
+            void Configure(nxt::TextureFormat format, nxt::TextureUsageBit allowedUsage, nxt::TextureUsageBit initialUsage, uint32_t width, uint32_t height);
             TextureBase* GetNextTexture();
             void Present(TextureBase* texture);
 
@@ -44,6 +44,8 @@ namespace backend {
             DeviceBase* device = nullptr;
             nxtSwapChainImplementation implementation = {};
             nxt::TextureFormat format = {};
+            nxt::TextureUsageBit allowedUsage;
+            nxt::TextureUsageBit initialUsage;
             uint32_t width = 0;
             uint32_t height = 0;
             TextureBase* lastNextTexture = nullptr;

--- a/src/backend/Texture.cpp
+++ b/src/backend/Texture.cpp
@@ -58,6 +58,7 @@ namespace backend {
     bool TextureFormatHasDepthOrStencil(nxt::TextureFormat format) {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
+            case nxt::TextureFormat::R8G8B8A8Uint:
                 return false;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return true;

--- a/src/backend/opengl/TextureGL.cpp
+++ b/src/backend/opengl/TextureGL.cpp
@@ -37,6 +37,8 @@ namespace opengl {
             switch (format) {
                 case nxt::TextureFormat::R8G8B8A8Unorm:
                     return {GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE};
+                case nxt::TextureFormat::R8G8B8A8Uint:
+                    return { GL_RGBA8UI, GL_RGBA, GL_UNSIGNED_INT };
                 case nxt::TextureFormat::D32FloatS8Uint:
                     return {GL_DEPTH32F_STENCIL8, GL_DEPTH_STENCIL, GL_FLOAT_32_UNSIGNED_INT_24_8_REV};
                 default:

--- a/src/include/nxt/nxt_wsi.h
+++ b/src/include/nxt/nxt_wsi.h
@@ -35,7 +35,7 @@ typedef struct {
     void (*Destroy)(void* userData);
 
     /// Configure/reconfigure the swap chain.
-    nxtSwapChainError (*Configure)(void* userData, nxtTextureFormat format, uint32_t width, uint32_t height);
+    nxtSwapChainError (*Configure)(void* userData, nxtTextureFormat format, nxtTextureUsageBit allowedUsage, nxtTextureUsageBit initialUsage, uint32_t width, uint32_t height);
 
     /// Acquire the next texture from the swap chain.
     nxtSwapChainError (*GetNextTexture)(void* userData, nxtSwapChainNextTexture* nextTexture);

--- a/src/utils/MetalBinding.mm
+++ b/src/utils/MetalBinding.mm
@@ -68,7 +68,7 @@ namespace utils {
                 commandQueue = [mtlDevice newCommandQueue];
             }
 
-            nxtSwapChainError Configure(nxtTextureFormat format,
+            nxtSwapChainError Configure(nxtTextureFormat format, nxtTextureUsageBit, nxtTextureUsageBit,
                     uint32_t width, uint32_t height) {
                 if (format != NXT_TEXTURE_FORMAT_R8_G8_B8_A8_UNORM) {
                     return "unsupported format";

--- a/src/utils/OpenGLBinding.cpp
+++ b/src/utils/OpenGLBinding.cpp
@@ -69,7 +69,7 @@ namespace utils {
                         GL_TEXTURE_2D, backTexture, 0);
             }
 
-            nxtSwapChainError Configure(nxtTextureFormat format,
+            nxtSwapChainError Configure(nxtTextureFormat format, nxtTextureUsageBit, nxtTextureUsageBit,
                     uint32_t width, uint32_t height) {
                 if (format != NXT_TEXTURE_FORMAT_R8_G8_B8_A8_UNORM) {
                     return "unsupported format";

--- a/src/utils/SwapChainImpl.h
+++ b/src/utils/SwapChainImpl.h
@@ -28,9 +28,9 @@ namespace utils {
                 impl.Destroy = [](void* userData) {
                     delete reinterpret_cast<TImpl*>(userData);
                 };
-                impl.Configure = [](void* userData, nxtTextureFormat format, uint32_t width, uint32_t height) {
+                impl.Configure = [](void* userData, nxtTextureFormat format, nxtTextureUsageBit allowedUsage, nxtTextureUsageBit initialUsage, uint32_t width, uint32_t height) {
                     return reinterpret_cast<TImpl*>(userData)->Configure(
-                        format, width, height);
+                        format, allowedUsage, initialUsage, width, height);
                 };
                 impl.GetNextTexture = [](void* userData, nxtSwapChainNextTexture* nextTexture) {
                     return reinterpret_cast<TImpl*>(userData)->GetNextTexture(


### PR DESCRIPTION
Right now configuring initial / allowed usage only affects the D3D12 binding. Not sure if anything needs to change for Metal.