### PR TITLE
Fix leak in Metal's Device::GetPendingCommandBuffer().

### DIFF
--- a/scripts/travis_lint_format.sh
+++ b/scripts/travis_lint_format.sh
@@ -24,7 +24,7 @@ files_to_check=$(echo $files_to_check | tr '\n' ' ')
 
 # Run git-clang-format, check if it formatted anything
 format_output=$(scripts/git-clang-format --binary $1 --commit $base_commit --diff --style=file $files_to_check)
-if [ "$format_output" == "clang-format did not modify any files" ] || [ "format_output" == "no modified files to format" ] ; then
+if [ "$format_output" == "clang-format did not modify any files" ] || [ "$format_output" == "no modified files to format" ] ; then
     exit 0
 fi
 

--- a/src/backend/metal/MetalBackend.mm
+++ b/src/backend/metal/MetalBackend.mm
@@ -152,7 +152,6 @@ namespace backend { namespace metal {
     id<MTLCommandBuffer> Device::GetPendingCommandBuffer() {
         if (mPendingCommands == nil) {
             mPendingCommands = [mCommandQueue commandBuffer];
-            [mPendingCommands retain];
         }
         return mPendingCommands;
     }


### PR DESCRIPTION
GetPendingCommandBuffer() doesn't need to retain the metal
command buffer; it's created with a ref.