### PR TITLE
Assert HandleCommands succeeds

### DIFF
--- a/examples/SampleUtils.cpp
+++ b/examples/SampleUtils.cpp
@@ -14,6 +14,7 @@
 
 #include "SampleUtils.h"
 
+#include "common/Assert.h"
 #include "common/Platform.h"
 #include "utils/BackendBinding.h"
 #include "wire/TerribleCommandBuffer.h"
@@ -212,8 +213,8 @@ bool InitSample(int argc, const char** argv) {
 
 void DoFlush() {
     if (cmdBufType == CmdBufType::Terrible) {
-        c2sBuf->Flush();
-        s2cBuf->Flush();
+        ASSERT(c2sBuf->Flush());
+        ASSERT(s2cBuf->Flush());
     }
     glfwPollEvents();
 }

--- a/generator/templates/wire/WireClient.cpp
+++ b/generator/templates/wire/WireClient.cpp
@@ -437,7 +437,7 @@ namespace nxt { namespace wire {
                 }
 
                 const char* HandleCommands(const char* commands, size_t size) override {
-                    while (size > sizeof(ReturnWireCmd)) {
+                    while (size >= sizeof(ReturnWireCmd)) {
                         ReturnWireCmd cmdId = *reinterpret_cast<const ReturnWireCmd*>(commands);
 
                         bool success = false;

--- a/generator/templates/wire/WireServer.cpp
+++ b/generator/templates/wire/WireServer.cpp
@@ -304,7 +304,7 @@ namespace nxt { namespace wire {
                 const char* HandleCommands(const char* commands, size_t size) override {
                     mProcs.deviceTick(mKnownDevice.Get(1)->handle);
 
-                    while (size > sizeof(WireCmd)) {
+                    while (size >= sizeof(WireCmd)) {
                         WireCmd cmdId = *reinterpret_cast<const WireCmd*>(commands);
 
                         bool success = false;

--- a/src/tests/NXTTest.cpp
+++ b/src/tests/NXTTest.cpp
@@ -282,8 +282,8 @@ void NXTTest::SwapBuffersForCapture() {
 
 void NXTTest::FlushWire() {
     if (gTestUsesWire) {
-        mC2sBuf->Flush();
-        mS2cBuf->Flush();
+        ASSERT(mC2sBuf->Flush());
+        ASSERT(mS2cBuf->Flush());
     }
 }
 

--- a/src/tests/unittests/WireTests.cpp
+++ b/src/tests/unittests/WireTests.cpp
@@ -15,6 +15,7 @@
 #include "gtest/gtest.h"
 #include "mock/mock_nxt.h"
 
+#include "common/Assert.h"
 #include "wire/TerribleCommandBuffer.h"
 #include "wire/Wire.h"
 
@@ -163,11 +164,11 @@ class WireTestsBase : public Test {
         }
 
         void FlushClient() {
-            mC2sBuf->Flush();
+            ASSERT_TRUE(mC2sBuf->Flush());
         }
 
         void FlushServer() {
-            mS2cBuf->Flush();
+            ASSERT_TRUE(mS2cBuf->Flush());
         }
 
         MockProcTable api;
@@ -772,7 +773,7 @@ TEST_F(WireBufferMappingTests, DestroyBeforeReadRequestEnd) {
 TEST_F(WireBufferMappingTests, UnmapCalledTooEarlyForRead) {
     nxtCallbackUserdata userdata = 8657;
     nxtBufferMapReadAsync(buffer, 40, sizeof(uint32_t), ToMockBufferMapReadCallback, userdata);
-    
+
     uint32_t bufferContent = 31337;
     EXPECT_CALL(api, OnBufferMapReadAsyncCallback(apiBuffer, 40, sizeof(uint32_t), _, _))
         .WillOnce(InvokeWithoutArgs([&]() {

--- a/src/wire/TerribleCommandBuffer.cpp
+++ b/src/wire/TerribleCommandBuffer.cpp
@@ -14,6 +14,8 @@
 
 #include "wire/TerribleCommandBuffer.h"
 
+#include "common/Assert.h"
+
 namespace nxt { namespace wire {
 
     TerribleCommandBuffer::TerribleCommandBuffer() {
@@ -35,16 +37,19 @@ namespace nxt { namespace wire {
         mOffset += size;
 
         if (mOffset > sizeof(mBuffer)) {
-            Flush();
+            if (!Flush()) {
+                return nullptr;
+            }
             return GetCmdSpace(size);
         }
 
         return result;
     }
 
-    void TerribleCommandBuffer::Flush() {
-        mHandler->HandleCommands(mBuffer, mOffset);
+    bool TerribleCommandBuffer::Flush() {
+        bool success = mHandler->HandleCommands(mBuffer, mOffset) != nullptr;
         mOffset = 0;
+        return success;
     }
 
 }}  // namespace nxt::wire

--- a/src/wire/TerribleCommandBuffer.h
+++ b/src/wire/TerribleCommandBuffer.h
@@ -29,7 +29,7 @@ namespace nxt { namespace wire {
         void SetHandler(CommandHandler* handler);
 
         void* GetCmdSpace(size_t size) override;
-        void Flush() override;
+        bool Flush() override;
 
       private:
         CommandHandler* mHandler = nullptr;

--- a/src/wire/Wire.h
+++ b/src/wire/Wire.h
@@ -25,7 +25,7 @@ namespace nxt { namespace wire {
       public:
         virtual ~CommandSerializer() = default;
         virtual void* GetCmdSpace(size_t size) = 0;
-        virtual void Flush() = 0;
+        virtual bool Flush() = 0;
     };
 
     class CommandHandler {


### PR DESCRIPTION
This isn't ready to land yet because it causes at least one test to fail:

- [x] WireBufferMappingTests.UnmapCalledTooEarlyForRead

But @Kangz maybe you can take care of it if this is a problem.