### PR TITLE
Add Device::CreateQueue() instead of the builder

### DIFF
--- a/examples/Animometer.cpp
+++ b/examples/Animometer.cpp
@@ -46,7 +46,7 @@ static std::vector<ShaderData> shaderData;
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/CHelloTriangle.cpp
+++ b/examples/CHelloTriangle.cpp
@@ -26,12 +26,7 @@ nxtTextureFormat swapChainFormat;
 
 void init() {
     device = CreateCppNXTDevice().Release();
-
-    {
-        nxtQueueBuilder builder = nxtDeviceCreateQueueBuilder(device);
-        queue = nxtQueueBuilderGetResult(builder);
-        nxtQueueBuilderRelease(builder);
-    }
+    queue = nxtDeviceCreateQueue(device);
 
     {
         nxtSwapChainBuilder builder = nxtDeviceCreateSwapChainBuilder(device);

--- a/examples/ComputeBoids.cpp
+++ b/examples/ComputeBoids.cpp
@@ -286,7 +286,7 @@ nxt::CommandBuffer createCommandBuffer(const nxt::RenderPassDescriptor& renderPa
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/HelloCompute.cpp
+++ b/examples/HelloCompute.cpp
@@ -32,7 +32,7 @@ nxt::BindGroup computeBindGroup;
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/HelloDepthStencil.cpp
+++ b/examples/HelloDepthStencil.cpp
@@ -113,7 +113,7 @@ struct CameraData {
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/HelloIndices.cpp
+++ b/examples/HelloIndices.cpp
@@ -46,7 +46,7 @@ void initBuffers() {
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/HelloInstancing.cpp
+++ b/examples/HelloInstancing.cpp
@@ -49,7 +49,7 @@ void initBuffers() {
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/HelloTriangle.cpp
+++ b/examples/HelloTriangle.cpp
@@ -79,7 +79,7 @@ void initTextures() {
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/HelloUBO.cpp
+++ b/examples/HelloUBO.cpp
@@ -30,7 +30,7 @@ struct {uint32_t a; float b;} s;
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/HelloVertices.cpp
+++ b/examples/HelloVertices.cpp
@@ -40,7 +40,7 @@ void initBuffers() {
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/RenderToTexture.cpp
+++ b/examples/RenderToTexture.cpp
@@ -150,7 +150,7 @@ void initPipelinePost() {
 void init() {
     device = CreateCppNXTDevice();
 
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
     swapchain = GetSwapChain(device);
     swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                         nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -458,7 +458,7 @@ namespace {
     void init() {
         device = CreateCppNXTDevice();
 
-        queue = device.CreateQueueBuilder().GetResult();
+        queue = device.CreateQueue();
         swapchain = GetSwapChain(device);
         swapchain.Configure(GetPreferredSwapChainTextureFormat(),
                             nxt::TextureUsageBit::OutputAttachment, 640, 480);

--- a/next.json
+++ b/next.json
@@ -612,8 +612,8 @@
                 "returns": "pipeline layout builder"
             },
             {
-                "name": "create queue builder",
-                "returns": "queue builder"
+                "name": "create queue",
+                "returns": "queue"
             },
             {
                 "name": "create sampler",
@@ -805,15 +805,6 @@
                     {"name": "num commands", "type": "uint32_t"},
                     {"name": "commands", "type": "command buffer", "annotation": "const*", "length": "num commands"}
                 ]
-            }
-        ]
-    },
-    "queue builder": {
-        "category": "object",
-        "methods": [
-            {
-                "name": "get result",
-                "returns": "queue"
             }
         ]
     },

--- a/src/backend/Device.cpp
+++ b/src/backend/Device.cpp
@@ -122,8 +122,14 @@ namespace backend {
     PipelineLayoutBuilder* DeviceBase::CreatePipelineLayoutBuilder() {
         return new PipelineLayoutBuilder(this);
     }
-    QueueBuilder* DeviceBase::CreateQueueBuilder() {
-        return new QueueBuilder(this);
+    QueueBase* DeviceBase::CreateQueue() {
+        ResultOrError<QueueBase*> maybeQueue = CreateQueueImpl();
+        if (maybeQueue.IsError()) {
+            // TODO(cwallez@chromium.org): Implement the WebGPU error handling mechanism.
+            delete maybeQueue.AcquireError();
+            return nullptr;
+        }
+        return maybeQueue.AcquireSuccess();
     }
     RenderPassDescriptorBuilder* DeviceBase::CreateRenderPassDescriptorBuilder() {
         return new RenderPassDescriptorBuilder(this);
@@ -142,7 +148,7 @@ namespace backend {
         ResultOrError<SamplerBase*> maybeSampler = CreateSamplerImpl(descriptor);
         if (maybeSampler.IsError()) {
             // TODO(cwallez@chromium.org): Implement the WebGPU error handling mechanism.
-            delete validation.AcquireError();
+            delete maybeSampler.AcquireError();
             return nullptr;
         }
         return maybeSampler.AcquireSuccess();

--- a/src/backend/Device.h
+++ b/src/backend/Device.h
@@ -46,7 +46,6 @@ namespace backend {
             DepthStencilStateBuilder* builder) = 0;
         virtual InputStateBase* CreateInputState(InputStateBuilder* builder) = 0;
         virtual PipelineLayoutBase* CreatePipelineLayout(PipelineLayoutBuilder* builder) = 0;
-        virtual QueueBase* CreateQueue(QueueBuilder* builder) = 0;
         virtual RenderPassDescriptorBase* CreateRenderPassDescriptor(
             RenderPassDescriptorBuilder* builder) = 0;
         virtual RenderPipelineBase* CreateRenderPipeline(RenderPipelineBuilder* builder) = 0;
@@ -85,7 +84,7 @@ namespace backend {
         DepthStencilStateBuilder* CreateDepthStencilStateBuilder();
         InputStateBuilder* CreateInputStateBuilder();
         PipelineLayoutBuilder* CreatePipelineLayoutBuilder();
-        QueueBuilder* CreateQueueBuilder();
+        QueueBase* CreateQueue();
         RenderPassDescriptorBuilder* CreateRenderPassDescriptorBuilder();
         RenderPipelineBuilder* CreateRenderPipelineBuilder();
         SamplerBase* CreateSampler(const nxt::SamplerDescriptor* descriptor);
@@ -99,6 +98,7 @@ namespace backend {
         void Release();
 
       private:
+        virtual ResultOrError<QueueBase*> CreateQueueImpl() = 0;
         virtual ResultOrError<SamplerBase*> CreateSamplerImpl(
             const nxt::SamplerDescriptor* descriptor) = 0;
 

--- a/src/backend/Forward.h
+++ b/src/backend/Forward.h
@@ -40,7 +40,6 @@ namespace backend {
     class PipelineLayoutBase;
     class PipelineLayoutBuilder;
     class QueueBase;
-    class QueueBuilder;
     class RenderPassDescriptorBase;
     class RenderPassDescriptorBuilder;
     class RenderPipelineBase;

--- a/src/backend/Queue.cpp
+++ b/src/backend/Queue.cpp
@@ -21,7 +21,7 @@ namespace backend {
 
     // QueueBase
 
-    QueueBase::QueueBase(QueueBuilder* builder) : mDevice(builder->mDevice) {
+    QueueBase::QueueBase(DeviceBase* device) : mDevice(device) {
     }
 
     DeviceBase* QueueBase::GetDevice() {
@@ -30,15 +30,6 @@ namespace backend {
 
     bool QueueBase::ValidateSubmitCommand(CommandBufferBase* command) {
         return command->ValidateResourceUsagesImmediate();
-    }
-
-    // QueueBuilder
-
-    QueueBuilder::QueueBuilder(DeviceBase* device) : Builder(device) {
-    }
-
-    QueueBase* QueueBuilder::GetResultImpl() {
-        return mDevice->CreateQueue(this);
     }
 
 }  // namespace backend

--- a/src/backend/Queue.h
+++ b/src/backend/Queue.h
@@ -25,7 +25,7 @@ namespace backend {
 
     class QueueBase : public RefCounted {
       public:
-        QueueBase(QueueBuilder* builder);
+        QueueBase(DeviceBase* device);
 
         DeviceBase* GetDevice();
 
@@ -46,15 +46,6 @@ namespace backend {
         bool ValidateSubmitCommand(CommandBufferBase* command);
 
         DeviceBase* mDevice;
-    };
-
-    class QueueBuilder : public Builder<QueueBase> {
-      public:
-        QueueBuilder(DeviceBase* device);
-
-      private:
-        friend class QueueBase;
-        QueueBase* GetResultImpl() override;
     };
 
 }  // namespace backend

--- a/src/backend/d3d12/D3D12Backend.cpp
+++ b/src/backend/d3d12/D3D12Backend.cpp
@@ -288,8 +288,8 @@ namespace backend { namespace d3d12 {
     PipelineLayoutBase* Device::CreatePipelineLayout(PipelineLayoutBuilder* builder) {
         return new PipelineLayout(this, builder);
     }
-    QueueBase* Device::CreateQueue(QueueBuilder* builder) {
-        return new Queue(this, builder);
+    ResultOrError<QueueBase*> Device::CreateQueueImpl() {
+        return new Queue(this);
     }
     RenderPassDescriptorBase* Device::CreateRenderPassDescriptor(
         RenderPassDescriptorBuilder* builder) {

--- a/src/backend/d3d12/D3D12Backend.h
+++ b/src/backend/d3d12/D3D12Backend.h
@@ -96,7 +96,6 @@ namespace backend { namespace d3d12 {
         DepthStencilStateBase* CreateDepthStencilState(DepthStencilStateBuilder* builder) override;
         InputStateBase* CreateInputState(InputStateBuilder* builder) override;
         PipelineLayoutBase* CreatePipelineLayout(PipelineLayoutBuilder* builder) override;
-        QueueBase* CreateQueue(QueueBuilder* builder) override;
         RenderPassDescriptorBase* CreateRenderPassDescriptor(
             RenderPassDescriptorBuilder* builder) override;
         RenderPipelineBase* CreateRenderPipeline(RenderPipelineBuilder* builder) override;
@@ -128,6 +127,7 @@ namespace backend { namespace d3d12 {
         void ExecuteCommandLists(std::initializer_list<ID3D12CommandList*> commandLists);
 
       private:
+        ResultOrError<QueueBase*> CreateQueueImpl() override;
         ResultOrError<SamplerBase*> CreateSamplerImpl(
             const nxt::SamplerDescriptor* descriptor) override;
 

--- a/src/backend/d3d12/QueueD3D12.cpp
+++ b/src/backend/d3d12/QueueD3D12.cpp
@@ -19,21 +19,23 @@
 
 namespace backend { namespace d3d12 {
 
-    Queue::Queue(Device* device, QueueBuilder* builder) : QueueBase(builder), mDevice(device) {
+    Queue::Queue(Device* device) : QueueBase(device) {
     }
 
     void Queue::Submit(uint32_t numCommands, CommandBuffer* const* commands) {
-        mDevice->Tick();
+        Device* device = ToBackend(GetDevice());
 
-        mDevice->OpenCommandList(&mCommandList);
+        device->Tick();
+
+        device->OpenCommandList(&mCommandList);
         for (uint32_t i = 0; i < numCommands; ++i) {
             commands[i]->FillCommands(mCommandList);
         }
         ASSERT_SUCCESS(mCommandList->Close());
 
-        mDevice->ExecuteCommandLists({mCommandList.Get()});
+        device->ExecuteCommandLists({mCommandList.Get()});
 
-        mDevice->NextSerial();
+        device->NextSerial();
     }
 
 }}  // namespace backend::d3d12

--- a/src/backend/d3d12/QueueD3D12.h
+++ b/src/backend/d3d12/QueueD3D12.h
@@ -26,14 +26,12 @@ namespace backend { namespace d3d12 {
 
     class Queue : public QueueBase {
       public:
-        Queue(Device* device, QueueBuilder* builder);
+        Queue(Device* device);
 
         // NXT API
         void Submit(uint32_t numCommands, CommandBuffer* const* commands);
 
       private:
-        Device* mDevice;
-
         ComPtr<ID3D12GraphicsCommandList> mCommandList;
     };
 

--- a/src/backend/metal/MetalBackend.h
+++ b/src/backend/metal/MetalBackend.h
@@ -97,7 +97,6 @@ namespace backend { namespace metal {
         DepthStencilStateBase* CreateDepthStencilState(DepthStencilStateBuilder* builder) override;
         InputStateBase* CreateInputState(InputStateBuilder* builder) override;
         PipelineLayoutBase* CreatePipelineLayout(PipelineLayoutBuilder* builder) override;
-        QueueBase* CreateQueue(QueueBuilder* builder) override;
         RenderPassDescriptorBase* CreateRenderPassDescriptor(
             RenderPassDescriptorBuilder* builder) override;
         RenderPipelineBase* CreateRenderPipeline(RenderPipelineBuilder* builder) override;
@@ -118,6 +117,7 @@ namespace backend { namespace metal {
         ResourceUploader* GetResourceUploader() const;
 
       private:
+        ResultOrError<QueueBase*> CreateQueueImpl() override;
         ResultOrError<SamplerBase*> CreateSamplerImpl(
             const nxt::SamplerDescriptor* descriptor) override;
 
@@ -145,16 +145,10 @@ namespace backend { namespace metal {
 
     class Queue : public QueueBase {
       public:
-        Queue(QueueBuilder* builder);
-        ~Queue();
-
-        id<MTLCommandQueue> GetMTLCommandQueue();
+        Queue(Device* device);
 
         // NXT API
         void Submit(uint32_t numCommands, CommandBuffer* const* commands);
-
-      private:
-        id<MTLCommandQueue> mCommandQueue = nil;
     };
 
     class RenderPassDescriptor : public RenderPassDescriptorBase {

--- a/src/backend/metal/MetalBackend.mm
+++ b/src/backend/metal/MetalBackend.mm
@@ -107,15 +107,15 @@ namespace backend { namespace metal {
     PipelineLayoutBase* Device::CreatePipelineLayout(PipelineLayoutBuilder* builder) {
         return new PipelineLayout(builder);
     }
-    QueueBase* Device::CreateQueue(QueueBuilder* builder) {
-        return new Queue(builder);
-    }
     RenderPassDescriptorBase* Device::CreateRenderPassDescriptor(
         RenderPassDescriptorBuilder* builder) {
         return new RenderPassDescriptor(builder);
     }
     RenderPipelineBase* Device::CreateRenderPipeline(RenderPipelineBuilder* builder) {
         return new RenderPipeline(builder);
+    }
+    ResultOrError<QueueBase*> Device::CreateQueueImpl() {
+        return new Queue(this);
     }
     ResultOrError<SamplerBase*> Device::CreateSamplerImpl(
         const nxt::SamplerDescriptor* descriptor) {
@@ -203,18 +203,7 @@ namespace backend { namespace metal {
 
     // Queue
 
-    Queue::Queue(QueueBuilder* builder) : QueueBase(builder) {
-        Device* device = ToBackend(builder->GetDevice());
-        mCommandQueue = [device->GetMTLDevice() newCommandQueue];
-    }
-
-    Queue::~Queue() {
-        [mCommandQueue release];
-        mCommandQueue = nil;
-    }
-
-    id<MTLCommandQueue> Queue::GetMTLCommandQueue() {
-        return mCommandQueue;
+    Queue::Queue(Device* device) : QueueBase(device) {
     }
 
     void Queue::Submit(uint32_t numCommands, CommandBuffer* const* commands) {

--- a/src/backend/null/NullBackend.cpp
+++ b/src/backend/null/NullBackend.cpp
@@ -66,8 +66,8 @@ namespace backend { namespace null {
     PipelineLayoutBase* Device::CreatePipelineLayout(PipelineLayoutBuilder* builder) {
         return new PipelineLayout(builder);
     }
-    QueueBase* Device::CreateQueue(QueueBuilder* builder) {
-        return new Queue(builder);
+    ResultOrError<QueueBase*> Device::CreateQueueImpl() {
+        return new Queue(this);
     }
     RenderPassDescriptorBase* Device::CreateRenderPassDescriptor(
         RenderPassDescriptorBuilder* builder) {
@@ -205,7 +205,7 @@ namespace backend { namespace null {
 
     // Queue
 
-    Queue::Queue(QueueBuilder* builder) : QueueBase(builder) {
+    Queue::Queue(Device* device) : QueueBase(device) {
     }
 
     Queue::~Queue() {

--- a/src/backend/null/NullBackend.h
+++ b/src/backend/null/NullBackend.h
@@ -105,7 +105,6 @@ namespace backend { namespace null {
         DepthStencilStateBase* CreateDepthStencilState(DepthStencilStateBuilder* builder) override;
         InputStateBase* CreateInputState(InputStateBuilder* builder) override;
         PipelineLayoutBase* CreatePipelineLayout(PipelineLayoutBuilder* builder) override;
-        QueueBase* CreateQueue(QueueBuilder* builder) override;
         RenderPassDescriptorBase* CreateRenderPassDescriptor(
             RenderPassDescriptorBuilder* builder) override;
         RenderPipelineBase* CreateRenderPipeline(RenderPipelineBuilder* builder) override;
@@ -120,6 +119,7 @@ namespace backend { namespace null {
         std::vector<std::unique_ptr<PendingOperation>> AcquirePendingOperations();
 
       private:
+        ResultOrError<QueueBase*> CreateQueueImpl() override;
         ResultOrError<SamplerBase*> CreateSamplerImpl(
             const nxt::SamplerDescriptor* descriptor) override;
 
@@ -159,7 +159,7 @@ namespace backend { namespace null {
 
     class Queue : public QueueBase {
       public:
-        Queue(QueueBuilder* builder);
+        Queue(Device* device);
         ~Queue();
 
         // NXT API

--- a/src/backend/opengl/OpenGLBackend.cpp
+++ b/src/backend/opengl/OpenGLBackend.cpp
@@ -76,8 +76,8 @@ namespace backend { namespace opengl {
     PipelineLayoutBase* Device::CreatePipelineLayout(PipelineLayoutBuilder* builder) {
         return new PipelineLayout(builder);
     }
-    QueueBase* Device::CreateQueue(QueueBuilder* builder) {
-        return new Queue(builder);
+    ResultOrError<QueueBase*> Device::CreateQueueImpl() {
+        return new Queue(this);
     }
     RenderPassDescriptorBase* Device::CreateRenderPassDescriptor(
         RenderPassDescriptorBuilder* builder) {
@@ -119,7 +119,7 @@ namespace backend { namespace opengl {
 
     // Queue
 
-    Queue::Queue(QueueBuilder* builder) : QueueBase(builder) {
+    Queue::Queue(Device* device) : QueueBase(device) {
     }
 
     void Queue::Submit(uint32_t numCommands, CommandBuffer* const* commands) {

--- a/src/backend/opengl/OpenGLBackend.h
+++ b/src/backend/opengl/OpenGLBackend.h
@@ -93,7 +93,6 @@ namespace backend { namespace opengl {
         DepthStencilStateBase* CreateDepthStencilState(DepthStencilStateBuilder* builder) override;
         InputStateBase* CreateInputState(InputStateBuilder* builder) override;
         PipelineLayoutBase* CreatePipelineLayout(PipelineLayoutBuilder* builder) override;
-        QueueBase* CreateQueue(QueueBuilder* builder) override;
         RenderPassDescriptorBase* CreateRenderPassDescriptor(
             RenderPassDescriptorBuilder* builder) override;
         RenderPipelineBase* CreateRenderPipeline(RenderPipelineBuilder* builder) override;
@@ -105,6 +104,7 @@ namespace backend { namespace opengl {
         void TickImpl() override;
 
       private:
+        ResultOrError<QueueBase*> CreateQueueImpl() override;
         ResultOrError<SamplerBase*> CreateSamplerImpl(
             const nxt::SamplerDescriptor* descriptor) override;
     };
@@ -121,7 +121,7 @@ namespace backend { namespace opengl {
 
     class Queue : public QueueBase {
       public:
-        Queue(QueueBuilder* builder);
+        Queue(Device* device);
 
         // NXT API
         void Submit(uint32_t numCommands, CommandBuffer* const* commands);

--- a/src/backend/vulkan/VulkanBackend.cpp
+++ b/src/backend/vulkan/VulkanBackend.cpp
@@ -243,8 +243,8 @@ namespace backend { namespace vulkan {
     PipelineLayoutBase* Device::CreatePipelineLayout(PipelineLayoutBuilder* builder) {
         return new PipelineLayout(builder);
     }
-    QueueBase* Device::CreateQueue(QueueBuilder* builder) {
-        return new Queue(builder);
+    ResultOrError<QueueBase*> Device::CreateQueueImpl() {
+        return new Queue(this);
     }
     RenderPassDescriptorBase* Device::CreateRenderPassDescriptor(
         RenderPassDescriptorBuilder* builder) {
@@ -677,7 +677,7 @@ namespace backend { namespace vulkan {
 
     // Queue
 
-    Queue::Queue(QueueBuilder* builder) : QueueBase(builder) {
+    Queue::Queue(Device* device) : QueueBase(device) {
     }
 
     Queue::~Queue() {

--- a/src/backend/vulkan/VulkanBackend.h
+++ b/src/backend/vulkan/VulkanBackend.h
@@ -121,7 +121,6 @@ namespace backend { namespace vulkan {
         DepthStencilStateBase* CreateDepthStencilState(DepthStencilStateBuilder* builder) override;
         InputStateBase* CreateInputState(InputStateBuilder* builder) override;
         PipelineLayoutBase* CreatePipelineLayout(PipelineLayoutBuilder* builder) override;
-        QueueBase* CreateQueue(QueueBuilder* builder) override;
         RenderPassDescriptorBase* CreateRenderPassDescriptor(
             RenderPassDescriptorBuilder* builder) override;
         RenderPipelineBase* CreateRenderPipeline(RenderPipelineBuilder* builder) override;
@@ -133,6 +132,7 @@ namespace backend { namespace vulkan {
         void TickImpl() override;
 
       private:
+        ResultOrError<QueueBase*> CreateQueueImpl() override;
         ResultOrError<SamplerBase*> CreateSamplerImpl(
             const nxt::SamplerDescriptor* descriptor) override;
 
@@ -203,7 +203,7 @@ namespace backend { namespace vulkan {
 
     class Queue : public QueueBase {
       public:
-        Queue(QueueBuilder* builder);
+        Queue(Device* device);
         ~Queue();
 
         // NXT API

--- a/src/tests/NXTTest.cpp
+++ b/src/tests/NXTTest.cpp
@@ -167,7 +167,7 @@ void NXTTest::SetUp() {
     // deferred expectations.
     nxtSetProcs(&procs);
     device = nxt::Device::Acquire(cDevice);
-    queue = device.CreateQueueBuilder().GetResult();
+    queue = device.CreateQueue();
 
     // The swapchain isn't used by tests but is useful when debugging with graphics debuggers that
     // capture at frame boundaries.

--- a/src/tests/unittests/WireTests.cpp
+++ b/src/tests/unittests/WireTests.cpp
@@ -367,15 +367,9 @@ TEST_F(WireTests, ObjectsAsPointerArgument) {
     }
 
     // Create queue
-    nxtQueueBuilder queueBuilder = nxtDeviceCreateQueueBuilder(device);
-    nxtQueue queue = nxtQueueBuilderGetResult(queueBuilder);
-
-    nxtQueueBuilder apiQueueBuilder = api.GetNewQueueBuilder();
-    EXPECT_CALL(api, DeviceCreateQueueBuilder(apiDevice))
-        .WillOnce(Return(apiQueueBuilder));
-
+    nxtQueue queue = nxtDeviceCreateQueue(device);
     nxtQueue apiQueue = api.GetNewQueue();
-    EXPECT_CALL(api, QueueBuilderGetResult(apiQueueBuilder))
+    EXPECT_CALL(api, DeviceCreateQueue(apiDevice))
         .WillOnce(Return(apiQueue));
 
     // Submit command buffer and check we got a call with both API-side command buffers

--- a/src/tests/unittests/validation/BufferValidationTests.cpp
+++ b/src/tests/unittests/validation/BufferValidationTests.cpp
@@ -72,7 +72,7 @@ class BufferValidationTest : public ValidationTest {
 
             mockBufferMapReadCallback = new MockBufferMapReadCallback;
             mockBufferMapWriteCallback = new MockBufferMapWriteCallback;
-            queue = device.CreateQueueBuilder().GetResult();
+            queue = device.CreateQueue();
         }
 
         void TearDown() override {

--- a/src/tests/unittests/validation/PushConstantsValidationTests.cpp
+++ b/src/tests/unittests/validation/PushConstantsValidationTests.cpp
@@ -40,7 +40,7 @@ class PushConstantTest : public ValidationTest {
     private:
         void SetUp() override {
             ValidationTest::SetUp();
-            queue = device.CreateQueueBuilder().GetResult();
+            queue = device.CreateQueue();
         }
 };
 

--- a/src/tests/unittests/validation/UsageValidationTests.cpp
+++ b/src/tests/unittests/validation/UsageValidationTests.cpp
@@ -25,7 +25,7 @@ class UsageValidationTest : public ValidationTest {
     private:
         void SetUp() override {
             ValidationTest::SetUp();
-            queue = device.CreateQueueBuilder().GetResult();
+            queue = device.CreateQueue();
         }
 };
 


### PR DESCRIPTION
We are changing all object creation to use descriptors but there is no
creation argument to pass for queue, so instead Device::CreateQueue
takes no argument.