### PR TITLE
Implement recent vertex and texture formats on Vk.

### DIFF
--- a/src/backend/vulkan/InputStateVk.cpp
+++ b/src/backend/vulkan/InputStateVk.cpp
@@ -41,6 +41,10 @@ namespace backend { namespace vulkan {
                     return VK_FORMAT_R32G32_SFLOAT;
                 case nxt::VertexFormat::FloatR32:
                     return VK_FORMAT_R32_SFLOAT;
+                case nxt::VertexFormat::UnormR8G8B8A8:
+                    return VK_FORMAT_R8G8B8A8_UNORM;
+                case nxt::VertexFormat::UnormR8G8:
+                    return VK_FORMAT_R8G8_UNORM;
                 default:
                     UNREACHABLE();
             }

--- a/src/backend/vulkan/TextureVk.cpp
+++ b/src/backend/vulkan/TextureVk.cpp
@@ -188,8 +188,16 @@ namespace backend { namespace vulkan {
         switch (format) {
             case nxt::TextureFormat::R8G8B8A8Unorm:
                 return VK_FORMAT_R8G8B8A8_UNORM;
+            case nxt::TextureFormat::R8G8Unorm:
+                return VK_FORMAT_R8G8_UNORM;
+            case nxt::TextureFormat::R8Unorm:
+                return VK_FORMAT_R8_UNORM;
             case nxt::TextureFormat::R8G8B8A8Uint:
                 return VK_FORMAT_R8G8B8A8_UINT;
+            case nxt::TextureFormat::R8G8Uint:
+                return VK_FORMAT_R8G8_UINT;
+            case nxt::TextureFormat::R8Uint:
+                return VK_FORMAT_R8_UINT;
             case nxt::TextureFormat::B8G8R8A8Unorm:
                 return VK_FORMAT_B8G8R8A8_UNORM;
             case nxt::TextureFormat::D32FloatS8Uint:


### PR DESCRIPTION
Implement unorm_rgba8 and unorm_rg8 vertex formats and
{uint8, unorm8} x {r, rg} texture formats on Vulkan backend.