### PR TITLE
OpenGL: Fix rendered textures being flipped.

### DIFF
--- a/src/backend/d3d12/ShaderModuleD3D12.cpp
+++ b/src/backend/d3d12/ShaderModuleD3D12.cpp
@@ -23,12 +23,14 @@ namespace d3d12 {
         : ShaderModuleBase(builder), device(device) {
         spirv_cross::CompilerHLSL compiler(builder->AcquireSpirv());
 
-        spirv_cross::CompilerHLSL::Options options;
-        options.shader_model = 51;
-        options.flip_vert_y = false;
-        options.fixup_clipspace = true;
+        spirv_cross::CompilerGLSL::Options options_glsl;
+        options_glsl.vertex.flip_vert_y = false;
+        options_glsl.vertex.fixup_clipspace = true;
+        compiler.spirv_cross::CompilerGLSL::set_options(options_glsl);
 
-        compiler.set_options(options);
+        spirv_cross::CompilerHLSL::Options options_hlsl;
+        options_hlsl.shader_model = 51;
+        compiler.spirv_cross::CompilerHLSL::set_options(options_hlsl);
 
         ExtractSpirvInfo(compiler);
 

--- a/src/backend/opengl/ShaderModuleGL.cpp
+++ b/src/backend/opengl/ShaderModuleGL.cpp
@@ -57,6 +57,7 @@ namespace opengl {
 #else
         options.version = 440;
 #endif
+        options.vertex.flip_vert_y = true;
         compiler.set_options(options);
 
         // Rename the push constant block to be prefixed with the shader stage type so that uniform names

--- a/src/tests/end2end/InputStateTests.cpp
+++ b/src/tests/end2end/InputStateTests.cpp
@@ -439,7 +439,7 @@ TEST_P(InputStateTest, MixedEverything) {
     DoTestDraw(pipeline, 1, 1, {{0, &buffer0}, {1, &buffer1}});
 }
 
-NXT_INSTANTIATE_TEST(InputStateTest, D3D12Backend, MetalBackend)
+NXT_INSTANTIATE_TEST(InputStateTest, D3D12Backend, MetalBackend, OpenGLBackend)
 
 // TODO for the input state:
 //  - Add more vertex formats

--- a/src/tests/end2end/PrimitiveTopologyTests.cpp
+++ b/src/tests/end2end/PrimitiveTopologyTests.cpp
@@ -308,4 +308,4 @@ TEST_P(PrimitiveTopologyTest, TriangleStrip) {
     });
 }
 
-NXT_INSTANTIATE_TEST(PrimitiveTopologyTest, D3D12Backend, MetalBackend)
+NXT_INSTANTIATE_TEST(PrimitiveTopologyTest, D3D12Backend, MetalBackend, OpenGLBackend)


### PR DESCRIPTION
This was because the clip space of OpenGL has an inverted Y compared to
other APIs. This commit:
 - Updates SPIRV-Cross to the latest version
 - Uses the new vertex.flip_vert_y option in ShaderModuleGL
 - Enables tests that are now passing in GL.