### PR TITLE
Fix for strict-aliasing issue.

### DIFF
--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -129,8 +129,8 @@ namespace backend { namespace opengl {
                                 break;
                             case PushConstantType::Float:
                                 float value;
-                                // Use a memcpy to avoid strict-aliasing warnings, even if it is still
-                                // technically undefined behavior.
+                                // Use a memcpy to avoid strict-aliasing warnings, even if it is
+                                // still technically undefined behavior.
                                 memcpy(&value, &mValues[stage][constant], sizeof(value));
                                 glUniform1f(location, value);
                                 break;

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -129,7 +129,8 @@ namespace backend { namespace opengl {
                                 break;
                             case PushConstantType::Float:
                                 float value;
-                                // Use a memcpy to avoid strict-aliasing warnings.
+                                // Use a memcpy to avoid strict-aliasing warnings, even if it is still
+                                // technically undefined behavior.
                                 memcpy(&value, &mValues[stage][constant], sizeof(value));
                                 glUniform1f(location, value);
                                 break;

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -128,8 +128,10 @@ namespace backend { namespace opengl {
                                              *reinterpret_cast<GLuint*>(&mValues[stage][constant]));
                                 break;
                             case PushConstantType::Float:
-                                glUniform1f(location,
-                                            *reinterpret_cast<GLfloat*>(&mValues[stage][constant]));
+                                float value;
+                                // Use a memcpy to avoid strict-aliasing warnings.
+                                memcpy(&value, &mValues[stage][constant], sizeof(value));
+                                glUniform1f(location, value);
                                 break;
                         }
                     }


### PR DESCRIPTION
Use a memcpy() to avoid strict-aliasing warnings. Using a union instead would be ideal, but this works for now.