### PR TITLE
Implement R8 and RG8 texture formats with uint and unorm components.

### DIFF
--- a/next.json
+++ b/next.json
@@ -1211,9 +1211,13 @@
         "category": "enum",
         "values": [
             {"value": 0, "name": "r8 g8 b8 a8 unorm"},
-            {"value": 1, "name": "r8 g8 b8 a8 uint"},
-            {"value": 2, "name": "b8 g8 r8 a8 unorm"},
-            {"value": 3, "name": "d32 float s8 uint"}
+            {"value": 1, "name": "r8 g8 unorm"},
+            {"value": 2, "name": "r8 unorm"},
+            {"value": 3, "name": "r8 g8 b8 a8 uint"},
+            {"value": 4, "name": "r8 g8 uint"},
+            {"value": 5, "name": "r8 uint"},
+            {"value": 6, "name": "b8 g8 r8 a8 unorm"},
+            {"value": 7, "name": "d32 float s8 uint"}
         ]
     },
     "vertex format": {

--- a/src/backend/Texture.cpp
+++ b/src/backend/Texture.cpp
@@ -21,6 +21,12 @@ namespace backend {
 
     uint32_t TextureFormatPixelSize(nxt::TextureFormat format) {
         switch (format) {
+            case nxt::TextureFormat::R8Unorm:
+            case nxt::TextureFormat::R8Uint:
+                return 1;
+            case nxt::TextureFormat::R8G8Unorm:
+            case nxt::TextureFormat::R8G8Uint:
+                return 2;
             case nxt::TextureFormat::R8G8B8A8Unorm:
             case nxt::TextureFormat::R8G8B8A8Uint:
             case nxt::TextureFormat::B8G8R8A8Unorm:
@@ -34,40 +40,28 @@ namespace backend {
 
     bool TextureFormatHasDepth(nxt::TextureFormat format) {
         switch (format) {
-            case nxt::TextureFormat::R8G8B8A8Unorm:
-            case nxt::TextureFormat::R8G8B8A8Uint:
-            case nxt::TextureFormat::B8G8R8A8Unorm:
-                return false;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return true;
             default:
-                UNREACHABLE();
+                return false;
         }
     }
 
     bool TextureFormatHasStencil(nxt::TextureFormat format) {
         switch (format) {
-            case nxt::TextureFormat::R8G8B8A8Unorm:
-            case nxt::TextureFormat::R8G8B8A8Uint:
-            case nxt::TextureFormat::B8G8R8A8Unorm:
-                return false;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return true;
             default:
-                UNREACHABLE();
+                return false;
         }
     }
 
     bool TextureFormatHasDepthOrStencil(nxt::TextureFormat format) {
         switch (format) {
-            case nxt::TextureFormat::R8G8B8A8Unorm:
-            case nxt::TextureFormat::R8G8B8A8Uint:
-            case nxt::TextureFormat::B8G8R8A8Unorm:
-                return false;
             case nxt::TextureFormat::D32FloatS8Uint:
                 return true;
             default:
-                UNREACHABLE();
+                return false;
         }
     }
 

--- a/src/backend/d3d12/TextureD3D12.cpp
+++ b/src/backend/d3d12/TextureD3D12.cpp
@@ -88,8 +88,16 @@ namespace backend { namespace d3d12 {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
                 return DXGI_FORMAT_R8G8B8A8_UNORM;
+            case nxt::TextureFormat::R8G8Unorm:
+                return DXGI_FORMAT_R8G8_UNORM;
+            case nxt::TextureFormat::R8Unorm:
+                return DXGI_FORMAT_R8_UNORM;
             case nxt::TextureFormat::R8G8B8A8Uint:
                 return DXGI_FORMAT_R8G8B8A8_UINT;
+            case nxt::TextureFormat::R8G8Uint:
+                return DXGI_FORMAT_R8G8_UINT;
+            case nxt::TextureFormat::R8Uint:
+                return DXGI_FORMAT_R8_UINT;
             case nxt::TextureFormat::B8G8R8A8Unorm:
                 return DXGI_FORMAT_B8G8R8A8_UNORM;
             case nxt::TextureFormat::D32FloatS8Uint:

--- a/src/backend/metal/TextureMTL.mm
+++ b/src/backend/metal/TextureMTL.mm
@@ -22,8 +22,16 @@ namespace backend { namespace metal {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
                 return MTLPixelFormatRGBA8Unorm;
+            case nxt::TextureFormat::R8G8Unorm:
+                return MTLPixelFormatRG8Unorm;
+            case nxt::TextureFormat::R8Unorm:
+                return MTLPixelFormatR8Unorm;
             case nxt::TextureFormat::R8G8B8A8Uint:
                 return MTLPixelFormatRGBA8Uint;
+            case nxt::TextureFormat::R8G8Uint:
+                return MTLPixelFormatRG8Uint;
+            case nxt::TextureFormat::R8Uint:
+                return MTLPixelFormatR8Uint;
             case nxt::TextureFormat::B8G8R8A8Unorm:
                 return MTLPixelFormatBGRA8Unorm;
             case nxt::TextureFormat::D32FloatS8Uint:

--- a/src/backend/opengl/TextureGL.cpp
+++ b/src/backend/opengl/TextureGL.cpp
@@ -36,8 +36,16 @@ namespace backend { namespace opengl {
             switch (format) {
                 case nxt::TextureFormat::R8G8B8A8Unorm:
                     return {GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE};
+                case nxt::TextureFormat::R8G8Unorm:
+                    return {GL_RG8, GL_RG, GL_UNSIGNED_BYTE};
+                case nxt::TextureFormat::R8Unorm:
+                    return {GL_R8, GL_RED, GL_UNSIGNED_BYTE};
                 case nxt::TextureFormat::R8G8B8A8Uint:
                     return {GL_RGBA8UI, GL_RGBA, GL_UNSIGNED_INT};
+                case nxt::TextureFormat::R8G8Uint:
+                    return {GL_RG8UI, GL_RG, GL_UNSIGNED_INT};
+                case nxt::TextureFormat::R8Uint:
+                    return {GL_R8UI, GL_RED, GL_UNSIGNED_INT};
                 case nxt::TextureFormat::B8G8R8A8Unorm:
                     // This doesn't have an enum for the internal format in OpenGL, so use RGBA8.
                     return {GL_RGBA8, GL_BGRA, GL_UNSIGNED_BYTE};


### PR DESCRIPTION
Backend support added for Metal, D3D12 and OpenGL.
Also fix BGRA support in OpenGL to give it a valid internal format.