### PR TITLE
Implement support for all Int32 vertex formats.

### DIFF
--- a/next.json
+++ b/next.json
@@ -1239,14 +1239,18 @@
     "vertex format": {
         "category": "enum",
         "values": [
-            {"value": 0, "name": "float r32 g32 b32 a32"},
-            {"value": 1, "name": "float r32 g32 b32"},
-            {"value": 2, "name": "float r32 g32"},
-            {"value": 3, "name": "float r32"},
-            {"value": 4, "name": "ushort r16 g16 b16 a16"},
-            {"value": 5, "name": "ushort r16 g16"},
-            {"value": 6, "name": "unorm r8 g8 b8 a8"},
-            {"value": 7, "name": "unorm r8 g8"}
+            {"value": 0,  "name": "float r32 g32 b32 a32"},
+            {"value": 1,  "name": "float r32 g32 b32"},
+            {"value": 2,  "name": "float r32 g32"},
+            {"value": 3,  "name": "float r32"},
+            {"value": 4,  "name": "int r32 g32 b32 a32"},
+            {"value": 5,  "name": "int r32 g32 b32"},
+            {"value": 6,  "name": "int r32 g32"},
+            {"value": 7,  "name": "int r32"},
+            {"value": 8,  "name": "ushort r16 g16 b16 a16"},
+            {"value": 9,  "name": "ushort r16 g16"},
+            {"value": 10, "name": "unorm r8 g8 b8 a8"},
+            {"value": 11, "name": "unorm r8 g8"}
         ]
     },
     "void": {

--- a/src/backend/InputState.cpp
+++ b/src/backend/InputState.cpp
@@ -35,16 +35,20 @@ namespace backend {
     uint32_t VertexFormatNumComponents(nxt::VertexFormat format) {
         switch (format) {
             case nxt::VertexFormat::FloatR32G32B32A32:
+            case nxt::VertexFormat::IntR32G32B32A32:
             case nxt::VertexFormat::UshortR16G16B16A16:
             case nxt::VertexFormat::UnormR8G8B8A8:
                 return 4;
             case nxt::VertexFormat::FloatR32G32B32:
+            case nxt::VertexFormat::IntR32G32B32:
                 return 3;
             case nxt::VertexFormat::FloatR32G32:
+            case nxt::VertexFormat::IntR32G32:
             case nxt::VertexFormat::UshortR16G16:
             case nxt::VertexFormat::UnormR8G8:
                 return 2;
             case nxt::VertexFormat::FloatR32:
+            case nxt::VertexFormat::IntR32:
                 return 1;
             default:
                 UNREACHABLE();
@@ -58,6 +62,11 @@ namespace backend {
             case nxt::VertexFormat::FloatR32G32:
             case nxt::VertexFormat::FloatR32:
                 return sizeof(float);
+            case nxt::VertexFormat::IntR32G32B32A32:
+            case nxt::VertexFormat::IntR32G32B32:
+            case nxt::VertexFormat::IntR32G32:
+            case nxt::VertexFormat::IntR32:
+                return sizeof(int32_t);
             case nxt::VertexFormat::UshortR16G16B16A16:
             case nxt::VertexFormat::UshortR16G16:
                 return sizeof(uint16_t);

--- a/src/backend/d3d12/InputStateD3D12.cpp
+++ b/src/backend/d3d12/InputStateD3D12.cpp
@@ -28,6 +28,14 @@ namespace backend { namespace d3d12 {
                 return DXGI_FORMAT_R32G32_FLOAT;
             case nxt::VertexFormat::FloatR32:
                 return DXGI_FORMAT_R32_FLOAT;
+            case nxt::VertexFormat::IntR32G32B32A32:
+                return DXGI_FORMAT_R32_G32_B32_A32_SINT;
+            case nxt::VertexFormat::IntR32G32B32:
+                return DXGI_FORMAT_R32_G32_B32_SINT;
+            case nxt::VertexFormat::IntR32G32:
+                return DXGI_FORMAT_R32_G32_SINT;
+            case nxt::VertexFormat::IntR32:
+                return DXGI_FORMAT_R32_SINT;
             case nxt::VertexFormat::UshortR16G16B16A16:
                 return DXGI_FORMAT_R16G16B16A16_UINT;
             case nxt::VertexFormat::UshortR16G16:

--- a/src/backend/d3d12/InputStateD3D12.cpp
+++ b/src/backend/d3d12/InputStateD3D12.cpp
@@ -29,11 +29,11 @@ namespace backend { namespace d3d12 {
             case nxt::VertexFormat::FloatR32:
                 return DXGI_FORMAT_R32_FLOAT;
             case nxt::VertexFormat::IntR32G32B32A32:
-                return DXGI_FORMAT_R32_G32_B32_A32_SINT;
+                return DXGI_FORMAT_R32G32B32A32_SINT;
             case nxt::VertexFormat::IntR32G32B32:
-                return DXGI_FORMAT_R32_G32_B32_SINT;
+                return DXGI_FORMAT_R32G32B32_SINT;
             case nxt::VertexFormat::IntR32G32:
-                return DXGI_FORMAT_R32_G32_SINT;
+                return DXGI_FORMAT_R32G32_SINT;
             case nxt::VertexFormat::IntR32:
                 return DXGI_FORMAT_R32_SINT;
             case nxt::VertexFormat::UshortR16G16B16A16:

--- a/src/backend/metal/InputStateMTL.mm
+++ b/src/backend/metal/InputStateMTL.mm
@@ -30,6 +30,14 @@ namespace backend { namespace metal {
                     return MTLVertexFormatFloat2;
                 case nxt::VertexFormat::FloatR32:
                     return MTLVertexFormatFloat;
+                case nxt::VertexFormat::IntR32G32B32A32:
+                    return MTLVertexFormatInt4;
+                case nxt::VertexFormat::IntR32G32B32:
+                    return MTLVertexFormatInt3;
+                case nxt::VertexFormat::IntR32G32:
+                    return MTLVertexFormatInt2;
+                case nxt::VertexFormat::IntR32:
+                    return MTLVertexFormatInt;
                 case nxt::VertexFormat::UshortR16G16B16A16:
                     return MTLVertexFormatUShort4;
                 case nxt::VertexFormat::UshortR16G16:

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -49,6 +49,11 @@ namespace backend { namespace opengl {
                 case nxt::VertexFormat::FloatR32G32:
                 case nxt::VertexFormat::FloatR32:
                     return GL_FLOAT;
+                case nxt::VertexFormat::IntR32G32B32A32:
+                case nxt::VertexFormat::IntR32G32B32:
+                case nxt::VertexFormat::IntR32G32:
+                case nxt::VertexFormat::IntR32:
+                    return GL_INT;
                 case nxt::VertexFormat::UshortR16G16B16A16:
                 case nxt::VertexFormat::UshortR16G16:
                     return GL_UNSIGNED_SHORT;

--- a/src/backend/vulkan/InputStateVk.cpp
+++ b/src/backend/vulkan/InputStateVk.cpp
@@ -41,6 +41,14 @@ namespace backend { namespace vulkan {
                     return VK_FORMAT_R32G32_SFLOAT;
                 case nxt::VertexFormat::FloatR32:
                     return VK_FORMAT_R32_SFLOAT;
+                case nxt::VertexFormat::IntR32G32B32A32:
+                    return VK_FORMAT_R32G32B32A32_SINT;
+                case nxt::VertexFormat::IntR32G32B32:
+                    return VK_FORMAT_R32G32B32_SINT;
+                case nxt::VertexFormat::IntR32G32:
+                    return VK_FORMAT_R32G32_SINT;
+                case nxt::VertexFormat::IntR32:
+                    return VK_FORMAT_R32_SINT;
                 case nxt::VertexFormat::UshortR16G16B16A16:
                     return VK_FORMAT_R16G16B16A16_UINT;
                 case nxt::VertexFormat::UshortR16G16:


### PR DESCRIPTION
Add support for { int } x { rgba32, rgb32, rg32, r32 } vertex formats.