### PR TITLE
Metal backend: do a Tick() on queue submit.

### DIFF
--- a/src/backend/metal/MetalBackend.mm
+++ b/src/backend/metal/MetalBackend.mm
@@ -231,6 +231,7 @@ namespace backend { namespace metal {
 
     void Queue::Submit(uint32_t numCommands, CommandBuffer* const* commands) {
         Device* device = ToBackend(GetDevice());
+        device->Tick();
         id<MTLCommandBuffer> commandBuffer = device->GetPendingCommandBuffer();
 
         for (uint32_t i = 0; i < numCommands; ++i) {


### PR DESCRIPTION
Without this, the temporary buffers used for SetSubData() uploads never get cleaned up, and eventually will exhaust memory. Note that the D3D12 backend does this also.