### PR TITLE
Vulkan: hack SetSubData and MapRead

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -289,6 +289,10 @@ if (NXT_ENABLE_VULKAN)
 
     list(APPEND BACKEND_SOURCES
         ${VULKAN_DIR}/vulkan_platform.h
+        ${VULKAN_DIR}/BufferVk.cpp
+        ${VULKAN_DIR}/BufferVk.h
+        ${VULKAN_DIR}/MemoryAllocator.cpp
+        ${VULKAN_DIR}/MemoryAllocator.h
         ${VULKAN_DIR}/VulkanBackend.cpp
         ${VULKAN_DIR}/VulkanBackend.h
         ${VULKAN_DIR}/VulkanFunctions.cpp

--- a/src/backend/RefCounted.h
+++ b/src/backend/RefCounted.h
@@ -48,7 +48,7 @@ namespace backend {
                 Reference();
             }
 
-            Ref(Ref<T>& other): pointee(other.pointee) {
+            Ref(const Ref<T>& other): pointee(other.pointee) {
                 Reference();
             }
             Ref<T>& operator=(const Ref<T>& other) {

--- a/src/backend/d3d12/BufferD3D12.cpp
+++ b/src/backend/d3d12/BufferD3D12.cpp
@@ -172,7 +172,6 @@ namespace d3d12 {
         }
     }
 
-
     BufferView::BufferView(BufferViewBuilder* builder)
         : BufferViewBase(builder) {
 

--- a/src/backend/vulkan/BufferVk.cpp
+++ b/src/backend/vulkan/BufferVk.cpp
@@ -1,0 +1,148 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "backend/vulkan/BufferVk.h"
+#include "backend/vulkan/VulkanBackend.h"
+
+#include <cstring>
+
+namespace backend {
+namespace vulkan {
+
+    namespace {
+
+        VkBufferUsageFlags VulkanBufferUsage(nxt::BufferUsageBit usage) {
+            VkBufferUsageFlags flags = 0;
+
+            if (usage & nxt::BufferUsageBit::TransferSrc) {
+                flags |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+            }
+            if (usage & nxt::BufferUsageBit::TransferDst) {
+                flags |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+            }
+            if (usage & nxt::BufferUsageBit::Index) {
+                flags |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+            }
+            if (usage & nxt::BufferUsageBit::Vertex) {
+                flags |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+            }
+            if (usage & nxt::BufferUsageBit::Uniform) {
+                flags |= VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+            }
+            if (usage & nxt::BufferUsageBit::Storage) {
+                flags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+            }
+
+            return flags;
+        }
+
+    }
+
+    Buffer::Buffer(BufferBuilder* builder)
+        : BufferBase(builder) {
+        Device* device = ToBackend(GetDevice());
+
+        VkBufferCreateInfo createInfo;
+        createInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        createInfo.pNext = nullptr;
+        createInfo.flags = 0;
+        createInfo.size = GetSize();
+        createInfo.usage = VulkanBufferUsage(GetAllowedUsage());
+        createInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        createInfo.queueFamilyIndexCount = 0;
+        createInfo.pQueueFamilyIndices = 0;
+
+        if (device->fn.CreateBuffer(device->GetVkDevice(), &createInfo, nullptr, &handle) != VK_SUCCESS) {
+            ASSERT(false);
+        }
+
+        VkMemoryRequirements requirements;
+        device->fn.GetBufferMemoryRequirements(device->GetVkDevice(), handle, &requirements);
+
+        bool requestMappable = (GetAllowedUsage() & (nxt::BufferUsageBit::MapRead | nxt::BufferUsageBit::MapWrite)) != 0;
+        if (!device->GetMemoryAllocator()->Allocate(requirements, requestMappable, &memoryAllocation)) {
+            ASSERT(false);
+        }
+
+        if (device->fn.BindBufferMemory(device->GetVkDevice(), handle, memoryAllocation.GetMemory(),
+                                        memoryAllocation.GetMemoryOffset()) != VK_SUCCESS) {
+            ASSERT(false);
+        }
+    }
+
+    Buffer::~Buffer() {
+        Device* device = ToBackend(GetDevice());
+
+        device->GetMemoryAllocator()->Free(&memoryAllocation);
+
+        if (handle != VK_NULL_HANDLE) {
+            device->fn.DestroyBuffer(device->GetVkDevice(), handle, nullptr);
+            handle = VK_NULL_HANDLE;
+        }
+    }
+
+    void Buffer::OnMapReadCommandSerialFinished(uint32_t mapSerial, const void* data) {
+        CallMapReadCallback(mapSerial, NXT_BUFFER_MAP_READ_STATUS_SUCCESS, data);
+    }
+
+    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
+        // TODO(cwallez@chromium.org): Make a proper resource uploader. Not all resources
+        // can be directly mapped.
+        uint8_t* memory = memoryAllocation.GetMappedPointer();
+        ASSERT(memory != nullptr);
+
+        memcpy(memory + start * sizeof(uint32_t), data, count * sizeof(uint32_t));
+    }
+
+    void Buffer::MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t /*count*/) {
+        const uint8_t* memory = memoryAllocation.GetMappedPointer();
+        ASSERT(memory != nullptr);
+
+        MapReadRequestTracker* tracker = ToBackend(GetDevice())->GetMapReadRequestTracker();
+        tracker->Track(this, serial, memory + start);
+    }
+
+    void Buffer::UnmapImpl() {
+        // No need to do anything, we keep CPU-visible memory mapped at all time.
+    }
+
+    void Buffer::TransitionUsageImpl(nxt::BufferUsageBit, nxt::BufferUsageBit) {
+    }
+
+    MapReadRequestTracker::MapReadRequestTracker(Device* device)
+        : device(device) {
+    }
+
+    MapReadRequestTracker::~MapReadRequestTracker() {
+        ASSERT(inflightRequests.Empty());
+    }
+
+    void MapReadRequestTracker::Track(Buffer* buffer, uint32_t mapSerial, const void* data) {
+        Request request;
+        request.buffer = buffer;
+        request.mapSerial = mapSerial;
+        request.data = data;
+
+        inflightRequests.Enqueue(std::move(request), device->GetSerial());
+    }
+
+    void MapReadRequestTracker::Tick(Serial finishedSerial) {
+        for (auto& request : inflightRequests.IterateUpTo(finishedSerial)) {
+            request.buffer->OnMapReadCommandSerialFinished(request.mapSerial, request.data);
+        }
+        inflightRequests.ClearUpTo(finishedSerial);
+    }
+
+}
+}

--- a/src/backend/vulkan/BufferVk.h
+++ b/src/backend/vulkan/BufferVk.h
@@ -1,0 +1,68 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_VULKAN_BUFFERVK_H_
+#define BACKEND_VULKAN_BUFFERVK_H_
+
+#include "backend/Buffer.h"
+
+#include "backend/vulkan/vulkan_platform.h"
+#include "backend/vulkan/MemoryAllocator.h"
+#include "common/SerialQueue.h"
+
+namespace backend {
+namespace vulkan {
+
+    class Device;
+
+    class Buffer : public BufferBase {
+        public:
+            Buffer(BufferBuilder* builder);
+            ~Buffer();
+
+            void OnMapReadCommandSerialFinished(uint32_t mapSerial, const void* data);
+
+        private:
+            void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
+            void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
+            void UnmapImpl() override;
+            void TransitionUsageImpl(nxt::BufferUsageBit currentUsage, nxt::BufferUsageBit targetUsage) override;
+
+            VkBuffer handle = VK_NULL_HANDLE;
+            DeviceMemoryAllocation memoryAllocation;
+    };
+
+    class MapReadRequestTracker {
+        public:
+            MapReadRequestTracker(Device* device);
+            ~MapReadRequestTracker();
+
+            void Track(Buffer* buffer, uint32_t mapSerial, const void* data);
+            void Tick(Serial finishedSerial);
+
+        private:
+            Device* device;
+
+            struct Request {
+                Ref<Buffer> buffer;
+                uint32_t mapSerial;
+                const void* data;
+            };
+            SerialQueue<Request> inflightRequests;
+    };
+
+}
+}
+
+#endif // BACKEND_VULKAN_BUFFERVK_H_

--- a/src/backend/vulkan/GeneratedCodeIncludes.h
+++ b/src/backend/vulkan/GeneratedCodeIncludes.h
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "backend/vulkan/BufferVk.h"
 #include "backend/vulkan/VulkanBackend.h"

--- a/src/backend/vulkan/MemoryAllocator.cpp
+++ b/src/backend/vulkan/MemoryAllocator.cpp
@@ -1,0 +1,131 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "backend/vulkan/MemoryAllocator.h"
+#include "backend/vulkan/VulkanBackend.h"
+
+namespace backend {
+namespace vulkan {
+
+    DeviceMemoryAllocation::~DeviceMemoryAllocation() {
+        ASSERT(memory == VK_NULL_HANDLE);
+    }
+
+    VkDeviceMemory DeviceMemoryAllocation::GetMemory() const {
+        return memory;
+    }
+
+    size_t DeviceMemoryAllocation::GetMemoryOffset() const {
+        return offset;
+    }
+
+    uint8_t* DeviceMemoryAllocation::GetMappedPointer() const {
+        return mappedPointer;
+    }
+
+    MemoryAllocator::MemoryAllocator(Device* device)
+        :device(device) {
+    }
+
+    MemoryAllocator::~MemoryAllocator() {
+        ASSERT(releasedMemory.Empty());
+    }
+
+    bool MemoryAllocator::Allocate(VkMemoryRequirements requirements, bool mappable, DeviceMemoryAllocation* allocation) {
+        const VulkanDeviceInfo& info = device->GetDeviceInfo();
+
+        // Find a suitable memory type for this allocation
+        int bestType = -1;
+        for (size_t i = 0; i < info.memoryTypes.size(); ++i) {
+            // Resource must support this memory type
+            if ((requirements.memoryTypeBits & (1 << i)) == 0) {
+                continue;
+            }
+
+            // Mappable resource must be host visible
+            if (mappable && (info.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0) {
+                continue;
+            }
+
+            // Found the first candidate memory type
+            if (bestType == -1) {
+                bestType = static_cast<int>(i);
+                continue;
+            }
+
+            // For non-mappable resources, favor device local memory.
+            if (!mappable) {
+                if ((info.memoryTypes[bestType].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) == 0 &&
+                    (info.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0) {
+                    bestType = static_cast<int>(i);
+                    continue;
+                }
+            }
+
+            // All things equal favor the memory in the biggest heap
+            VkDeviceSize bestTypeHeapSize = info.memoryHeaps[info.memoryTypes[bestType].heapIndex].size;
+            VkDeviceSize candidateHeapSize = info.memoryHeaps[info.memoryTypes[bestType].heapIndex].size;
+            if (candidateHeapSize > bestTypeHeapSize) {
+                bestType = static_cast<int>(i);
+                continue;
+            }
+        }
+
+        // TODO(cwallez@chromium.org): I think the Vulkan spec guarantees this should never happen
+        if (bestType == -1) {
+            ASSERT(false);
+            return false;
+        }
+
+        VkMemoryAllocateInfo allocateInfo;
+        allocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        allocateInfo.pNext = nullptr;
+        allocateInfo.allocationSize = requirements.size;
+        allocateInfo.memoryTypeIndex = static_cast<uint32_t>(bestType);
+
+        VkDeviceMemory allocatedMemory = VK_NULL_HANDLE;
+        if (device->fn.AllocateMemory(device->GetVkDevice(), &allocateInfo, nullptr, &allocatedMemory) != VK_SUCCESS) {
+            return false;
+        }
+
+        void* mappedPointer = nullptr;
+        if (mappable) {
+            if (device->fn.MapMemory(device->GetVkDevice(), allocatedMemory, 0, requirements.size, 0,
+                                     &mappedPointer) != VK_SUCCESS) {
+                return false;
+            }
+        }
+
+        allocation->memory = allocatedMemory;
+        allocation->offset = 0;
+        allocation->mappedPointer = reinterpret_cast<uint8_t*>(mappedPointer);
+
+        return true;
+    }
+
+    void MemoryAllocator::Free(DeviceMemoryAllocation* allocation) {
+        releasedMemory.Enqueue(allocation->memory, device->GetSerial());
+        allocation->memory = VK_NULL_HANDLE;
+        allocation->offset = 0;
+        allocation->mappedPointer = nullptr;
+    }
+
+    void MemoryAllocator::Tick(Serial finishedSerial) {
+        for (auto memory : releasedMemory.IterateUpTo(finishedSerial)) {
+            device->fn.FreeMemory(device->GetVkDevice(), memory, nullptr);
+        }
+        releasedMemory.ClearUpTo(finishedSerial);
+    }
+}
+}

--- a/src/backend/vulkan/MemoryAllocator.h
+++ b/src/backend/vulkan/MemoryAllocator.h
@@ -1,0 +1,59 @@
+// Copyright 2017 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_VULKAN_MEMORYALLOCATOR_H_
+#define BACKEND_VULKAN_MEMORYALLOCATOR_H_
+
+#include "backend/vulkan/vulkan_platform.h"
+#include "common/SerialQueue.h"
+
+namespace backend {
+namespace vulkan {
+
+    class Device;
+    class MemoryAllocator;
+
+    class DeviceMemoryAllocation {
+        public:
+            ~DeviceMemoryAllocation();
+            VkDeviceMemory GetMemory() const;
+            size_t GetMemoryOffset() const;
+            uint8_t* GetMappedPointer() const;
+
+        private:
+            friend class MemoryAllocator;
+            VkDeviceMemory memory = VK_NULL_HANDLE;
+            size_t offset = 0;
+            uint8_t* mappedPointer = nullptr;
+    };
+
+    class MemoryAllocator {
+        public:
+            MemoryAllocator(Device* device);
+            ~MemoryAllocator();
+
+            bool Allocate(VkMemoryRequirements requirements, bool mappable, DeviceMemoryAllocation* allocation);
+            void Free(DeviceMemoryAllocation* allocation);
+
+            void Tick(Serial finishedSerial);
+
+        private:
+            Device* device = nullptr;
+            SerialQueue<VkDeviceMemory> releasedMemory;
+    };
+
+}
+}
+
+#endif // BACKEND_VULKAN_MEMORYALLOCATOR_H_

--- a/src/backend/vulkan/VulkanBackend.h
+++ b/src/backend/vulkan/VulkanBackend.h
@@ -121,13 +121,14 @@ namespace vulkan {
 
             // Contains all the Vulkan entry points, vkDoFoo is called via device->fn.DoFoo.
             const VulkanFunctions fn;
-            // All the information queried about this Vulkan system
-            const VulkanInfo info;
+
+            VkInstance GetInstance() const;
 
         private:
-            bool CreateInstance(KnownGlobalVulkanExtensions* usedGlobals);
-            bool RegisterDebugReport();
+            bool CreateInstance(VulkanGlobalKnobs* usedKnobs);
+            bool CreateDevice(VulkanDeviceKnobs* usedKnobs);
 
+            bool RegisterDebugReport();
             static VkBool32 OnDebugReportCallback(VkDebugReportFlagsEXT flags,
                                                   VkDebugReportObjectTypeEXT objectType,
                                                   uint64_t object,
@@ -140,11 +141,16 @@ namespace vulkan {
             // To make it easier to use fn it is a public const member. However
             // the Device is allowed to mutate them through these private methods.
             VulkanFunctions* GetMutableFunctions();
-            VulkanInfo* GetMutableInfo();
+
+            VulkanGlobalInfo globalInfo;
+            VulkanDeviceInfo deviceInfo;
 
             DynamicLib vulkanLib;
 
             VkInstance instance = VK_NULL_HANDLE;
+            VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+            VkDevice vkDevice = VK_NULL_HANDLE;
+            uint32_t queueFamily = 0;
             VkDebugReportCallbackEXT debugReportCallback = VK_NULL_HANDLE;
     };
 

--- a/src/backend/vulkan/VulkanFunctions.cpp
+++ b/src/backend/vulkan/VulkanFunctions.cpp
@@ -32,7 +32,6 @@ namespace vulkan {
         }
 
         GET_GLOBAL_PROC(CreateInstance);
-        GET_GLOBAL_PROC(DestroyInstance);
         GET_GLOBAL_PROC(EnumerateInstanceExtensionProperties);
         GET_GLOBAL_PROC(EnumerateInstanceLayerProperties);
 
@@ -45,12 +44,16 @@ namespace vulkan {
             return false; \
         }
 
-    bool VulkanFunctions::LoadInstanceProcs(VkInstance instance, const KnownGlobalVulkanExtensions& usedGlobals) {
+    bool VulkanFunctions::LoadInstanceProcs(VkInstance instance, const VulkanGlobalKnobs& usedKnobs) {
+        // Load this proc first so that we can destroy the instance even if some other GET_INSTANCE_PROC fails
+        GET_INSTANCE_PROC(DestroyInstance);
+
         GET_INSTANCE_PROC(CreateDevice);
         GET_INSTANCE_PROC(DestroyDevice);
         GET_INSTANCE_PROC(EnumerateDeviceExtensionProperties);
         GET_INSTANCE_PROC(EnumerateDeviceLayerProperties);
         GET_INSTANCE_PROC(EnumeratePhysicalDevices);
+        GET_INSTANCE_PROC(GetDeviceProcAddr);
         GET_INSTANCE_PROC(GetPhysicalDeviceFeatures);
         GET_INSTANCE_PROC(GetPhysicalDeviceFormatProperties);
         GET_INSTANCE_PROC(GetPhysicalDeviceImageFormatProperties);
@@ -59,10 +62,156 @@ namespace vulkan {
         GET_INSTANCE_PROC(GetPhysicalDeviceQueueFamilyProperties);
         GET_INSTANCE_PROC(GetPhysicalDeviceSparseImageFormatProperties);
 
-        if (usedGlobals.debugReport) {
+        if (usedKnobs.debugReport) {
             GET_INSTANCE_PROC(CreateDebugReportCallbackEXT);
             GET_INSTANCE_PROC(DebugReportMessageEXT);
             GET_INSTANCE_PROC(DestroyDebugReportCallbackEXT);
+        }
+
+        if (usedKnobs.surface) {
+            GET_INSTANCE_PROC(DestroySurfaceKHR);
+            GET_INSTANCE_PROC(GetPhysicalDeviceSurfaceSupportKHR);
+            GET_INSTANCE_PROC(GetPhysicalDeviceSurfaceCapabilitiesKHR);
+            GET_INSTANCE_PROC(GetPhysicalDeviceSurfaceFormatsKHR);
+            GET_INSTANCE_PROC(GetPhysicalDeviceSurfacePresentModesKHR);
+        }
+
+        return true;
+    }
+
+    #define GET_DEVICE_PROC(name) \
+        name = reinterpret_cast<decltype(name)>(GetDeviceProcAddr(device, "vk" #name)); \
+        if (name == nullptr) { \
+            return false; \
+        }
+
+    bool VulkanFunctions::LoadDeviceProcs(VkDevice device, const VulkanDeviceKnobs& usedKnobs) {
+        GET_DEVICE_PROC(AllocateCommandBuffers);
+        GET_DEVICE_PROC(AllocateDescriptorSets);
+        GET_DEVICE_PROC(AllocateMemory);
+        GET_DEVICE_PROC(BeginCommandBuffer);
+        GET_DEVICE_PROC(BindBufferMemory);
+        GET_DEVICE_PROC(BindImageMemory);
+        GET_DEVICE_PROC(CmdBeginQuery);
+        GET_DEVICE_PROC(CmdBeginRenderPass);
+        GET_DEVICE_PROC(CmdBindDescriptorSets);
+        GET_DEVICE_PROC(CmdBindIndexBuffer);
+        GET_DEVICE_PROC(CmdBindPipeline);
+        GET_DEVICE_PROC(CmdBindVertexBuffers);
+        GET_DEVICE_PROC(CmdBlitImage);
+        GET_DEVICE_PROC(CmdClearAttachments);
+        GET_DEVICE_PROC(CmdClearColorImage);
+        GET_DEVICE_PROC(CmdClearDepthStencilImage);
+        GET_DEVICE_PROC(CmdCopyBuffer);
+        GET_DEVICE_PROC(CmdCopyBufferToImage);
+        GET_DEVICE_PROC(CmdCopyImage);
+        GET_DEVICE_PROC(CmdCopyImageToBuffer);
+        GET_DEVICE_PROC(CmdCopyQueryPoolResults);
+        GET_DEVICE_PROC(CmdDispatch);
+        GET_DEVICE_PROC(CmdDispatchIndirect);
+        GET_DEVICE_PROC(CmdDraw);
+        GET_DEVICE_PROC(CmdDrawIndexed);
+        GET_DEVICE_PROC(CmdDrawIndexedIndirect);
+        GET_DEVICE_PROC(CmdDrawIndirect);
+        GET_DEVICE_PROC(CmdEndQuery);
+        GET_DEVICE_PROC(CmdEndRenderPass);
+        GET_DEVICE_PROC(CmdExecuteCommands);
+        GET_DEVICE_PROC(CmdFillBuffer);
+        GET_DEVICE_PROC(CmdNextSubpass);
+        GET_DEVICE_PROC(CmdPipelineBarrier);
+        GET_DEVICE_PROC(CmdPushConstants);
+        GET_DEVICE_PROC(CmdResetEvent);
+        GET_DEVICE_PROC(CmdResetQueryPool);
+        GET_DEVICE_PROC(CmdResolveImage);
+        GET_DEVICE_PROC(CmdSetBlendConstants);
+        GET_DEVICE_PROC(CmdSetDepthBias);
+        GET_DEVICE_PROC(CmdSetDepthBounds);
+        GET_DEVICE_PROC(CmdSetEvent);
+        GET_DEVICE_PROC(CmdSetLineWidth);
+        GET_DEVICE_PROC(CmdSetScissor);
+        GET_DEVICE_PROC(CmdSetStencilCompareMask);
+        GET_DEVICE_PROC(CmdSetStencilReference);
+        GET_DEVICE_PROC(CmdSetStencilWriteMask);
+        GET_DEVICE_PROC(CmdSetViewport);
+        GET_DEVICE_PROC(CmdUpdateBuffer);
+        GET_DEVICE_PROC(CmdWaitEvents);
+        GET_DEVICE_PROC(CmdWriteTimestamp);
+        GET_DEVICE_PROC(CreateBuffer);
+        GET_DEVICE_PROC(CreateBufferView);
+        GET_DEVICE_PROC(CreateCommandPool);
+        GET_DEVICE_PROC(CreateComputePipelines);
+        GET_DEVICE_PROC(CreateDescriptorPool);
+        GET_DEVICE_PROC(CreateDescriptorSetLayout);
+        GET_DEVICE_PROC(CreateEvent);
+        GET_DEVICE_PROC(CreateFence);
+        GET_DEVICE_PROC(CreateFramebuffer);
+        GET_DEVICE_PROC(CreateGraphicsPipelines);
+        GET_DEVICE_PROC(CreateImage);
+        GET_DEVICE_PROC(CreateImageView);
+        GET_DEVICE_PROC(CreatePipelineCache);
+        GET_DEVICE_PROC(CreatePipelineLayout);
+        GET_DEVICE_PROC(CreateQueryPool);
+        GET_DEVICE_PROC(CreateRenderPass);
+        GET_DEVICE_PROC(CreateSampler);
+        GET_DEVICE_PROC(CreateSemaphore);
+        GET_DEVICE_PROC(CreateShaderModule);
+        GET_DEVICE_PROC(DestroyBuffer);
+        GET_DEVICE_PROC(DestroyBufferView);
+        GET_DEVICE_PROC(DestroyCommandPool);
+        GET_DEVICE_PROC(DestroyDescriptorPool);
+        GET_DEVICE_PROC(DestroyDescriptorSetLayout);
+        GET_DEVICE_PROC(DestroyEvent);
+        GET_DEVICE_PROC(DestroyFence);
+        GET_DEVICE_PROC(DestroyFramebuffer);
+        GET_DEVICE_PROC(DestroyImage);
+        GET_DEVICE_PROC(DestroyImageView);
+        GET_DEVICE_PROC(DestroyPipeline);
+        GET_DEVICE_PROC(DestroyPipelineCache);
+        GET_DEVICE_PROC(DestroyPipelineLayout);
+        GET_DEVICE_PROC(DestroyQueryPool);
+        GET_DEVICE_PROC(DestroyRenderPass);
+        GET_DEVICE_PROC(DestroySampler);
+        GET_DEVICE_PROC(DestroySemaphore);
+        GET_DEVICE_PROC(DestroyShaderModule);
+        GET_DEVICE_PROC(DeviceWaitIdle);
+        GET_DEVICE_PROC(EndCommandBuffer);
+        GET_DEVICE_PROC(FlushMappedMemoryRanges);
+        GET_DEVICE_PROC(FreeCommandBuffers);
+        GET_DEVICE_PROC(FreeDescriptorSets);
+        GET_DEVICE_PROC(FreeMemory);
+        GET_DEVICE_PROC(GetBufferMemoryRequirements);
+        GET_DEVICE_PROC(GetDeviceMemoryCommitment);
+        GET_DEVICE_PROC(GetDeviceQueue);
+        GET_DEVICE_PROC(GetEventStatus);
+        GET_DEVICE_PROC(GetFenceStatus);
+        GET_DEVICE_PROC(GetImageMemoryRequirements);
+        GET_DEVICE_PROC(GetImageSparseMemoryRequirements);
+        GET_DEVICE_PROC(GetImageSubresourceLayout);
+        GET_DEVICE_PROC(GetPipelineCacheData);
+        GET_DEVICE_PROC(GetQueryPoolResults);
+        GET_DEVICE_PROC(GetRenderAreaGranularity);
+        GET_DEVICE_PROC(InvalidateMappedMemoryRanges);
+        GET_DEVICE_PROC(MapMemory);
+        GET_DEVICE_PROC(MergePipelineCaches);
+        GET_DEVICE_PROC(QueueBindSparse);
+        GET_DEVICE_PROC(QueueSubmit);
+        GET_DEVICE_PROC(QueueWaitIdle);
+        GET_DEVICE_PROC(ResetCommandBuffer);
+        GET_DEVICE_PROC(ResetCommandPool);
+        GET_DEVICE_PROC(ResetDescriptorPool);
+        GET_DEVICE_PROC(ResetEvent);
+        GET_DEVICE_PROC(ResetFences);
+        GET_DEVICE_PROC(SetEvent);
+        GET_DEVICE_PROC(UnmapMemory);
+        GET_DEVICE_PROC(UpdateDescriptorSets);
+        GET_DEVICE_PROC(WaitForFences);
+
+        if (usedKnobs.swapchain) {
+            GET_DEVICE_PROC(CreateSwapchainKHR);
+            GET_DEVICE_PROC(DestroySwapchainKHR);
+            GET_DEVICE_PROC(GetSwapchainImagesKHR);
+            GET_DEVICE_PROC(AcquireNextImageKHR);
+            GET_DEVICE_PROC(QueuePresentKHR);
         }
 
         return true;

--- a/src/backend/vulkan/VulkanFunctions.h
+++ b/src/backend/vulkan/VulkanFunctions.h
@@ -22,18 +22,21 @@ class DynamicLib;
 namespace backend {
 namespace vulkan {
 
-    struct KnownGlobalVulkanExtensions;
+    struct VulkanGlobalKnobs;
+    struct VulkanDeviceKnobs;
 
     // Stores the Vulkan entry points. Also loads them from the dynamic library
     // and the vkGet*ProcAddress entry points.
     struct VulkanFunctions {
         bool LoadGlobalProcs(const DynamicLib& vulkanLib);
-        bool LoadInstanceProcs(VkInstance instance, const KnownGlobalVulkanExtensions& usedGlobals);
+        bool LoadInstanceProcs(VkInstance instance, const VulkanGlobalKnobs& usedGlobals);
+        bool LoadDeviceProcs(VkDevice device, const VulkanDeviceKnobs& usedKnobs);
+
+        // ---------- Global procs
 
         // Initial proc from which we can get all the others
         PFN_vkGetInstanceProcAddr GetInstanceProcAddr = nullptr;
 
-        // Global procs, can be used without an instance
         PFN_vkCreateInstance CreateInstance = nullptr;
         PFN_vkEnumerateInstanceExtensionProperties EnumerateInstanceExtensionProperties = nullptr;
         PFN_vkEnumerateInstanceLayerProperties EnumerateInstanceLayerProperties = nullptr;
@@ -41,11 +44,14 @@ namespace vulkan {
         // before querying the instance procs in case we need to error out during initialization.
         PFN_vkDestroyInstance DestroyInstance = nullptr;
 
-        // Instance procs
+        // ---------- Instance procs
+
+        // Core Vulkan 1.0
         PFN_vkCreateDevice CreateDevice = nullptr;
         PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties = nullptr;
         PFN_vkEnumerateDeviceLayerProperties EnumerateDeviceLayerProperties = nullptr;
         PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices = nullptr;
+        PFN_vkGetDeviceProcAddr GetDeviceProcAddr = nullptr;
         PFN_vkGetPhysicalDeviceFeatures GetPhysicalDeviceFeatures = nullptr;
         PFN_vkGetPhysicalDeviceFormatProperties GetPhysicalDeviceFormatProperties = nullptr;
         PFN_vkGetPhysicalDeviceImageFormatProperties GetPhysicalDeviceImageFormatProperties = nullptr;
@@ -61,8 +67,144 @@ namespace vulkan {
         PFN_vkCreateDebugReportCallbackEXT CreateDebugReportCallbackEXT = nullptr;
         PFN_vkDebugReportMessageEXT DebugReportMessageEXT = nullptr;
         PFN_vkDestroyDebugReportCallbackEXT DestroyDebugReportCallbackEXT = nullptr;
-    };
 
+        // VK_KHR_surface
+        PFN_vkDestroySurfaceKHR DestroySurfaceKHR = nullptr;
+        PFN_vkGetPhysicalDeviceSurfaceSupportKHR GetPhysicalDeviceSurfaceSupportKHR = nullptr;
+        PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR GetPhysicalDeviceSurfaceCapabilitiesKHR = nullptr;
+        PFN_vkGetPhysicalDeviceSurfaceFormatsKHR GetPhysicalDeviceSurfaceFormatsKHR = nullptr;
+        PFN_vkGetPhysicalDeviceSurfacePresentModesKHR GetPhysicalDeviceSurfacePresentModesKHR = nullptr;
+
+        // ---------- Device procs
+
+        // Core Vulkan 1.0
+        PFN_vkAllocateCommandBuffers AllocateCommandBuffers = nullptr;
+        PFN_vkAllocateDescriptorSets AllocateDescriptorSets = nullptr;
+        PFN_vkAllocateMemory AllocateMemory = nullptr;
+        PFN_vkBeginCommandBuffer BeginCommandBuffer = nullptr;
+        PFN_vkBindBufferMemory BindBufferMemory = nullptr;
+        PFN_vkBindImageMemory BindImageMemory = nullptr;
+        PFN_vkCmdBeginQuery CmdBeginQuery = nullptr;
+        PFN_vkCmdBeginRenderPass CmdBeginRenderPass = nullptr;
+        PFN_vkCmdBindDescriptorSets CmdBindDescriptorSets = nullptr;
+        PFN_vkCmdBindIndexBuffer CmdBindIndexBuffer = nullptr;
+        PFN_vkCmdBindPipeline CmdBindPipeline = nullptr;
+        PFN_vkCmdBindVertexBuffers CmdBindVertexBuffers = nullptr;
+        PFN_vkCmdBlitImage CmdBlitImage = nullptr;
+        PFN_vkCmdClearAttachments CmdClearAttachments = nullptr;
+        PFN_vkCmdClearColorImage CmdClearColorImage = nullptr;
+        PFN_vkCmdClearDepthStencilImage CmdClearDepthStencilImage = nullptr;
+        PFN_vkCmdCopyBuffer CmdCopyBuffer = nullptr;
+        PFN_vkCmdCopyBufferToImage CmdCopyBufferToImage = nullptr;
+        PFN_vkCmdCopyImage CmdCopyImage = nullptr;
+        PFN_vkCmdCopyImageToBuffer CmdCopyImageToBuffer = nullptr;
+        PFN_vkCmdCopyQueryPoolResults CmdCopyQueryPoolResults = nullptr;
+        PFN_vkCmdDispatch CmdDispatch = nullptr;
+        PFN_vkCmdDispatchIndirect CmdDispatchIndirect = nullptr;
+        PFN_vkCmdDraw CmdDraw = nullptr;
+        PFN_vkCmdDrawIndexed CmdDrawIndexed = nullptr;
+        PFN_vkCmdDrawIndexedIndirect CmdDrawIndexedIndirect = nullptr;
+        PFN_vkCmdDrawIndirect CmdDrawIndirect = nullptr;
+        PFN_vkCmdEndQuery CmdEndQuery = nullptr;
+        PFN_vkCmdEndRenderPass CmdEndRenderPass = nullptr;
+        PFN_vkCmdExecuteCommands CmdExecuteCommands = nullptr;
+        PFN_vkCmdFillBuffer CmdFillBuffer = nullptr;
+        PFN_vkCmdNextSubpass CmdNextSubpass = nullptr;
+        PFN_vkCmdPipelineBarrier CmdPipelineBarrier = nullptr;
+        PFN_vkCmdPushConstants CmdPushConstants = nullptr;
+        PFN_vkCmdResetEvent CmdResetEvent = nullptr;
+        PFN_vkCmdResetQueryPool CmdResetQueryPool = nullptr;
+        PFN_vkCmdResolveImage CmdResolveImage = nullptr;
+        PFN_vkCmdSetBlendConstants CmdSetBlendConstants = nullptr;
+        PFN_vkCmdSetDepthBias CmdSetDepthBias = nullptr;
+        PFN_vkCmdSetDepthBounds CmdSetDepthBounds = nullptr;
+        PFN_vkCmdSetEvent CmdSetEvent = nullptr;
+        PFN_vkCmdSetLineWidth CmdSetLineWidth = nullptr;
+        PFN_vkCmdSetScissor CmdSetScissor = nullptr;
+        PFN_vkCmdSetStencilCompareMask CmdSetStencilCompareMask = nullptr;
+        PFN_vkCmdSetStencilReference CmdSetStencilReference = nullptr;
+        PFN_vkCmdSetStencilWriteMask CmdSetStencilWriteMask = nullptr;
+        PFN_vkCmdSetViewport CmdSetViewport = nullptr;
+        PFN_vkCmdUpdateBuffer CmdUpdateBuffer = nullptr;
+        PFN_vkCmdWaitEvents CmdWaitEvents = nullptr;
+        PFN_vkCmdWriteTimestamp CmdWriteTimestamp = nullptr;
+        PFN_vkCreateBuffer CreateBuffer = nullptr;
+        PFN_vkCreateBufferView CreateBufferView = nullptr;
+        PFN_vkCreateCommandPool CreateCommandPool = nullptr;
+        PFN_vkCreateComputePipelines CreateComputePipelines = nullptr;
+        PFN_vkCreateDescriptorPool CreateDescriptorPool = nullptr;
+        PFN_vkCreateDescriptorSetLayout CreateDescriptorSetLayout = nullptr;
+        PFN_vkCreateEvent CreateEvent = nullptr;
+        PFN_vkCreateFence CreateFence = nullptr;
+        PFN_vkCreateFramebuffer CreateFramebuffer = nullptr;
+        PFN_vkCreateGraphicsPipelines CreateGraphicsPipelines = nullptr;
+        PFN_vkCreateImage CreateImage = nullptr;
+        PFN_vkCreateImageView CreateImageView = nullptr;
+        PFN_vkCreatePipelineCache CreatePipelineCache = nullptr;
+        PFN_vkCreatePipelineLayout CreatePipelineLayout = nullptr;
+        PFN_vkCreateQueryPool CreateQueryPool = nullptr;
+        PFN_vkCreateRenderPass CreateRenderPass = nullptr;
+        PFN_vkCreateSampler CreateSampler = nullptr;
+        PFN_vkCreateSemaphore CreateSemaphore = nullptr;
+        PFN_vkCreateShaderModule CreateShaderModule = nullptr;
+        PFN_vkDestroyBuffer DestroyBuffer = nullptr;
+        PFN_vkDestroyBufferView DestroyBufferView = nullptr;
+        PFN_vkDestroyCommandPool DestroyCommandPool = nullptr;
+        PFN_vkDestroyDescriptorPool DestroyDescriptorPool = nullptr;
+        PFN_vkDestroyDescriptorSetLayout DestroyDescriptorSetLayout = nullptr;
+        PFN_vkDestroyEvent DestroyEvent = nullptr;
+        PFN_vkDestroyFence DestroyFence = nullptr;
+        PFN_vkDestroyFramebuffer DestroyFramebuffer = nullptr;
+        PFN_vkDestroyImage DestroyImage = nullptr;
+        PFN_vkDestroyImageView DestroyImageView = nullptr;
+        PFN_vkDestroyPipeline DestroyPipeline = nullptr;
+        PFN_vkDestroyPipelineCache DestroyPipelineCache = nullptr;
+        PFN_vkDestroyPipelineLayout DestroyPipelineLayout = nullptr;
+        PFN_vkDestroyQueryPool DestroyQueryPool = nullptr;
+        PFN_vkDestroyRenderPass DestroyRenderPass = nullptr;
+        PFN_vkDestroySampler DestroySampler = nullptr;
+        PFN_vkDestroySemaphore DestroySemaphore = nullptr;
+        PFN_vkDestroyShaderModule DestroyShaderModule = nullptr;
+        PFN_vkDeviceWaitIdle DeviceWaitIdle = nullptr;
+        PFN_vkEndCommandBuffer EndCommandBuffer = nullptr;
+        PFN_vkFlushMappedMemoryRanges FlushMappedMemoryRanges = nullptr;
+        PFN_vkFreeCommandBuffers FreeCommandBuffers = nullptr;
+        PFN_vkFreeDescriptorSets FreeDescriptorSets = nullptr;
+        PFN_vkFreeMemory FreeMemory = nullptr;
+        PFN_vkGetBufferMemoryRequirements GetBufferMemoryRequirements = nullptr;
+        PFN_vkGetDeviceMemoryCommitment GetDeviceMemoryCommitment = nullptr;
+        PFN_vkGetDeviceQueue GetDeviceQueue = nullptr;
+        PFN_vkGetEventStatus GetEventStatus = nullptr;
+        PFN_vkGetFenceStatus GetFenceStatus = nullptr;
+        PFN_vkGetImageMemoryRequirements GetImageMemoryRequirements = nullptr;
+        PFN_vkGetImageSparseMemoryRequirements GetImageSparseMemoryRequirements = nullptr;
+        PFN_vkGetImageSubresourceLayout GetImageSubresourceLayout = nullptr;
+        PFN_vkGetPipelineCacheData GetPipelineCacheData = nullptr;
+        PFN_vkGetQueryPoolResults GetQueryPoolResults = nullptr;
+        PFN_vkGetRenderAreaGranularity GetRenderAreaGranularity = nullptr;
+        PFN_vkInvalidateMappedMemoryRanges InvalidateMappedMemoryRanges = nullptr;
+        PFN_vkMapMemory MapMemory = nullptr;
+        PFN_vkMergePipelineCaches MergePipelineCaches = nullptr;
+        PFN_vkQueueBindSparse QueueBindSparse = nullptr;
+        PFN_vkQueueSubmit QueueSubmit = nullptr;
+        PFN_vkQueueWaitIdle QueueWaitIdle = nullptr;
+        PFN_vkResetCommandBuffer ResetCommandBuffer = nullptr;
+        PFN_vkResetCommandPool ResetCommandPool = nullptr;
+        PFN_vkResetDescriptorPool ResetDescriptorPool = nullptr;
+        PFN_vkResetEvent ResetEvent = nullptr;
+        PFN_vkResetFences ResetFences = nullptr;
+        PFN_vkSetEvent SetEvent = nullptr;
+        PFN_vkUnmapMemory UnmapMemory = nullptr;
+        PFN_vkUpdateDescriptorSets UpdateDescriptorSets = nullptr;
+        PFN_vkWaitForFences WaitForFences = nullptr;
+
+        // VK_KHR_swapchain
+        PFN_vkCreateSwapchainKHR CreateSwapchainKHR = nullptr;
+        PFN_vkDestroySwapchainKHR DestroySwapchainKHR = nullptr;
+        PFN_vkGetSwapchainImagesKHR GetSwapchainImagesKHR = nullptr;
+        PFN_vkAcquireNextImageKHR AcquireNextImageKHR = nullptr;
+        PFN_vkQueuePresentKHR QueuePresentKHR = nullptr;
+    };
 
 }
 }

--- a/src/backend/vulkan/VulkanInfo.h
+++ b/src/backend/vulkan/VulkanInfo.h
@@ -27,29 +27,48 @@ namespace vulkan {
     extern const char kLayerNameLunargStandardValidation[];
 
     extern const char kExtensionNameExtDebugReport[];
+    extern const char kExtensionNameKhrSurface[];
+    extern const char kExtensionNameKhrSwapchain[];
 
-    struct KnownGlobalVulkanExtensions {
+    // Global information - gathered before the instance is created
+    struct VulkanGlobalKnobs {
         // Layers
         bool standardValidation = false;
 
         // Extensions
         bool debugReport = false;
+        bool surface = false;
     };
 
-    // Stores the information about the Vulkan system that are required to use Vulkan.
-    // Also does the querying of the information.
-    struct VulkanInfo {
-        // Global information - gathered before the instance is created
-        struct : KnownGlobalVulkanExtensions {
-            std::vector<VkLayerProperties> layers;
-            std::vector<VkExtensionProperties> extensions;
-            // TODO(cwallez@chromium.org): layer instance extensions
-        } global;
-
-        bool GatherGlobalInfo(const Device& device);
-        void SetUsedGlobals(const KnownGlobalVulkanExtensions& usedGlobals);
+    struct VulkanGlobalInfo : VulkanGlobalKnobs {
+        std::vector<VkLayerProperties> layers;
+        std::vector<VkExtensionProperties> extensions;
+        // TODO(cwallez@chromium.org): layer instance extensions
     };
 
+    // Device information - gathered before the device is created.
+    struct VulkanDeviceKnobs {
+        VkPhysicalDeviceFeatures features;
+
+        // Extensions
+        bool swapchain = false;
+    };
+
+    struct VulkanDeviceInfo : VulkanDeviceKnobs {
+        VkPhysicalDeviceProperties properties;
+        std::vector<VkQueueFamilyProperties> queueFamilies;
+
+        std::vector<VkMemoryType> memoryTypes;
+        std::vector<VkMemoryHeap> memoryHeaps;
+
+        std::vector<VkLayerProperties> layers;
+        std::vector<VkExtensionProperties> extensions;
+        // TODO(cwallez@chromium.org): layer instance extensions
+    };
+
+    bool GatherGlobalInfo(const Device& device, VulkanGlobalInfo* info);
+    bool GetPhysicalDevices(const Device& device, std::vector<VkPhysicalDevice>* physicalDevices);
+    bool GatherDeviceInfo(const Device& device, VkPhysicalDevice physicalDevice, VulkanDeviceInfo* info);
 }
 }
 


### PR DESCRIPTION
PTAL, at this point the VulkanBackend can pass the SetSubData tests with the NXTTest swapchain related code commented out. This is a hack however because everything stays inside `vulkan::Buffer`. I'll add a proper queue, GPU copies, and fencing next. Then a proper "buffer uploader" for SetSubData.