### PR TITLE
Error handling scaffolding.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(NXT_ENABLE_NULL "Enable compilation of the Null backend" ON)
 option(NXT_ENABLE_OPENGL "Enable compilation of the OpenGL backend" ON)
 option(NXT_ENABLE_VULKAN "Enable compilation of the Vulkan backend" OFF)
 option(NXT_ALWAYS_ASSERT "Enable assertions on all build types" OFF)
+option(NXT_USE_CPP17 "Use some optional C++17 features for compile-time checks" OFF)
 
 ################################################################################
 # Precompute compile flags and defines, functions to set them
@@ -63,6 +64,12 @@ set(NXT_GENERATED_FLAGS "")
 set(NXT_ENABLE_ASSERTS $<OR:$<CONFIG:Debug>,$<BOOL:${NXT_ALWAYS_ASSERT}>>)
 
 list(APPEND NXT_DEFS $<${NXT_ENABLE_ASSERTS}:NXT_ENABLE_ASSERTS>)
+
+if (NXT_USE_CPP17)
+    list(APPEND NXT_INTERNAL_DEFS "NXT_CPP_VERSION=17")
+else()
+    list(APPEND NXT_INTERNAL_DEFS "NXT_CPP_VERSION=14")
+endif()
 
 if (NXT_ENABLE_D3D12)
     list(APPEND NXT_INTERNAL_DEFS "NXT_ENABLE_BACKEND_D3D12")

--- a/generator/templates/backend/ValidationUtils.cpp
+++ b/generator/templates/backend/ValidationUtils.cpp
@@ -17,22 +17,25 @@
 namespace backend {
 
     {% for type in by_category["enum"] %}
-        bool IsValid{{type.name.CamelCase()}}(nxt::{{as_cppType(type.name)}} value) {
+        MaybeError Validate{{type.name.CamelCase()}}(nxt::{{as_cppType(type.name)}} value) {
             switch (value) {
                 {% for value in type.values %}
                     case nxt::{{as_cppType(type.name)}}::{{as_cppEnum(value.name)}}:
-                        return true;
+                        return {};
                 {% endfor %}
                 default:
-                    return false;
+                    NXT_RETURN_ERROR("Invalid value for {{as_cType(type.name)}}");
             }
         }
 
     {% endfor %}
 
     {% for type in by_category["bitmask"] %}
-        bool IsValid{{type.name.CamelCase()}}(nxt::{{as_cppType(type.name)}} value) {
-            return (value & static_cast<nxt::{{as_cppType(type.name)}}>(~{{type.full_mask}})) == 0;
+        MaybeError Validate{{type.name.CamelCase()}}(nxt::{{as_cppType(type.name)}} value) {
+            if ((value & static_cast<nxt::{{as_cppType(type.name)}}>(~{{type.full_mask}})) == 0) {
+                return {};
+            }
+            NXT_RETURN_ERROR("Invalid value for {{as_cType(type.name)}}");
         }
 
     {% endfor %}

--- a/generator/templates/backend/ValidationUtils.h
+++ b/generator/templates/backend/ValidationUtils.h
@@ -17,11 +17,13 @@
 
 #include "nxt/nxtcpp.h"
 
+#include "backend/Error.h"
+
 namespace backend {
 
     // Helper functions to check the value of enums and bitmasks
     {% for type in by_category["enum"] + by_category["bitmask"] %}
-        bool IsValid{{type.name.CamelCase()}}(nxt::{{as_cppType(type.name)}} value);
+        MaybeError Validate{{type.name.CamelCase()}}(nxt::{{as_cppType(type.name)}} value);
     {% endfor %}
 
 } // namespace backend

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -30,6 +30,7 @@ Generate(
 )
 target_link_libraries(backend_utils_autogen nxtcpp)
 target_include_directories(backend_utils_autogen PUBLIC ${GENERATED_DIR})
+target_include_directories(backend_utils_autogen PRIVATE ${SRC_DIR})
 
 function(GenerateProcTable backend)
     Generate(
@@ -342,6 +343,10 @@ list(APPEND BACKEND_SOURCES
     ${BACKEND_DIR}/CommandBufferStateTracker.h
     ${BACKEND_DIR}/Device.cpp
     ${BACKEND_DIR}/Device.h
+    ${BACKEND_DIR}/Error.cpp
+    ${BACKEND_DIR}/Error.h
+    ${BACKEND_DIR}/ErrorData.cpp
+    ${BACKEND_DIR}/ErrorData.h
     ${BACKEND_DIR}/Forward.h
     ${BACKEND_DIR}/InputState.cpp
     ${BACKEND_DIR}/InputState.h

--- a/src/backend/Device.cpp
+++ b/src/backend/Device.cpp
@@ -139,7 +139,13 @@ namespace backend {
             return nullptr;
         }
 
-        return CreateSamplerImpl(descriptor);
+        ResultOrError<SamplerBase*> maybeSampler = CreateSamplerImpl(descriptor);
+        if (maybeSampler.IsError()) {
+            // TODO(cwallez@chromium.org): Implement the WebGPU error handling mechanism.
+            delete validation.AcquireError();
+            return nullptr;
+        }
+        return maybeSampler.AcquireSuccess();
     }
     ShaderModuleBuilder* DeviceBase::CreateShaderModuleBuilder() {
         return new ShaderModuleBuilder(this);

--- a/src/backend/Device.cpp
+++ b/src/backend/Device.cpp
@@ -21,6 +21,7 @@
 #include "backend/CommandBuffer.h"
 #include "backend/ComputePipeline.h"
 #include "backend/DepthStencilState.h"
+#include "backend/ErrorData.h"
 #include "backend/InputState.h"
 #include "backend/PipelineLayout.h"
 #include "backend/Queue.h"
@@ -131,9 +132,13 @@ namespace backend {
         return new RenderPipelineBuilder(this);
     }
     SamplerBase* DeviceBase::CreateSampler(const nxt::SamplerDescriptor* descriptor) {
-        if (!ValidateSamplerDescriptor(this, descriptor)) {
+        MaybeError validation = ValidateSamplerDescriptor(this, descriptor);
+        if (validation.IsError()) {
+            // TODO(cwallez@chromium.org): Implement the WebGPU error handling mechanism.
+            delete validation.AcquireError();
             return nullptr;
         }
+
         return CreateSamplerImpl(descriptor);
     }
     ShaderModuleBuilder* DeviceBase::CreateShaderModuleBuilder() {

--- a/src/backend/Device.h
+++ b/src/backend/Device.h
@@ -15,6 +15,7 @@
 #ifndef BACKEND_DEVICEBASE_H_
 #define BACKEND_DEVICEBASE_H_
 
+#include "backend/Error.h"
 #include "backend/Forward.h"
 #include "backend/RefCounted.h"
 
@@ -98,7 +99,8 @@ namespace backend {
         void Release();
 
       private:
-        virtual SamplerBase* CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) = 0;
+        virtual ResultOrError<SamplerBase*> CreateSamplerImpl(
+            const nxt::SamplerDescriptor* descriptor) = 0;
 
         // The object caches aren't exposed in the header as they would require a lot of
         // additional includes.

--- a/src/backend/Error.cpp
+++ b/src/backend/Error.cpp
@@ -1,0 +1,31 @@
+// Copyright 2018 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "backend/Error.h"
+
+#include "backend/ErrorData.h"
+
+namespace backend {
+
+    ErrorData* MakeError(const char* message, const char* file, const char* function, int line) {
+        ErrorData* error = new ErrorData(message);
+        error->AppendBacktrace(file, function, line);
+        return error;
+    }
+
+    void AppendBacktrace(ErrorData* error, const char* file, const char* function, int line) {
+        error->AppendBacktrace(file, function, line);
+    }
+
+}  // namespace backend

--- a/src/backend/Error.h
+++ b/src/backend/Error.h
@@ -1,0 +1,83 @@
+// Copyright 2018 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_ERROR_H_
+#define BACKEND_ERROR_H_
+
+#include "common/Result.h"
+
+namespace backend {
+
+    // This is the content of an error value for MaybeError or ResultOrError, split off to its own
+    // file to avoid having all files including headers like <string> and <vector>
+    class ErrorData;
+
+    // MaybeError and ResultOrError are meant to be used as return value for function that are not
+    // expected to, but might fail. The handling of error is potentially much slower than successes.
+    using MaybeError = Result<void, ErrorData*>;
+
+    template <typename T>
+    using ResultOrError = Result<T, ErrorData*>;
+
+    // Returning a success is done like so:
+    //   return {}; // for Error
+    //   return SomethingOfTypeT; // for ResultOrError<T>
+    //
+    // Returning an error is done via:
+    //   NXT_RETURN_ERROR("My error message");
+#define NXT_RETURN_ERROR(EXPR) return MakeError(EXPR, __FILE__, __func__, __LINE__)
+
+#define NXT_CONCAT1(x, y) x##y
+#define NXT_CONCAT2(x, y) NXT_CONCAT1(x, y)
+#define NXT_LOCAL_VAR NXT_CONCAT2(_localVar, __LINE__)
+
+    // When Errors aren't handled explicitly, calls to functions returning errors should be
+    // wrapped in an NXT_TRY. It will return the error if any, otherwise keep executing
+    // the current function.
+#define NXT_TRY(EXPR)                                             \
+    {                                                             \
+        auto NXT_LOCAL_VAR = EXPR;                                \
+        if (NXT_UNLIKELY(NXT_LOCAL_VAR.IsError())) {              \
+            ErrorData* error = NXT_LOCAL_VAR.AcquireError();      \
+            AppendBacktrace(error, __FILE__, __func__, __LINE__); \
+            return {error};                                       \
+        }                                                         \
+    }                                                             \
+    for (;;)                                                      \
+    break
+
+    // NXT_TRY_ASSIGN is the same as NXT_TRY for ResultOrError and assigns the success value, if
+    // any, to VAR.
+#define NXT_TRY_ASSIGN(VAR, EXPR)                                 \
+    {                                                             \
+        auto NXT_LOCAL_VAR = EXPR;                                \
+        if (NXT_UNLIKELY(NXT_LOCAL_VAR.IsError())) {              \
+            ErrorData* error = NXT_LOCAL_VAR.AcquireError();      \
+            AppendBacktrace(error, __FILE__, __func__, __LINE__); \
+            return {error};                                       \
+        }                                                         \
+        VAR = NXT_LOCAL_VAR.AcquireSuccess();                     \
+    }                                                             \
+    for (;;)                                                      \
+    break
+
+    // Implementation detail of NXT_TRY and NXT_TRY_ASSIGN's adding to the Error's backtrace.
+    void AppendBacktrace(ErrorData* error, const char* file, const char* function, int line);
+
+    // Implementation detail of NXT_RETURN_ERROR
+    ErrorData* MakeError(const char* message, const char* file, const char* function, int line);
+
+}  // namespace backend
+
+#endif  // BACKEND_ERROR_H_

--- a/src/backend/ErrorData.cpp
+++ b/src/backend/ErrorData.cpp
@@ -1,0 +1,41 @@
+// Copyright 2018 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "backend/ErrorData.h"
+
+namespace backend {
+
+    ErrorData::ErrorData() = default;
+
+    ErrorData::ErrorData(std::string message) : mMessage(std::move(message)) {
+    }
+
+    void ErrorData::AppendBacktrace(const char* file, const char* function, int line) {
+        BacktraceRecord record;
+        record.file = file;
+        record.function = function;
+        record.line = line;
+
+        mBacktrace.push_back(std::move(record));
+    }
+
+    const std::string& ErrorData::GetMessage() const {
+        return mMessage;
+    }
+
+    const std::vector<ErrorData::BacktraceRecord>& ErrorData::GetBacktrace() const {
+        return mBacktrace;
+    }
+
+}  // namespace backend

--- a/src/backend/ErrorData.h
+++ b/src/backend/ErrorData.h
@@ -1,0 +1,45 @@
+// Copyright 2018 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_ERRORDATA_H_
+#define BACKEND_ERRORDATA_H_
+
+#include <string>
+#include <vector>
+
+namespace backend {
+
+    class ErrorData {
+      public:
+        ErrorData();
+        ErrorData(std::string message);
+
+        struct BacktraceRecord {
+            const char* file;
+            const char* function;
+            int line;
+        };
+        void AppendBacktrace(const char* file, const char* function, int line);
+
+        const std::string& GetMessage() const;
+        const std::vector<BacktraceRecord>& GetBacktrace() const;
+
+      private:
+        std::string mMessage;
+        std::vector<BacktraceRecord> mBacktrace;
+    };
+
+}  // namespace backend
+
+#endif  // BACKEND_ERRORDATA_H_

--- a/src/backend/Sampler.cpp
+++ b/src/backend/Sampler.cpp
@@ -19,13 +19,18 @@
 
 namespace backend {
 
-    bool ValidateSamplerDescriptor(DeviceBase*, const nxt::SamplerDescriptor* descriptor) {
-        return descriptor->nextInChain == nullptr && IsValidFilterMode(descriptor->magFilter) &&
-               IsValidFilterMode(descriptor->minFilter) &&
-               IsValidFilterMode(descriptor->mipmapFilter) &&
-               IsValidAddressMode(descriptor->addressModeU) &&
-               IsValidAddressMode(descriptor->addressModeV) &&
-               IsValidAddressMode(descriptor->addressModeW);
+    MaybeError ValidateSamplerDescriptor(DeviceBase*, const nxt::SamplerDescriptor* descriptor) {
+        NXT_TRY(ValidateFilterMode(descriptor->minFilter));
+        NXT_TRY(ValidateFilterMode(descriptor->magFilter));
+        NXT_TRY(ValidateFilterMode(descriptor->mipmapFilter));
+        NXT_TRY(ValidateAddressMode(descriptor->addressModeU));
+        NXT_TRY(ValidateAddressMode(descriptor->addressModeV));
+        NXT_TRY(ValidateAddressMode(descriptor->addressModeW));
+
+        if (descriptor->nextInChain != nullptr) {
+            NXT_RETURN_ERROR("nextInChain must be nullptr");
+        }
+        return {};
     }
 
     // SamplerBase

--- a/src/backend/Sampler.h
+++ b/src/backend/Sampler.h
@@ -15,6 +15,7 @@
 #ifndef BACKEND_SAMPLER_H_
 #define BACKEND_SAMPLER_H_
 
+#include "backend/Error.h"
 #include "backend/RefCounted.h"
 
 #include "nxt/nxtcpp.h"
@@ -23,7 +24,8 @@ namespace backend {
 
     class DeviceBase;
 
-    bool ValidateSamplerDescriptor(DeviceBase* device, const nxt::SamplerDescriptor* descriptor);
+    MaybeError ValidateSamplerDescriptor(DeviceBase* device,
+                                         const nxt::SamplerDescriptor* descriptor);
 
     class SamplerBase : public RefCounted {
       public:

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -298,7 +298,8 @@ namespace backend { namespace d3d12 {
     RenderPipelineBase* Device::CreateRenderPipeline(RenderPipelineBuilder* builder) {
         return new RenderPipeline(builder);
     }
-    SamplerBase* Device::CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) {
+    ResultOrError<SamplerBase*> Device::CreateSamplerImpl(
+        const nxt::SamplerDescriptor* descriptor) {
         return new Sampler(this, descriptor);
     }
     ShaderModuleBase* Device::CreateShaderModule(ShaderModuleBuilder* builder) {

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -128,7 +128,8 @@ namespace backend { namespace d3d12 {
         void ExecuteCommandLists(std::initializer_list<ID3D12CommandList*> commandLists);
 
       private:
-        SamplerBase* CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) override;
+        ResultOrError<SamplerBase*> CreateSamplerImpl(
+            const nxt::SamplerDescriptor* descriptor) override;
 
         uint64_t mSerial = 0;
         ComPtr<ID3D12Fence> mFence;

--- a/src/backend/metal/MetalBackend.h
+++ b/src/backend/metal/MetalBackend.h
@@ -118,7 +118,8 @@ namespace backend { namespace metal {
         ResourceUploader* GetResourceUploader() const;
 
       private:
-        SamplerBase* CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) override;
+        ResultOrError<SamplerBase*> CreateSamplerImpl(
+            const nxt::SamplerDescriptor* descriptor) override;
 
         void OnCompletedHandler();
 

--- a/src/backend/metal/MetalBackend.mm
+++ b/src/backend/metal/MetalBackend.mm
@@ -117,7 +117,8 @@ namespace backend { namespace metal {
     RenderPipelineBase* Device::CreateRenderPipeline(RenderPipelineBuilder* builder) {
         return new RenderPipeline(builder);
     }
-    SamplerBase* Device::CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) {
+    ResultOrError<SamplerBase*> Device::CreateSamplerImpl(
+        const nxt::SamplerDescriptor* descriptor) {
         return new Sampler(this, descriptor);
     }
     ShaderModuleBase* Device::CreateShaderModule(ShaderModuleBuilder* builder) {

--- a/src/backend/null/NullBackend.cpp
+++ b/src/backend/null/NullBackend.cpp
@@ -76,7 +76,8 @@ namespace backend { namespace null {
     RenderPipelineBase* Device::CreateRenderPipeline(RenderPipelineBuilder* builder) {
         return new RenderPipeline(builder);
     }
-    SamplerBase* Device::CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) {
+    ResultOrError<SamplerBase*> Device::CreateSamplerImpl(
+        const nxt::SamplerDescriptor* descriptor) {
         return new Sampler(this, descriptor);
     }
     ShaderModuleBase* Device::CreateShaderModule(ShaderModuleBuilder* builder) {

--- a/src/backend/null/NullBackend.h
+++ b/src/backend/null/NullBackend.h
@@ -120,7 +120,8 @@ namespace backend { namespace null {
         std::vector<std::unique_ptr<PendingOperation>> AcquirePendingOperations();
 
       private:
-        SamplerBase* CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) override;
+        ResultOrError<SamplerBase*> CreateSamplerImpl(
+            const nxt::SamplerDescriptor* descriptor) override;
 
         std::vector<std::unique_ptr<PendingOperation>> mPendingOperations;
     };

--- a/src/backend/opengl/OpenGLBackend.cpp
+++ b/src/backend/opengl/OpenGLBackend.cpp
@@ -86,7 +86,8 @@ namespace backend { namespace opengl {
     RenderPipelineBase* Device::CreateRenderPipeline(RenderPipelineBuilder* builder) {
         return new RenderPipeline(builder);
     }
-    SamplerBase* Device::CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) {
+    ResultOrError<SamplerBase*> Device::CreateSamplerImpl(
+        const nxt::SamplerDescriptor* descriptor) {
         return new Sampler(this, descriptor);
     }
     ShaderModuleBase* Device::CreateShaderModule(ShaderModuleBuilder* builder) {

--- a/src/backend/opengl/OpenGLBackend.h
+++ b/src/backend/opengl/OpenGLBackend.h
@@ -105,7 +105,8 @@ namespace backend { namespace opengl {
         void TickImpl() override;
 
       private:
-        SamplerBase* CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) override;
+        ResultOrError<SamplerBase*> CreateSamplerImpl(
+            const nxt::SamplerDescriptor* descriptor) override;
     };
 
     class BindGroup : public BindGroupBase {

--- a/src/backend/vulkan/VulkanBackend.cpp
+++ b/src/backend/vulkan/VulkanBackend.cpp
@@ -253,7 +253,8 @@ namespace backend { namespace vulkan {
     RenderPipelineBase* Device::CreateRenderPipeline(RenderPipelineBuilder* builder) {
         return new RenderPipeline(builder);
     }
-    SamplerBase* Device::CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) {
+    ResultOrError<SamplerBase*> Device::CreateSamplerImpl(
+        const nxt::SamplerDescriptor* descriptor) {
         return new Sampler(this, descriptor);
     }
     ShaderModuleBase* Device::CreateShaderModule(ShaderModuleBuilder* builder) {

--- a/src/backend/vulkan/VulkanBackend.h
+++ b/src/backend/vulkan/VulkanBackend.h
@@ -133,7 +133,8 @@ namespace backend { namespace vulkan {
         void TickImpl() override;
 
       private:
-        SamplerBase* CreateSamplerImpl(const nxt::SamplerDescriptor* descriptor) override;
+        ResultOrError<SamplerBase*> CreateSamplerImpl(
+            const nxt::SamplerDescriptor* descriptor) override;
 
         bool CreateInstance(VulkanGlobalKnobs* usedKnobs,
                             const std::vector<const char*>& requiredExtensions);

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND COMMON_SOURCES
     ${COMMON_DIR}/Math.cpp
     ${COMMON_DIR}/Math.h
     ${COMMON_DIR}/Platform.h
+    ${COMMON_DIR}/Result.h
     ${COMMON_DIR}/Serial.h
     ${COMMON_DIR}/SerialQueue.h
     ${COMMON_DIR}/SwapChainUtils.h

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -20,6 +20,8 @@
 //  - NXT_BREAKPOINT(): Raises an exception and breaks in the debugger
 //  - NXT_BUILTIN_UNREACHABLE(): Hints the compiler that a code path is unreachable
 //  - NXT_NO_DISCARD: An attribute that is C++17 [[nodiscard]] where available
+//  - NXT_(UN)?LIKELY(EXPR): Where available, hints the compiler that the expression will be true
+//      (resp. false) to help it generate code that leads to better branch prediction.
 
 // Clang and GCC
 #if defined(__GNUC__)
@@ -36,6 +38,8 @@
 #    endif
 
 #    define NXT_BUILTIN_UNREACHABLE() __builtin_unreachable()
+#    define NXT_LIKELY(x) __builtin_expect(!!(x), 1)
+#    define NXT_UNLIKELY(x) __builtin_expect(!!(x), 0)
 
 #    if !defined(__has_cpp_attribute)
 #        define __has_cpp_attribute(name) 0
@@ -69,6 +73,12 @@ extern void __cdecl __debugbreak(void);
 #endif
 
 // Add noop replacements for macros for features that aren't supported by the compiler.
+#if !defined(NXT_LIKELY)
+#    define NXT_LIKELY(X) X
+#endif
+#if !defined(NXT_UNLIKELY)
+#    define NXT_UNLIKELY(X) X
+#endif
 #if !defined(NXT_NO_DISCARD)
 #    define NXT_NO_DISCARD
 #endif

--- a/src/common/Result.h
+++ b/src/common/Result.h
@@ -1,0 +1,250 @@
+// Copyright 2018 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMON_RESULT_H_
+#define COMMON_RESULT_H_
+
+#include "common/Assert.h"
+#include "common/Compiler.h"
+
+#include <cstddef>
+#include <cstdint>
+
+// Result<T, E> is the following sum type (Haskell notation):
+//
+//      data Result T E = Success T | Error E | Empty
+//
+// It is meant to be used as the return type of functions that might fail. The reason for the Empty
+// case is that a Result should never be discarded, only destructured (its error or success moved
+// out) or moved into a different Result. The Empty case tags Results that have been moved out and
+// Result's destructor should ASSERT on it being Empty.
+//
+// Since C++ doesn't have efficient sum types for the special cases we care about, we provide
+// template specializations for them.
+
+template <typename T, typename E>
+class Result;
+
+// The interface of Result<T, E> shoud look like the following.
+//  public:
+//    Result(T success);
+//    Result(E error);
+//
+//    Result(Result<T, E>&& other);
+//    Result<T, E>&& operator=(Result<T, E>&& other);
+//
+//    ~Result();
+//
+//    bool IsError() const;
+//    bool IsSuccess() const;
+//
+//    T&& AcquireSuccess();
+//    E&& AcquireError();
+
+// Specialization of Result for returning errors only via pointers. It is basically a pointer
+// where nullptr is both Success and Empty.
+template <typename E>
+class NXT_NO_DISCARD Result<void, E*> {
+  public:
+    Result();
+    Result(E* error);
+
+    Result(Result<void, E*>&& other);
+    Result<void, E*>& operator=(Result<void, E>&& other);
+
+    ~Result();
+
+    bool IsError() const;
+    bool IsSuccess() const;
+
+    void AcquireSuccess();
+    E* AcquireError();
+
+  private:
+    E* mError = nullptr;
+};
+
+// Uses SFINAE to try to get alignof(T) but fallback to Default if T isn't defined.
+template <typename T, size_t Default, typename = size_t>
+constexpr size_t alignof_if_defined_else_default = Default;
+
+template <typename T, size_t Default>
+constexpr size_t alignof_if_defined_else_default<T, Default, decltype(alignof(T))> = alignof(T);
+
+// Specialization of Result when both the error an success are pointers. It is implemented as a
+// tagged pointer. The tag for Success is 0 so that returning the value is fastest.
+template <typename T, typename E>
+class NXT_NO_DISCARD Result<T*, E*> {
+  public:
+    static_assert(alignof_if_defined_else_default<T, 4> >= 4,
+                  "Result<T*, E*> reserves two bits for tagging pointers");
+    static_assert(alignof_if_defined_else_default<E, 4> >= 4,
+                  "Result<T*, E*> reserves two bits for tagging pointers");
+
+    Result(T* success);
+    Result(E* error);
+
+    Result(Result<T*, E*>&& other);
+    Result<T*, E*>& operator=(Result<T*, E>&& other);
+
+    ~Result();
+
+    bool IsError() const;
+    bool IsSuccess() const;
+
+    T* AcquireSuccess();
+    E* AcquireError();
+
+  private:
+    enum PayloadType {
+        Success = 0,
+        Error = 1,
+        Empty = 2,
+    };
+
+    // Utility functions to manipulate the tagged pointer some of them don't need to be templated
+    // but we really want them inlined so we keep them in templates
+    static intptr_t MakePayload(void* pointer, PayloadType type);
+    static PayloadType GetPayloadType(intptr_t payload);
+    static T* GetSuccessFromPayload(intptr_t payload);
+    static E* GetErrorFromPayload(intptr_t payload);
+
+    constexpr static intptr_t kEmptyPayload = Empty;
+    intptr_t mPayload = kEmptyPayload;
+};
+
+// Implementation of Result<void, E*>
+template <typename E>
+Result<void, E*>::Result() {
+}
+
+template <typename E>
+Result<void, E*>::Result(E* error) : mError(error) {
+}
+
+template <typename E>
+Result<void, E*>::Result(Result<void, E*>&& other) : mError(other.mError) {
+    other.mError = nullptr;
+}
+
+template <typename E>
+Result<void, E*>& Result<void, E*>::operator=(Result<void, E>&& other) {
+    ASSERT(mError == nullptr);
+    mError = other.mError;
+    other.mError = nullptr;
+    return *this;
+}
+
+template <typename E>
+Result<void, E*>::~Result() {
+    ASSERT(mError == nullptr);
+}
+
+template <typename E>
+bool Result<void, E*>::IsError() const {
+    return mError != nullptr;
+}
+
+template <typename E>
+bool Result<void, E*>::IsSuccess() const {
+    return mError == nullptr;
+}
+
+template <typename E>
+void Result<void, E*>::AcquireSuccess() {
+}
+
+template <typename E>
+E* Result<void, E*>::AcquireError() {
+    E* error = mError;
+    mError = nullptr;
+    return error;
+}
+
+// Implementation of Result<T*, E*>
+template <typename T, typename E>
+Result<T*, E*>::Result(T* success) : mPayload(MakePayload(success, Success)) {
+}
+
+template <typename T, typename E>
+Result<T*, E*>::Result(E* error) : mPayload(MakePayload(error, Error)) {
+}
+
+template <typename T, typename E>
+Result<T*, E*>::Result(Result<T*, E*>&& other) : mPayload(other.mPayload) {
+    other.mPayload = kEmptyPayload;
+}
+
+template <typename T, typename E>
+Result<T*, E*>& Result<T*, E*>::operator=(Result<T*, E>&& other) {
+    ASSERT(mPayload == kEmptyPayload);
+    mPayload = other.mPayload;
+    other.mPayload = kEmptyPayload;
+    return *this;
+}
+
+template <typename T, typename E>
+Result<T*, E*>::~Result() {
+    ASSERT(mPayload == kEmptyPayload);
+}
+
+template <typename T, typename E>
+bool Result<T*, E*>::IsError() const {
+    return GetPayloadType(mPayload) == Error;
+}
+
+template <typename T, typename E>
+bool Result<T*, E*>::IsSuccess() const {
+    return GetPayloadType(mPayload) == Success;
+}
+
+template <typename T, typename E>
+T* Result<T*, E*>::AcquireSuccess() {
+    T* success = GetSuccessFromPayload(mPayload);
+    mPayload = kEmptyPayload;
+    return success;
+}
+
+template <typename T, typename E>
+E* Result<T*, E*>::AcquireError() {
+    E* error = GetErrorFromPayload(mPayload);
+    mPayload = kEmptyPayload;
+    return error;
+}
+
+template <typename T, typename E>
+intptr_t Result<T*, E*>::MakePayload(void* pointer, PayloadType type) {
+    intptr_t payload = reinterpret_cast<intptr_t>(pointer);
+    ASSERT((payload & 3) == 0);
+    return payload | type;
+}
+
+template <typename T, typename E>
+typename Result<T*, E*>::PayloadType Result<T*, E*>::GetPayloadType(intptr_t payload) {
+    return static_cast<PayloadType>(payload & 3);
+}
+
+template <typename T, typename E>
+T* Result<T*, E*>::GetSuccessFromPayload(intptr_t payload) {
+    ASSERT(GetPayloadType(payload) == Success);
+    return reinterpret_cast<T*>(payload);
+}
+
+template <typename T, typename E>
+E* Result<T*, E*>::GetErrorFromPayload(intptr_t payload) {
+    ASSERT(GetPayloadType(payload) == Error);
+    return reinterpret_cast<E*>(payload ^ 1);
+}
+
+#endif  // COMMON_RESULT_H_

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ list(APPEND UNITTEST_SOURCES
     ${UNITTESTS_DIR}/ObjectBaseTests.cpp
     ${UNITTESTS_DIR}/PerStageTests.cpp
     ${UNITTESTS_DIR}/RefCountedTests.cpp
+    ${UNITTESTS_DIR}/ResultTests.cpp
     ${UNITTESTS_DIR}/SerialQueueTests.cpp
     ${UNITTESTS_DIR}/ToBackendTests.cpp
     ${UNITTESTS_DIR}/WireTests.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ list(APPEND UNITTEST_SOURCES
     ${UNITTESTS_DIR}/BitSetIteratorTests.cpp
     ${UNITTESTS_DIR}/CommandAllocatorTests.cpp
     ${UNITTESTS_DIR}/EnumClassBitmasksTests.cpp
+    ${UNITTESTS_DIR}/ErrorTests.cpp
     ${UNITTESTS_DIR}/MathTests.cpp
     ${UNITTESTS_DIR}/ObjectBaseTests.cpp
     ${UNITTESTS_DIR}/PerStageTests.cpp

--- a/src/tests/unittests/ErrorTests.cpp
+++ b/src/tests/unittests/ErrorTests.cpp
@@ -1,0 +1,269 @@
+// Copyright 2018 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "backend/Error.h"
+#include "backend/ErrorData.h"
+
+using namespace backend;
+
+namespace {
+
+int dummySuccess = 0xbeef;
+const char* dummyErrorMessage = "I am an error message :3";
+
+// Check returning a success MaybeError with {};
+TEST(ErrorTests, Error_Success) {
+    auto ReturnSuccess = []() -> MaybeError {
+        return {};
+    };
+
+    MaybeError result = ReturnSuccess();
+    ASSERT_TRUE(result.IsSuccess());
+}
+
+// Check returning an error MaybeError with NXT_RETURN_ERROR
+TEST(ErrorTests, Error_Error) {
+    auto ReturnError = []() -> MaybeError {
+        NXT_RETURN_ERROR(dummyErrorMessage);
+    };
+
+    MaybeError result = ReturnError();
+    ASSERT_TRUE(result.IsError());
+
+    ErrorData* errorData = result.AcquireError();
+    ASSERT_EQ(errorData->GetMessage(), dummyErrorMessage);
+    delete errorData;
+}
+
+// Check returning a success ResultOrError with an implicit conversion
+TEST(ErrorTests, ResultOrError_Success) {
+    auto ReturnSuccess = []() -> ResultOrError<int*> {
+        return &dummySuccess;
+    };
+
+    ResultOrError<int*> result = ReturnSuccess();
+    ASSERT_TRUE(result.IsSuccess());
+    ASSERT_EQ(result.AcquireSuccess(), &dummySuccess);
+}
+
+// Check returning an error ResultOrError with NXT_RETURN_ERROR
+TEST(ErrorTests, ResultOrError_Error) {
+    auto ReturnError = []() -> ResultOrError<int*> {
+        NXT_RETURN_ERROR(dummyErrorMessage);
+    };
+
+    ResultOrError<int*> result = ReturnError();
+    ASSERT_TRUE(result.IsError());
+
+    ErrorData* errorData = result.AcquireError();
+    ASSERT_EQ(errorData->GetMessage(), dummyErrorMessage);
+    delete errorData;
+}
+
+// Check NXT_TRY handles successes correctly.
+TEST(ErrorTests, TRY_Success) {
+    auto ReturnSuccess = []() -> MaybeError {
+        return {};
+    };
+
+    // We need to check that NXT_TRY doesn't return on successes
+    bool tryReturned = true;
+
+    auto Try = [ReturnSuccess, &tryReturned]() -> MaybeError {
+        NXT_TRY(ReturnSuccess());
+        tryReturned = false;
+        return {};
+    };
+
+    MaybeError result = Try();
+    ASSERT_TRUE(result.IsSuccess());
+    ASSERT_FALSE(tryReturned);
+}
+
+// Check NXT_TRY handles errors correctly.
+TEST(ErrorTests, TRY_Error) {
+    auto ReturnError = []() -> MaybeError {
+        NXT_RETURN_ERROR(dummyErrorMessage);
+    };
+
+    auto Try = [ReturnError]() -> MaybeError {
+        NXT_TRY(ReturnError());
+        // NXT_TRY should return before this point
+        EXPECT_FALSE(true);
+        return {};
+    };
+
+    MaybeError result = Try();
+    ASSERT_TRUE(result.IsError());
+
+    ErrorData* errorData = result.AcquireError();
+    ASSERT_EQ(errorData->GetMessage(), dummyErrorMessage);
+    delete errorData;
+}
+
+// Check NXT_TRY adds to the backtrace.
+TEST(ErrorTests, TRY_AddsToBacktrace) {
+    auto ReturnError = []() -> MaybeError {
+        NXT_RETURN_ERROR(dummyErrorMessage);
+    };
+
+    auto SingleTry = [ReturnError]() -> MaybeError {
+        NXT_TRY(ReturnError());
+        return {};
+    };
+
+    auto DoubleTry = [SingleTry]() -> MaybeError {
+        NXT_TRY(SingleTry());
+        return {};
+    };
+
+    MaybeError singleResult = SingleTry();
+    ASSERT_TRUE(singleResult.IsError());
+
+    MaybeError doubleResult = DoubleTry();
+    ASSERT_TRUE(doubleResult.IsError());
+
+    ErrorData* singleData = singleResult.AcquireError();
+    ErrorData* doubleData = doubleResult.AcquireError();
+
+    ASSERT_EQ(singleData->GetBacktrace().size() + 1, doubleData->GetBacktrace().size());
+
+    delete singleData;
+    delete doubleData;
+}
+
+// Check NXT_TRY_ASSIGN handles successes correctly.
+TEST(ErrorTests, TRY_RESULT_Success) {
+    auto ReturnSuccess = []() -> ResultOrError<int*> {
+        return &dummySuccess;
+    };
+
+    // We need to check that NXT_TRY doesn't return on successes
+    bool tryReturned = true;
+
+    auto Try = [ReturnSuccess, &tryReturned]() -> ResultOrError<int*> {
+        int* result = nullptr;
+        NXT_TRY_ASSIGN(result, ReturnSuccess());
+        tryReturned = false;
+
+        EXPECT_EQ(result, &dummySuccess);
+        return result;
+    };
+
+    ResultOrError<int*> result = Try();
+    ASSERT_TRUE(result.IsSuccess());
+    ASSERT_FALSE(tryReturned);
+    ASSERT_EQ(result.AcquireSuccess(), &dummySuccess);
+}
+
+// Check NXT_TRY_ASSIGN handles errors correctly.
+TEST(ErrorTests, TRY_RESULT_Error) {
+    auto ReturnError = []() -> ResultOrError<int*> {
+        NXT_RETURN_ERROR(dummyErrorMessage);
+    };
+
+    auto Try = [ReturnError]() -> ResultOrError<int*> {
+        int* result = nullptr;
+        NXT_TRY_ASSIGN(result, ReturnError());
+        (void) result;
+
+        // NXT_TRY should return before this point
+        EXPECT_FALSE(true);
+        return &dummySuccess;
+    };
+
+    ResultOrError<int*> result = Try();
+    ASSERT_TRUE(result.IsError());
+
+    ErrorData* errorData = result.AcquireError();
+    ASSERT_EQ(errorData->GetMessage(), dummyErrorMessage);
+    delete errorData;
+}
+
+// Check NXT_TRY_ASSIGN adds to the backtrace.
+TEST(ErrorTests, TRY_RESULT_AddsToBacktrace) {
+    auto ReturnError = []() -> ResultOrError<int*> {
+        NXT_RETURN_ERROR(dummyErrorMessage);
+    };
+
+    auto SingleTry = [ReturnError]() -> ResultOrError<int*> {
+        NXT_TRY(ReturnError());
+        return &dummySuccess;
+    };
+
+    auto DoubleTry = [SingleTry]() -> ResultOrError<int*> {
+        NXT_TRY(SingleTry());
+        return &dummySuccess;
+    };
+
+    ResultOrError<int*> singleResult = SingleTry();
+    ASSERT_TRUE(singleResult.IsError());
+
+    ResultOrError<int*> doubleResult = DoubleTry();
+    ASSERT_TRUE(doubleResult.IsError());
+
+    ErrorData* singleData = singleResult.AcquireError();
+    ErrorData* doubleData = doubleResult.AcquireError();
+
+    ASSERT_EQ(singleData->GetBacktrace().size() + 1, doubleData->GetBacktrace().size());
+
+    delete singleData;
+    delete doubleData;
+}
+
+// Check a ResultOrError can be NXT_TRY_ASSIGNED in a function that returns an Error
+TEST(ErrorTests, TRY_RESULT_ConversionToError) {
+    auto ReturnError = []() -> ResultOrError<int*> {
+        NXT_RETURN_ERROR(dummyErrorMessage);
+    };
+
+    auto Try = [ReturnError]() -> MaybeError {
+        int* result = nullptr;
+        NXT_TRY_ASSIGN(result, ReturnError());
+        (void) result;
+
+        return {};
+    };
+
+    MaybeError result = Try();
+    ASSERT_TRUE(result.IsError());
+
+    ErrorData* errorData = result.AcquireError();
+    ASSERT_EQ(errorData->GetMessage(), dummyErrorMessage);
+    delete errorData;
+}
+
+// Check a MaybeError can be NXT_TRIED in a function that returns an ResultOrError
+// Check NXT_TRY handles errors correctly.
+TEST(ErrorTests, TRY_ConversionToErrorOrResult) {
+    auto ReturnError = []() -> MaybeError {
+        NXT_RETURN_ERROR(dummyErrorMessage);
+    };
+
+    auto Try = [ReturnError]() -> ResultOrError<int*>{
+        NXT_TRY(ReturnError());
+        return &dummySuccess;
+    };
+
+    ResultOrError<int*> result = Try();
+    ASSERT_TRUE(result.IsError());
+
+    ErrorData* errorData = result.AcquireError();
+    ASSERT_EQ(errorData->GetMessage(), dummyErrorMessage);
+    delete errorData;
+}
+
+}  // anonymous namespace

--- a/src/tests/unittests/ResultTests.cpp
+++ b/src/tests/unittests/ResultTests.cpp
@@ -1,0 +1,137 @@
+// Copyright 2018 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "common/Result.h"
+
+namespace {
+
+template<typename T, typename E>
+void TestError(Result<T, E>* result, E expectedError) {
+    ASSERT_TRUE(result->IsError());
+    ASSERT_FALSE(result->IsSuccess());
+
+    E storedError = result->AcquireError();
+    ASSERT_EQ(storedError, expectedError);
+}
+
+template<typename T, typename E>
+void TestSuccess(Result<T, E>* result, T expectedSuccess) {
+    ASSERT_FALSE(result->IsError());
+    ASSERT_TRUE(result->IsSuccess());
+
+    T storedSuccess = result->AcquireSuccess();
+    ASSERT_EQ(storedSuccess, expectedSuccess);
+}
+
+static int dummyError = 0xbeef;
+static float dummySuccess = 42.0f;
+
+// Test constructing an error Result<void, E*>
+TEST(ResultOnlyPointerError, ConstructingError) {
+    Result<void, int*> result(&dummyError);
+    TestError(&result, &dummyError);
+}
+
+// Test moving an error Result<void, E*>
+TEST(ResultOnlyPointerError, MovingError) {
+    Result<void, int*> result(&dummyError);
+    Result<void, int*> movedResult(std::move(result));
+    TestError(&movedResult, &dummyError);
+}
+
+// Test returning an error Result<void, E*>
+TEST(ResultOnlyPointerError, ReturningError) {
+    auto CreateError = []() -> Result<void, int*> {
+        return {&dummyError};
+    };
+
+    Result<void, int*> result = CreateError();
+    TestError(&result, &dummyError);
+}
+
+// Test constructing a success Result<void, E*>
+TEST(ResultOnlyPointerError, ConstructingSuccess) {
+    Result<void, int*> result;
+    ASSERT_TRUE(result.IsSuccess());
+    ASSERT_FALSE(result.IsError());
+}
+
+// Test moving a success Result<void, E*>
+TEST(ResultOnlyPointerError, MovingSuccess) {
+    Result<void, int*> result;
+    Result<void, int*> movedResult(std::move(result));
+    ASSERT_TRUE(movedResult.IsSuccess());
+    ASSERT_FALSE(movedResult.IsError());
+}
+
+// Test returning a success Result<void, E*>
+TEST(ResultOnlyPointerError, ReturningSuccess) {
+    auto CreateError = []() -> Result<void, int*> {
+        return {};
+    };
+
+    Result<void, int*> result = CreateError();
+    ASSERT_TRUE(result.IsSuccess());
+    ASSERT_FALSE(result.IsError());
+}
+
+// Test constructing an error Result<T*, E*>
+TEST(ResultBothPointer, ConstructingError) {
+    Result<float*, int*> result(&dummyError);
+    TestError(&result, &dummyError);
+}
+
+// Test moving an error Result<T*, E*>
+TEST(ResultBothPointer, MovingError) {
+    Result<float*, int*> result(&dummyError);
+    Result<float*, int*> movedResult(std::move(result));
+    TestError(&movedResult, &dummyError);
+}
+
+// Test returning an error Result<T*, E*>
+TEST(ResultBothPointer, ReturningError) {
+    auto CreateError = []() -> Result<float*, int*> {
+        return {&dummyError};
+    };
+
+    Result<float*, int*> result = CreateError();
+    TestError(&result, &dummyError);
+}
+
+// Test constructing a success Result<T*, E*>
+TEST(ResultBothPointer, ConstructingSuccess) {
+    Result<float*, int*> result(&dummySuccess);
+    TestSuccess(&result, &dummySuccess);
+}
+
+// Test moving a success Result<T*, E*>
+TEST(ResultBothPointer, MovingSuccess) {
+    Result<float*, int*> result(&dummySuccess);
+    Result<float*, int*> movedResult(std::move(result));
+    TestSuccess(&movedResult, &dummySuccess);
+}
+
+// Test returning a success Result<T*, E*>
+TEST(ResultBothPointer, ReturningSuccess) {
+    auto CreateSuccess = []() -> Result<float*, int*> {
+        return {&dummySuccess};
+    };
+
+    Result<float*, int*> result = CreateSuccess();
+    TestSuccess(&result, &dummySuccess);
+}
+
+}  // anonymous namespace


### PR DESCRIPTION
PTAL, this adds the foundations of error handling similar to ANGLE's gl::Error and ANGLE_TRY. It is completely overkill for the usage done in this pull-request but will be used throughout NXT eventually.

@kainino0x, @SenorBlanco PTAL!

@vonture FYI as it is similar to a discussion we are having for ANGLE, and also for the fancy C++ usage.