### PR TITLE
Add support for r16g16 and r16g16b16a16 ushort vertex formats.

### DIFF
--- a/next.json
+++ b/next.json
@@ -1244,7 +1244,8 @@
             {"value": 2, "name": "float r32 g32"},
             {"value": 3, "name": "float r32"},
             {"value": 4, "name": "unorm r8 g8 b8 a8"},
-            {"value": 5, "name": "unorm r8 g8"}
+            {"value": 5, "name": "unorm r8 g8"},
+            {"value": 6, "name": "ushort r16 g16"}
         ]
     },
     "void": {

--- a/next.json
+++ b/next.json
@@ -1243,9 +1243,10 @@
             {"value": 1, "name": "float r32 g32 b32"},
             {"value": 2, "name": "float r32 g32"},
             {"value": 3, "name": "float r32"},
-            {"value": 4, "name": "unorm r8 g8 b8 a8"},
-            {"value": 5, "name": "unorm r8 g8"},
-            {"value": 6, "name": "ushort r16 g16"}
+            {"value": 4, "name": "ushort r16 g16 b16 a16"},
+            {"value": 5, "name": "ushort r16 g16"},
+            {"value": 6, "name": "unorm r8 g8 b8 a8"},
+            {"value": 7, "name": "unorm r8 g8"}
         ]
     },
     "void": {

--- a/src/backend/InputState.cpp
+++ b/src/backend/InputState.cpp
@@ -35,17 +35,17 @@ namespace backend {
     uint32_t VertexFormatNumComponents(nxt::VertexFormat format) {
         switch (format) {
             case nxt::VertexFormat::FloatR32G32B32A32:
+            case nxt::VertexFormat::UshortR16G16B16A16:
             case nxt::VertexFormat::UnormR8G8B8A8:
                 return 4;
             case nxt::VertexFormat::FloatR32G32B32:
                 return 3;
             case nxt::VertexFormat::FloatR32G32:
+            case nxt::VertexFormat::UshortR16G16:
             case nxt::VertexFormat::UnormR8G8:
                 return 2;
             case nxt::VertexFormat::FloatR32:
                 return 1;
-            case nxt::VertexFormat::UshortR16G16:
-                return 2;
             default:
                 UNREACHABLE();
         }
@@ -58,11 +58,12 @@ namespace backend {
             case nxt::VertexFormat::FloatR32G32:
             case nxt::VertexFormat::FloatR32:
                 return sizeof(float);
+            case nxt::VertexFormat::UshortR16G16B16A16:
+            case nxt::VertexFormat::UshortR16G16:
+                return sizeof(uint16_t);
             case nxt::VertexFormat::UnormR8G8B8A8:
             case nxt::VertexFormat::UnormR8G8:
                 return sizeof(uint8_t);
-            case nxt::VertexFormat::UshortR16G16:
-                return sizeof(unsigned short);
             default:
                 UNREACHABLE();
         }

--- a/src/backend/InputState.cpp
+++ b/src/backend/InputState.cpp
@@ -44,6 +44,8 @@ namespace backend {
                 return 2;
             case nxt::VertexFormat::FloatR32:
                 return 1;
+            case nxt::VertexFormat::UshortR16G16:
+                return 2;
             default:
                 UNREACHABLE();
         }
@@ -59,6 +61,8 @@ namespace backend {
             case nxt::VertexFormat::UnormR8G8B8A8:
             case nxt::VertexFormat::UnormR8G8:
                 return sizeof(uint8_t);
+            case nxt::VertexFormat::UshortR16G16:
+                return sizeof(unsigned short);
             default:
                 UNREACHABLE();
         }

--- a/src/backend/d3d12/InputStateD3D12.cpp
+++ b/src/backend/d3d12/InputStateD3D12.cpp
@@ -28,6 +28,8 @@ namespace backend { namespace d3d12 {
                 return DXGI_FORMAT_R32G32_FLOAT;
             case nxt::VertexFormat::FloatR32:
                 return DXGI_FORMAT_R32_FLOAT;
+            case nxt::VertexFormat::UshortR16G16:
+                return DXGI_FORMAT_R16G16_UINT;
             case nxt::VertexFormat::UnormR8G8B8A8:
                 return DXGI_FORMAT_R8G8B8A8_UNORM;
             case nxt::VertexFormat::UnormR8G8:

--- a/src/backend/d3d12/InputStateD3D12.cpp
+++ b/src/backend/d3d12/InputStateD3D12.cpp
@@ -28,6 +28,8 @@ namespace backend { namespace d3d12 {
                 return DXGI_FORMAT_R32G32_FLOAT;
             case nxt::VertexFormat::FloatR32:
                 return DXGI_FORMAT_R32_FLOAT;
+            case nxt::VertexFormat::UshortR16G16B16A16:
+                return DXGI_FORMAT_R16G16B16A16_UINT;
             case nxt::VertexFormat::UshortR16G16:
                 return DXGI_FORMAT_R16G16_UINT;
             case nxt::VertexFormat::UnormR8G8B8A8:

--- a/src/backend/metal/InputStateMTL.mm
+++ b/src/backend/metal/InputStateMTL.mm
@@ -30,6 +30,8 @@ namespace backend { namespace metal {
                     return MTLVertexFormatFloat2;
                 case nxt::VertexFormat::FloatR32:
                     return MTLVertexFormatFloat;
+                case nxt::VertexFormat::UshortR16G16:
+                    return MTLVertexFormatUShort2;
                 case nxt::VertexFormat::UnormR8G8B8A8:
                     return MTLVertexFormatUChar4Normalized;
                 case nxt::VertexFormat::UnormR8G8:

--- a/src/backend/metal/InputStateMTL.mm
+++ b/src/backend/metal/InputStateMTL.mm
@@ -30,6 +30,8 @@ namespace backend { namespace metal {
                     return MTLVertexFormatFloat2;
                 case nxt::VertexFormat::FloatR32:
                     return MTLVertexFormatFloat;
+                case nxt::VertexFormat::UshortR16G16B16A16:
+                    return MTLVertexFormatUShort4;
                 case nxt::VertexFormat::UshortR16G16:
                     return MTLVertexFormatUShort2;
                 case nxt::VertexFormat::UnormR8G8B8A8:

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -49,6 +49,7 @@ namespace backend { namespace opengl {
                 case nxt::VertexFormat::FloatR32G32:
                 case nxt::VertexFormat::FloatR32:
                     return GL_FLOAT;
+                case nxt::VertexFormat::UshortR16G16B16A16:
                 case nxt::VertexFormat::UshortR16G16:
                     return GL_UNSIGNED_SHORT;
                 case nxt::VertexFormat::UnormR8G8B8A8:
@@ -61,17 +62,11 @@ namespace backend { namespace opengl {
 
         GLboolean VertexFormatIsNormalized(nxt::VertexFormat format) {
             switch (format) {
-                case nxt::VertexFormat::FloatR32G32B32A32:
-                case nxt::VertexFormat::FloatR32G32B32:
-                case nxt::VertexFormat::FloatR32G32:
-                case nxt::VertexFormat::FloatR32:
-                case nxt::VertexFormat::UshortR16G16:
-                    return GL_FALSE;
                 case nxt::VertexFormat::UnormR8G8B8A8:
                 case nxt::VertexFormat::UnormR8G8:
                     return GL_TRUE;
                 default:
-                    UNREACHABLE();
+                    return GL_FALSE;
             }
         }
 

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -49,6 +49,8 @@ namespace backend { namespace opengl {
                 case nxt::VertexFormat::FloatR32G32:
                 case nxt::VertexFormat::FloatR32:
                     return GL_FLOAT;
+                case nxt::VertexFormat::UshortR16G16:
+                    return GL_UNSIGNED_SHORT;
                 case nxt::VertexFormat::UnormR8G8B8A8:
                 case nxt::VertexFormat::UnormR8G8:
                     return GL_UNSIGNED_BYTE;
@@ -63,6 +65,7 @@ namespace backend { namespace opengl {
                 case nxt::VertexFormat::FloatR32G32B32:
                 case nxt::VertexFormat::FloatR32G32:
                 case nxt::VertexFormat::FloatR32:
+                case nxt::VertexFormat::UshortR16G16:
                     return GL_FALSE;
                 case nxt::VertexFormat::UnormR8G8B8A8:
                 case nxt::VertexFormat::UnormR8G8:

--- a/src/backend/vulkan/InputStateVk.cpp
+++ b/src/backend/vulkan/InputStateVk.cpp
@@ -41,6 +41,10 @@ namespace backend { namespace vulkan {
                     return VK_FORMAT_R32G32_SFLOAT;
                 case nxt::VertexFormat::FloatR32:
                     return VK_FORMAT_R32_SFLOAT;
+                case nxt::VertexFormat::UshortR16G16B16A16:
+                    return VK_FORMAT_R16G16B16A16_UINT;
+                case nxt::VertexFormat::UshortR16G16:
+                    return VK_FORMAT_R16G16_UINT;
                 case nxt::VertexFormat::UnormR8G8B8A8:
                     return VK_FORMAT_R8G8B8A8_UNORM;
                 case nxt::VertexFormat::UnormR8G8:


### PR DESCRIPTION
Add support for r16g16 and r16g16b16a16 ushort vertex formats.

(r16 skipped because it requires MacOS 10.13.)