### PR TITLE
Change SetPipelineCommon to return void

### DIFF
--- a/src/backend/CommandBufferStateTracker.cpp
+++ b/src/backend/CommandBufferStateTracker.cpp
@@ -290,8 +290,10 @@ namespace backend {
             builder->HandleError("Can't use a compute pipeline while a render pass is active");
             return false;
         }
+
         aspects.set(VALIDATION_ASPECT_COMPUTE_PIPELINE);
-        return SetPipelineCommon(pipeline);
+        SetPipelineCommon(pipeline);
+        return true;
     }
 
     bool CommandBufferStateTracker::SetRenderPipeline(RenderPipelineBase* pipeline) {
@@ -303,10 +305,11 @@ namespace backend {
             builder->HandleError("Pipeline is incompatible with this render pass");
             return false;
         }
+
         aspects.set(VALIDATION_ASPECT_RENDER_PIPELINE);
         lastRenderPipeline = pipeline;
-
-        return SetPipelineCommon(pipeline);
+        SetPipelineCommon(pipeline);
+        return true;
     }
 
     bool CommandBufferStateTracker::SetBindGroup(uint32_t index, BindGroupBase* bindgroup) {
@@ -542,7 +545,7 @@ namespace backend {
         return true;
     }
 
-    bool CommandBufferStateTracker::SetPipelineCommon(PipelineBase* pipeline) {
+    void CommandBufferStateTracker::SetPipelineCommon(PipelineBase* pipeline) {
         PipelineLayoutBase* layout = pipeline->GetLayout();
 
         aspects.reset(VALIDATION_ASPECT_BIND_GROUPS);
@@ -556,7 +559,6 @@ namespace backend {
         }
 
         lastPipeline = pipeline;
-        return true;
     }
 
     void CommandBufferStateTracker::UnsetPipeline() {

--- a/src/backend/CommandBufferStateTracker.h
+++ b/src/backend/CommandBufferStateTracker.h
@@ -91,7 +91,7 @@ namespace backend {
             bool ValidateBindGroupUsages(BindGroupBase* group) const;
             bool RevalidateCanDraw();
 
-            bool SetPipelineCommon(PipelineBase* pipeline);
+            void SetPipelineCommon(PipelineBase* pipeline);
             void UnsetPipeline();
 
             CommandBufferBuilder* builder;


### PR DESCRIPTION
This is to avoid a potential future problem if SetPipelineCommon were to
ever return false (which is currently not possible), some state might
have been modified incorrectly.