### PR TITLE
Change Buffer::SetSubData() start and offset to chars

### DIFF
--- a/examples/ComputeBoids.cpp
+++ b/examples/ComputeBoids.cpp
@@ -88,8 +88,8 @@ void initBuffers() {
             .GetResult();
 
         particleBuffers[i].SetSubData(0,
-            sizeof(Particle) * kNumParticles / sizeof(uint32_t),
-            reinterpret_cast<uint32_t*>(initialParticles.data()));
+            sizeof(Particle) * kNumParticles,
+            reinterpret_cast<uint8_t*>(initialParticles.data()));
     }
 }
 

--- a/examples/HelloCompute.cpp
+++ b/examples/HelloCompute.cpp
@@ -45,7 +45,7 @@ void init() {
         .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
         .SetSize(sizeof(s))
         .GetResult();
-    buffer.SetSubData(0, sizeof(s) / sizeof(uint32_t), reinterpret_cast<uint32_t*>(&s));
+    buffer.SetSubData(0, sizeof(s), reinterpret_cast<uint8_t*>(&s));
 
     nxt::BufferView view = buffer.CreateBufferViewBuilder()
         .SetExtent(0, sizeof(s))

--- a/examples/HelloDepthStencil.cpp
+++ b/examples/HelloDepthStencil.cpp
@@ -274,7 +274,7 @@ void frame() {
     );
 
     cameraBuffer.TransitionUsage(nxt::BufferUsageBit::TransferDst);
-    cameraBuffer.SetSubData(0, sizeof(CameraData) / sizeof(uint32_t), reinterpret_cast<uint32_t*>(&cameraData));
+    cameraBuffer.SetSubData(0, sizeof(CameraData), reinterpret_cast<uint8_t*>(&cameraData));
 
     nxt::Texture backbuffer;
     nxt::Framebuffer framebuffer;

--- a/examples/HelloUBO.cpp
+++ b/examples/HelloUBO.cpp
@@ -96,7 +96,7 @@ void frame() {
     if (s.b >= 1.0f) {s.b = 0.0f;}
 
     buffer.TransitionUsage(nxt::BufferUsageBit::TransferDst);
-    buffer.SetSubData(0, sizeof(s) / sizeof(uint32_t), reinterpret_cast<uint32_t*>(&s));
+    buffer.SetSubData(0, sizeof(s), reinterpret_cast<uint8_t*>(&s));
 
     nxt::Texture backbuffer;
     nxt::Framebuffer framebuffer;

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -508,8 +508,8 @@ namespace {
             // but the draw is queue level command that is pipelined. This causes bad rendering for models
             // that use the same part multiple time.
             material.uniformBuffer.SetSubData(0,
-                    sizeof(u_transform_block) / sizeof(uint32_t),
-                    reinterpret_cast<const uint32_t*>(&transforms));
+                    sizeof(u_transform_block),
+                    reinterpret_cast<const uint8_t*>(&transforms));
             cmd.SetRenderPipeline(material.pipeline);
             cmd.TransitionBufferUsage(material.uniformBuffer, nxt::BufferUsageBit::Uniform);
             cmd.SetBindGroup(0, material.bindGroup0);

--- a/next.json
+++ b/next.json
@@ -197,7 +197,7 @@
                 "args": [
                     {"name": "start", "type": "uint32_t"},
                     {"name": "count", "type": "uint32_t"},
-                    {"name": "data", "type": "uint32_t", "annotation": "const*", "length": "count"}
+                    {"name": "data", "type": "uint8_t", "annotation": "const*", "length": "count"}
                 ]
             },
             {
@@ -1248,6 +1248,9 @@
         ]
     },
     "void": {
+        "category": "native"
+    },
+    "uint8_t": {
         "category": "native"
     },
     "uint32_t": {

--- a/src/backend/Buffer.cpp
+++ b/src/backend/Buffer.cpp
@@ -84,8 +84,8 @@ namespace backend {
         }
     }
 
-    void BufferBase::SetSubData(uint32_t start, uint32_t count, const uint32_t* data) {
-        if ((start + count) * sizeof(uint32_t) > GetSize()) {
+    void BufferBase::SetSubData(uint32_t start, uint32_t count, const uint8_t* data) {
+        if (start + count > GetSize()) {
             mDevice->HandleError("Buffer subdata out of range");
             return;
         }

--- a/src/backend/Buffer.h
+++ b/src/backend/Buffer.h
@@ -41,7 +41,7 @@ namespace backend {
 
         // NXT API
         BufferViewBuilder* CreateBufferViewBuilder();
-        void SetSubData(uint32_t start, uint32_t count, const uint32_t* data);
+        void SetSubData(uint32_t start, uint32_t count, const uint8_t* data);
         void MapReadAsync(uint32_t start,
                           uint32_t size,
                           nxtBufferMapReadCallback callback,
@@ -61,7 +61,7 @@ namespace backend {
         void CallMapWriteCallback(uint32_t serial, nxtBufferMapAsyncStatus status, void* pointer);
 
       private:
-        virtual void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) = 0;
+        virtual void SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) = 0;
         virtual void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t size) = 0;
         virtual void MapWriteAsyncImpl(uint32_t serial, uint32_t start, uint32_t size) = 0;
         virtual void UnmapImpl() = 0;

--- a/src/backend/d3d12/BufferD3D12.cpp
+++ b/src/backend/d3d12/BufferD3D12.cpp
@@ -152,9 +152,8 @@ namespace backend { namespace d3d12 {
         }
     }
 
-    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
-        mDevice->GetResourceUploader()->BufferSubData(mResource, start * sizeof(uint32_t),
-                                                      count * sizeof(uint32_t), data);
+    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) {
+        mDevice->GetResourceUploader()->BufferSubData(mResource, start, count, data);
     }
 
     void Buffer::MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) {

--- a/src/backend/d3d12/BufferD3D12.h
+++ b/src/backend/d3d12/BufferD3D12.h
@@ -42,7 +42,7 @@ namespace backend { namespace d3d12 {
         ComPtr<ID3D12Resource> mResource;
 
         // NXT API
-        void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
+        void SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) override;
         void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void MapWriteAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void UnmapImpl() override;

--- a/src/backend/metal/BufferMTL.h
+++ b/src/backend/metal/BufferMTL.h
@@ -34,7 +34,7 @@ namespace backend { namespace metal {
         void OnMapCommandSerialFinished(uint32_t mapSerial, uint32_t offset, bool isWrite);
 
       private:
-        void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
+        void SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) override;
         void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void MapWriteAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void UnmapImpl() override;

--- a/src/backend/metal/BufferMTL.mm
+++ b/src/backend/metal/BufferMTL.mm
@@ -49,10 +49,9 @@ namespace backend { namespace metal {
         }
     }
 
-    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
+    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) {
         auto* uploader = ToBackend(GetDevice())->GetResourceUploader();
-        uploader->BufferSubData(mMtlBuffer, start * sizeof(uint32_t), count * sizeof(uint32_t),
-                                data);
+        uploader->BufferSubData(mMtlBuffer, start, count, data);
     }
 
     void Buffer::MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t) {

--- a/src/backend/null/NullBackend.cpp
+++ b/src/backend/null/NullBackend.cpp
@@ -140,7 +140,7 @@ namespace backend { namespace null {
         }
     }
 
-    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
+    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) {
         ASSERT(start + count <= GetSize());
         ASSERT(mBackingData);
         memcpy(mBackingData.get() + start, data, count);

--- a/src/backend/null/NullBackend.h
+++ b/src/backend/null/NullBackend.h
@@ -135,7 +135,7 @@ namespace backend { namespace null {
         void MapReadOperationCompleted(uint32_t serial, void* ptr, bool isWrite);
 
       private:
-        void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
+        void SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) override;
         void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void MapWriteAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void UnmapImpl() override;

--- a/src/backend/opengl/BufferGL.cpp
+++ b/src/backend/opengl/BufferGL.cpp
@@ -30,9 +30,9 @@ namespace backend { namespace opengl {
         return mBuffer;
     }
 
-    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
+    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) {
         glBindBuffer(GL_ARRAY_BUFFER, mBuffer);
-        glBufferSubData(GL_ARRAY_BUFFER, start * sizeof(uint32_t), count * sizeof(uint32_t), data);
+        glBufferSubData(GL_ARRAY_BUFFER, start, count, data);
     }
 
     void Buffer::MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) {

--- a/src/backend/opengl/BufferGL.h
+++ b/src/backend/opengl/BufferGL.h
@@ -30,7 +30,7 @@ namespace backend { namespace opengl {
         GLuint GetHandle() const;
 
       private:
-        void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
+        void SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) override;
         void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void MapWriteAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void UnmapImpl() override;

--- a/src/backend/vulkan/BufferVk.cpp
+++ b/src/backend/vulkan/BufferVk.cpp
@@ -184,9 +184,9 @@ namespace backend { namespace vulkan {
                                     nullptr);
     }
 
-    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) {
+    void Buffer::SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) {
         BufferUploader* uploader = ToBackend(GetDevice())->GetBufferUploader();
-        uploader->BufferSubData(mHandle, start * sizeof(uint32_t), count * sizeof(uint32_t), data);
+        uploader->BufferSubData(mHandle, start, count, data);
     }
 
     void Buffer::MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t /*count*/) {

--- a/src/backend/vulkan/BufferVk.h
+++ b/src/backend/vulkan/BufferVk.h
@@ -40,7 +40,7 @@ namespace backend { namespace vulkan {
                            nxt::BufferUsageBit targetUsage) const;
 
       private:
-        void SetSubDataImpl(uint32_t start, uint32_t count, const uint32_t* data) override;
+        void SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) override;
         void MapReadAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void MapWriteAsyncImpl(uint32_t serial, uint32_t start, uint32_t count) override;
         void UnmapImpl() override;

--- a/src/tests/NXTTest.cpp
+++ b/src/tests/NXTTest.cpp
@@ -430,6 +430,7 @@ namespace detail {
         return testing::AssertionSuccess();
     }
 
+    template class ExpectEq<uint8_t>;
     template class ExpectEq<uint32_t>;
     template class ExpectEq<RGBA8>;
 }

--- a/src/tests/NXTTest.h
+++ b/src/tests/NXTTest.h
@@ -26,6 +26,10 @@
 #define EXPECT_BUFFER_U32_RANGE_EQ(expected, buffer, offset, count) \
     AddBufferExpectation(__FILE__, __LINE__, buffer, offset, sizeof(uint32_t) * count, new detail::ExpectEq<uint32_t>(expected, count))
 
+#define EXPECT_BUFFER_U8_EQ(expected, buffer, offset)                         \
+    AddBufferExpectation(__FILE__, __LINE__, buffer, offset, sizeof(uint8_t), \
+                         new detail::ExpectEq<uint8_t>(expected))
+
 // Test a pixel of the mip level 0 of a 2D texture.
 #define EXPECT_PIXEL_RGBA8_EQ(expected, texture, x, y) \
     AddTextureExpectation(__FILE__, __LINE__, texture, x, y, 1, 1, 0, sizeof(RGBA8), new detail::ExpectEq<RGBA8>(expected))
@@ -166,6 +170,7 @@ namespace detail {
         private:
             std::vector<T> mExpected;
     };
+    extern template class ExpectEq<uint8_t>;
     extern template class ExpectEq<uint32_t>;
     extern template class ExpectEq<RGBA8>;
 }

--- a/src/tests/end2end/BasicTests.cpp
+++ b/src/tests/end2end/BasicTests.cpp
@@ -28,10 +28,10 @@ TEST_P(BasicTests, BufferSetSubData) {
         .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
         .GetResult();
 
-    uint32_t value = 3094587;
-    buffer.SetSubData(0, 1, &value);
+    uint8_t value = 187;
+    buffer.SetSubData(0, sizeof(value), &value);
 
-    EXPECT_BUFFER_U32_EQ(value, buffer, 0);
+    EXPECT_BUFFER_U8_EQ(value, buffer, 0);
 }
 
 NXT_INSTANTIATE_TEST(BasicTests, D3D12Backend, MetalBackend, OpenGLBackend, VulkanBackend)

--- a/src/tests/end2end/CopyTests.cpp
+++ b/src/tests/end2end/CopyTests.cpp
@@ -107,7 +107,7 @@ class CopyTests_T2B : public CopyTests {
                 .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
                 .GetResult();
             std::vector<RGBA8> emptyData(bufferSpec.size / kBytesPerTexel);
-            buffer.SetSubData(0, static_cast<uint32_t>(emptyData.size()), reinterpret_cast<const uint32_t*>(emptyData.data()));
+            buffer.SetSubData(0, static_cast<uint32_t>(emptyData.size() * sizeof(RGBA8)), reinterpret_cast<const uint8_t*>(emptyData.data()));
 
             // Copy the region [(`x`, `y`), (`x + copyWidth, `y + copyWidth`)] from the `level` mip into the buffer at the specified `offset` and `rowPitch`
             commands[1] = device.CreateCommandBufferBuilder()
@@ -158,7 +158,7 @@ protected:
             .GetResult();
         std::vector<RGBA8> bufferData(bufferSpec.size / kBytesPerTexel);
         FillBufferData(bufferData.data(), bufferData.size());
-        buffer.SetSubData(0, static_cast<uint32_t>(bufferData.size()), reinterpret_cast<const uint32_t*>(bufferData.data()));
+        buffer.SetSubData(0, static_cast<uint32_t>(bufferData.size() * sizeof(RGBA8)), reinterpret_cast<const uint8_t*>(bufferData.data()));
 
         // Create a texture that is `width` x `height` with (`level` + 1) mip levels.
         nxt::Texture texture = device.CreateTextureBuilder()

--- a/src/tests/end2end/PushConstantTests.cpp
+++ b/src/tests/end2end/PushConstantTests.cpp
@@ -36,7 +36,7 @@ class PushConstantTest: public NXTTest {
                 .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
                 .GetResult();
             uint32_t one = 1;
-            buf1.SetSubData(0, 1, &one);
+            buf1.SetSubData(0, sizeof(one), reinterpret_cast<uint8_t*>(&one));
 
             nxt::Buffer buf2 = device.CreateBufferBuilder()
                 .SetSize(4)

--- a/src/tests/unittests/validation/BufferValidationTests.cpp
+++ b/src/tests/unittests/validation/BufferValidationTests.cpp
@@ -487,28 +487,28 @@ TEST_F(BufferValidationTest, DestroyInsideMapWriteCallback) {
 
 // Test the success case for Buffer::SetSubData
 TEST_F(BufferValidationTest, SetSubDataSuccess) {
-    nxt::Buffer buf = CreateSetSubDataBuffer(4);
+    nxt::Buffer buf = CreateSetSubDataBuffer(1);
 
-    uint32_t foo = 0;
-    buf.SetSubData(0, 1, &foo);
+    uint8_t foo = 0;
+    buf.SetSubData(0, sizeof(foo), &foo);
 }
 
 // Test error case for SetSubData out of bounds
 TEST_F(BufferValidationTest, SetSubDataOutOfBounds) {
-    nxt::Buffer buf = CreateSetSubDataBuffer(4);
+    nxt::Buffer buf = CreateSetSubDataBuffer(1);
 
-    uint32_t foo = 0;
+    uint8_t foo = 0;
     ASSERT_DEVICE_ERROR(buf.SetSubData(0, 2, &foo));
 }
 
 // Test error case for SetSubData with the wrong usage
 TEST_F(BufferValidationTest, SetSubDataWrongUsage) {
     nxt::Buffer buf = device.CreateBufferBuilder()
-        .SetSize(4)
+        .SetSize(1)
         .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::Vertex)
         .SetInitialUsage(nxt::BufferUsageBit::Vertex)
         .GetResult();
 
-    uint32_t foo = 0;
-    ASSERT_DEVICE_ERROR(buf.SetSubData(0, 1, &foo));
+    uint8_t foo = 0;
+    ASSERT_DEVICE_ERROR(buf.SetSubData(0, sizeof(foo), &foo));
 }

--- a/src/tests/unittests/validation/UsageValidationTests.cpp
+++ b/src/tests/unittests/validation/UsageValidationTests.cpp
@@ -35,16 +35,16 @@ TEST_F(UsageValidationTest, UsageAfterCommandBuffer) {
     // Should we make an end2end test that tests this as well?
 
     nxt::Buffer buf = device.CreateBufferBuilder()
-        .SetSize(4)
+        .SetSize(1)
         .SetAllowedUsage(nxt::BufferUsageBit::TransferDst | nxt::BufferUsageBit::Vertex)
         .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
         .GetResult();
 
-    uint32_t foo = 0;
-    buf.SetSubData(0, 1, &foo);
+    uint8_t foo = 0;
+    buf.SetSubData(0, sizeof(foo), &foo);
 
     buf.TransitionUsage(nxt::BufferUsageBit::Vertex);
-    ASSERT_DEVICE_ERROR(buf.SetSubData(0, 1, &foo));
+    ASSERT_DEVICE_ERROR(buf.SetSubData(0, sizeof(foo), &foo));
 
     nxt::CommandBuffer cmdbuf = device.CreateCommandBufferBuilder()
         .TransitionBufferUsage(buf, nxt::BufferUsageBit::TransferDst)
@@ -52,5 +52,5 @@ TEST_F(UsageValidationTest, UsageAfterCommandBuffer) {
     queue.Submit(1, &cmdbuf);
     // buf should be in TransferDst usage
 
-    buf.SetSubData(0, 1, &foo);
+    buf.SetSubData(0, sizeof(foo), &foo);
 }

--- a/src/utils/NXTHelpers.cpp
+++ b/src/utils/NXTHelpers.cpp
@@ -106,7 +106,7 @@ namespace utils {
                                  .SetInitialUsage(nxt::BufferUsageBit::TransferDst)
                                  .SetSize(size)
                                  .GetResult();
-        buffer.SetSubData(0, size / sizeof(uint32_t), reinterpret_cast<const uint32_t*>(data));
+        buffer.SetSubData(0, size, reinterpret_cast<const uint8_t*>(data));
         buffer.FreezeUsage(usage);
         return buffer;
     }


### PR DESCRIPTION
Change the uint32_t offsets in Buffer::SetSubData() to be uint8_ts, rather than uint32_ts.
This makes it practical to do subloads of 16-bit index buffers, for example.