### PR TITLE
 Expand allowable formats for color attachments

### DIFF
--- a/scripts/travis_lint_format.sh
+++ b/scripts/travis_lint_format.sh
@@ -24,7 +24,7 @@ files_to_check=$(echo $files_to_check | tr '\n' ' ')
 
 # Run git-clang-format, check if it formatted anything
 format_output=$(scripts/git-clang-format --binary $1 --commit $base_commit --diff --style=file $files_to_check)
-if [ "$format_output" == "clang-format did not modify any files" ] ; then
+if [ "$format_output" == "clang-format did not modify any files" ] || [ "format_output" == "no modified files to format" ] ; then
     exit 0
 fi
 

--- a/src/backend/opengl/CommandBufferGL.cpp
+++ b/src/backend/opengl/CommandBufferGL.cpp
@@ -311,9 +311,12 @@ namespace backend { namespace opengl {
                         attachmentCount = location + 1;
 
                         // TODO(kainino@chromium.org): the color clears (later in
-                        // this function) may be undefined for other texture formats.
-                        ASSERT(textureView->GetTexture()->GetFormat() ==
-                               nxt::TextureFormat::R8G8B8A8Unorm);
+                        // this function) may be undefined for non-normalized integer formats.
+                        nxt::TextureFormat format = textureView->GetTexture()->GetFormat();
+                        ASSERT(format == nxt::TextureFormat::R8G8B8A8Unorm ||
+                               format == nxt::TextureFormat::R8G8Unorm ||
+                               format == nxt::TextureFormat::R8Unorm ||
+                               format == nxt::TextureFormat::B8G8R8A8Unorm);
                     }
                     glDrawBuffers(attachmentCount, drawBuffers.data());
 


### PR DESCRIPTION
Remove assert for command buffer color binding point texture format. It was triggering on BGRA8, R8, etc.

Here's my reasoning: all color formats we've added so far are renderable. I think only legacy formats (luminance, intensity) and compressed formats are non-renderable. And if we do add non-renderable formats, binding them should probably be caught at validation, not with an assert.