### PR TITLE
Fix some leaking builder objects in common backend.

### DIFF
--- a/src/backend/PipelineLayout.cpp
+++ b/src/backend/PipelineLayout.cpp
@@ -59,9 +59,11 @@ namespace backend {
         // the device once we have a cache of BGL
         for (size_t group = 0; group < kMaxBindGroups; ++group) {
             if (!mBindGroupLayouts[group]) {
-                mBindGroupLayouts[group] = mDevice->CreateBindGroupLayoutBuilder()->GetResult();
+                auto builder = mDevice->CreateBindGroupLayoutBuilder();
+                mBindGroupLayouts[group] = builder->GetResult();
                 // Remove the external ref objects are created with
                 mBindGroupLayouts[group]->Release();
+                builder->Release();
             }
         }
 

--- a/src/backend/RenderPipeline.cpp
+++ b/src/backend/RenderPipeline.cpp
@@ -88,14 +88,18 @@ namespace backend {
         // TODO(cwallez@chromium.org): the layout should be required, and put the default objects in
         // the device
         if (!mInputState) {
-            mInputState = mDevice->CreateInputStateBuilder()->GetResult();
+            auto builder = mDevice->CreateInputStateBuilder();
+            mInputState = builder->GetResult();
             // Remove the external ref objects are created with
             mInputState->Release();
+            builder->Release();
         }
         if (!mDepthStencilState) {
-            mDepthStencilState = mDevice->CreateDepthStencilStateBuilder()->GetResult();
+            auto builder = mDevice->CreateDepthStencilStateBuilder();
+            mDepthStencilState = builder->GetResult();
             // Remove the external ref objects are created with
             mDepthStencilState->Release();
+            builder->Release();
         }
         if (!mRenderPass) {
             HandleError("Pipeline render pass not set");

--- a/src/backend/SwapChain.cpp
+++ b/src/backend/SwapChain.cpp
@@ -68,6 +68,7 @@ namespace backend {
 
         auto* texture = GetNextTextureImpl(builder);
         mLastNextTexture = texture;
+        builder->Release();
         return texture;
     }
 


### PR DESCRIPTION
Delete the TextureBuilder created in SwapChainBase::GetNextTexture().
Delete the InputStateBuilder and DepthStencilStateBuilder created in
RenderPipelineBuilder::GetResultImpl().