### PR TITLE
D3D12 fix for Framebuffer GPU refcount issue.

### DIFF
--- a/src/backend/d3d12/DescriptorHeapAllocator.cpp
+++ b/src/backend/d3d12/DescriptorHeapAllocator.cpp
@@ -96,6 +96,9 @@ namespace backend { namespace d3d12 {
         ComPtr<ID3D12DescriptorHeap> heap;
         ASSERT_SUCCESS(
             mDevice->GetD3D12Device()->CreateDescriptorHeap(&heapDescriptor, IID_PPV_ARGS(&heap)));
+        if (heapInfo->first) {
+            mDevice->ReferenceUntilUnused(heapInfo->first);
+        }
 
         AllocationInfo allocationInfo = {allocationSize, allocationSize - count};
         *heapInfo = std::make_pair(heap, allocationInfo);


### PR DESCRIPTION
Reference the outgoing heap ComPtr, so it doesn't get Released before
the GPU is done with it.

This fixes intermittent ComPtr assertions on the D3D12 backend.