### PR TITLE
Allow bind group layouts to be sparse in pipeline layout

### DIFF
--- a/src/backend/CommandBufferStateTracker.cpp
+++ b/src/backend/CommandBufferStateTracker.cpp
@@ -494,7 +494,7 @@ namespace backend {
         mAspects.reset(VALIDATION_ASPECT_BIND_GROUPS);
         mAspects.reset(VALIDATION_ASPECT_VERTEX_BUFFERS);
         // Reset bindgroups but mark unused bindgroups as valid
-        mBindgroupsSet = ~layout->GetBindGroupsLayoutMask();
+        mBindgroupsSet = ~layout->GetBindGroupLayoutsMask();
 
         // Only bindgroups that were not the same layout in the last pipeline need to be set again.
         if (mLastPipeline) {

--- a/src/backend/PipelineLayout.cpp
+++ b/src/backend/PipelineLayout.cpp
@@ -49,7 +49,7 @@ namespace backend {
         return mBindGroupLayouts[group].Get();
     }
 
-    const std::bitset<kMaxBindGroups> PipelineLayoutBase::GetBindGroupsLayoutMask() const {
+    const std::bitset<kMaxBindGroups> PipelineLayoutBase::GetBindGroupLayoutsMask() const {
         return mMask;
     }
 

--- a/src/backend/PipelineLayout.cpp
+++ b/src/backend/PipelineLayout.cpp
@@ -34,8 +34,9 @@ namespace backend {
 
     // PipelineLayoutBase
 
-    PipelineLayoutBase::PipelineLayoutBase(DeviceBase*,
-                                           const nxt::PipelineLayoutDescriptor* descriptor) {
+    PipelineLayoutBase::PipelineLayoutBase(DeviceBase* device,
+                                           const nxt::PipelineLayoutDescriptor* descriptor)
+        : mDevice(device) {
         ASSERT(descriptor->numBindGroupLayouts <= kMaxBindGroups);
         for (uint32_t group = 0; group < descriptor->numBindGroupLayouts; ++group) {
             mBindGroupLayouts[group] =
@@ -65,6 +66,10 @@ namespace backend {
             }
         }
         return kMaxBindGroups + 1;
+    }
+
+    DeviceBase* PipelineLayoutBase::GetDevice() const {
+        return mDevice;
     }
 
 }  // namespace backend

--- a/src/backend/PipelineLayout.cpp
+++ b/src/backend/PipelineLayout.cpp
@@ -34,22 +34,13 @@ namespace backend {
 
     // PipelineLayoutBase
 
-    PipelineLayoutBase::PipelineLayoutBase(DeviceBase* device,
+    PipelineLayoutBase::PipelineLayoutBase(DeviceBase*,
                                            const nxt::PipelineLayoutDescriptor* descriptor) {
         ASSERT(descriptor->numBindGroupLayouts <= kMaxBindGroups);
         for (uint32_t group = 0; group < descriptor->numBindGroupLayouts; ++group) {
             mBindGroupLayouts[group] =
                 reinterpret_cast<BindGroupLayoutBase*>(descriptor->bindGroupLayouts[group].Get());
             mMask.set(group);
-        }
-        // TODO(kainino@chromium.org): It shouldn't be necessary to construct default bind
-        // group layouts here. Remove these and fix things so that they are not needed.
-        for (uint32_t group = descriptor->numBindGroupLayouts; group < kMaxBindGroups; ++group) {
-            auto builder = device->CreateBindGroupLayoutBuilder();
-            mBindGroupLayouts[group] = builder->GetResult();
-            // Remove the external ref objects are created with
-            mBindGroupLayouts[group]->Release();
-            builder->Release();
         }
     }
 

--- a/src/backend/PipelineLayout.h
+++ b/src/backend/PipelineLayout.h
@@ -37,6 +37,7 @@ namespace backend {
         PipelineLayoutBase(DeviceBase* device, const nxt::PipelineLayoutDescriptor* descriptor);
 
         const BindGroupLayoutBase* GetBindGroupLayout(size_t group) const;
+        // XXX: rename to GetBindGroupLayoutsMask?
         const std::bitset<kMaxBindGroups> GetBindGroupsLayoutMask() const;
 
         // Utility functions to compute inherited bind groups.

--- a/src/backend/PipelineLayout.h
+++ b/src/backend/PipelineLayout.h
@@ -47,7 +47,10 @@ namespace backend {
         // [1, kMaxBindGroups + 1]
         uint32_t GroupsInheritUpTo(const PipelineLayoutBase* other) const;
 
+        DeviceBase* GetDevice() const;
+
       protected:
+        DeviceBase* mDevice;
         BindGroupLayoutArray mBindGroupLayouts;
         std::bitset<kMaxBindGroups> mMask;
     };

--- a/src/backend/PipelineLayout.h
+++ b/src/backend/PipelineLayout.h
@@ -37,8 +37,7 @@ namespace backend {
         PipelineLayoutBase(DeviceBase* device, const nxt::PipelineLayoutDescriptor* descriptor);
 
         const BindGroupLayoutBase* GetBindGroupLayout(size_t group) const;
-        // XXX: rename to GetBindGroupLayoutsMask?
-        const std::bitset<kMaxBindGroups> GetBindGroupsLayoutMask() const;
+        const std::bitset<kMaxBindGroups> GetBindGroupLayoutsMask() const;
 
         // Utility functions to compute inherited bind groups.
         // Returns the inherited bind groups as a mask.

--- a/src/backend/d3d12/PipelineLayoutD3D12.cpp
+++ b/src/backend/d3d12/PipelineLayoutD3D12.cpp
@@ -43,7 +43,7 @@ namespace backend { namespace d3d12 {
         uint32_t parameterIndex = 0;
         uint32_t rangeIndex = 0;
 
-        for (uint32_t group : IterateBitSet(GetBindGroupsLayoutMask())) {
+        for (uint32_t group : IterateBitSet(GetBindGroupLayoutsMask())) {
             const BindGroupLayout* bindGroupLayout = ToBackend(GetBindGroupLayout(group));
 
             // Set the root descriptor table parameter and copy ranges. Ranges are offset by the

--- a/src/backend/d3d12/PipelineLayoutD3D12.cpp
+++ b/src/backend/d3d12/PipelineLayoutD3D12.cpp
@@ -17,6 +17,7 @@
 #include "backend/d3d12/BindGroupLayoutD3D12.h"
 #include "backend/d3d12/DeviceD3D12.h"
 #include "common/Assert.h"
+#include "common/BitSetIterator.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -42,7 +43,7 @@ namespace backend { namespace d3d12 {
         uint32_t parameterIndex = 0;
         uint32_t rangeIndex = 0;
 
-        for (uint32_t group = 0; group < kMaxBindGroups; ++group) {
+        for (uint32_t group : IterateBitSet(GetBindGroupsLayoutMask())) {
             const BindGroupLayout* bindGroupLayout = ToBackend(GetBindGroupLayout(group));
 
             // Set the root descriptor table parameter and copy ranges. Ranges are offset by the

--- a/src/backend/metal/PipelineLayoutMTL.mm
+++ b/src/backend/metal/PipelineLayoutMTL.mm
@@ -16,6 +16,7 @@
 
 #include "backend/BindGroupLayout.h"
 #include "backend/metal/DeviceMTL.h"
+#include "common/BitSetIterator.h"
 
 namespace backend { namespace metal {
 
@@ -28,7 +29,7 @@ namespace backend { namespace metal {
             uint32_t samplerIndex = 0;
             uint32_t textureIndex = 0;
 
-            for (size_t group = 0; group < kMaxBindGroups; ++group) {
+            for (uint32_t group : IterateBitSet(GetBindGroupsLayoutMask())) {
                 const auto& groupInfo = GetBindGroupLayout(group)->GetBindingInfo();
                 for (size_t binding = 0; binding < kMaxBindingsPerGroup; ++binding) {
                     if (!(groupInfo.visibilities[binding] & StageBit(stage))) {

--- a/src/backend/metal/PipelineLayoutMTL.mm
+++ b/src/backend/metal/PipelineLayoutMTL.mm
@@ -29,7 +29,7 @@ namespace backend { namespace metal {
             uint32_t samplerIndex = 0;
             uint32_t textureIndex = 0;
 
-            for (uint32_t group : IterateBitSet(GetBindGroupsLayoutMask())) {
+            for (uint32_t group : IterateBitSet(GetBindGroupLayoutsMask())) {
                 const auto& groupInfo = GetBindGroupLayout(group)->GetBindingInfo();
                 for (size_t binding = 0; binding < kMaxBindingsPerGroup; ++binding) {
                     if (!(groupInfo.visibilities[binding] & StageBit(stage))) {

--- a/src/backend/metal/ShaderModuleMTL.mm
+++ b/src/backend/metal/ShaderModuleMTL.mm
@@ -71,7 +71,7 @@ namespace backend { namespace metal {
         }
 
         // Create one resource binding entry per stage per binding.
-        for (uint32_t group : IterateBitSet(layout->GetBindGroupsLayoutMask())) {
+        for (uint32_t group : IterateBitSet(layout->GetBindGroupLayoutsMask())) {
             const auto& bgInfo = layout->GetBindGroupLayout(group)->GetBindingInfo();
             for (uint32_t binding : IterateBitSet(bgInfo.mask)) {
                 for (auto stage : IterateStages(bgInfo.visibilities[binding])) {

--- a/src/backend/opengl/PipelineGL.cpp
+++ b/src/backend/opengl/PipelineGL.cpp
@@ -19,6 +19,7 @@
 #include "backend/opengl/PersistentPipelineStateGL.h"
 #include "backend/opengl/PipelineLayoutGL.h"
 #include "backend/opengl/ShaderModuleGL.h"
+#include "common/BitSetIterator.h"
 
 #include <iostream>
 #include <set>
@@ -125,7 +126,7 @@ namespace backend { namespace opengl {
         const auto& layout = ToBackend(parent->GetLayout());
         const auto& indices = layout->GetBindingIndexInfo();
 
-        for (uint32_t group = 0; group < kMaxBindGroups; ++group) {
+        for (uint32_t group : IterateBitSet(layout->GetBindGroupsLayoutMask())) {
             const auto& groupInfo = layout->GetBindGroupLayout(group)->GetBindingInfo();
 
             for (uint32_t binding = 0; binding < kMaxBindingsPerGroup; ++binding) {

--- a/src/backend/opengl/PipelineGL.cpp
+++ b/src/backend/opengl/PipelineGL.cpp
@@ -126,7 +126,7 @@ namespace backend { namespace opengl {
         const auto& layout = ToBackend(parent->GetLayout());
         const auto& indices = layout->GetBindingIndexInfo();
 
-        for (uint32_t group : IterateBitSet(layout->GetBindGroupsLayoutMask())) {
+        for (uint32_t group : IterateBitSet(layout->GetBindGroupLayoutsMask())) {
             const auto& groupInfo = layout->GetBindGroupLayout(group)->GetBindingInfo();
 
             for (uint32_t binding = 0; binding < kMaxBindingsPerGroup; ++binding) {

--- a/src/backend/opengl/PipelineLayoutGL.cpp
+++ b/src/backend/opengl/PipelineLayoutGL.cpp
@@ -16,6 +16,7 @@
 
 #include "backend/BindGroupLayout.h"
 #include "backend/opengl/DeviceGL.h"
+#include "common/BitSetIterator.h"
 
 namespace backend { namespace opengl {
 
@@ -26,7 +27,7 @@ namespace backend { namespace opengl {
         GLuint sampledTextureIndex = 0;
         GLuint ssboIndex = 0;
 
-        for (size_t group = 0; group < kMaxBindGroups; ++group) {
+        for (uint32_t group : IterateBitSet(GetBindGroupsLayoutMask())) {
             const auto& groupInfo = GetBindGroupLayout(group)->GetBindingInfo();
 
             for (size_t binding = 0; binding < kMaxBindingsPerGroup; ++binding) {

--- a/src/backend/opengl/PipelineLayoutGL.cpp
+++ b/src/backend/opengl/PipelineLayoutGL.cpp
@@ -27,7 +27,7 @@ namespace backend { namespace opengl {
         GLuint sampledTextureIndex = 0;
         GLuint ssboIndex = 0;
 
-        for (uint32_t group : IterateBitSet(GetBindGroupsLayoutMask())) {
+        for (uint32_t group : IterateBitSet(GetBindGroupLayoutsMask())) {
             const auto& groupInfo = GetBindGroupLayout(group)->GetBindingInfo();
 
             for (size_t binding = 0; binding < kMaxBindingsPerGroup; ++binding) {

--- a/src/backend/vulkan/PipelineLayoutVk.cpp
+++ b/src/backend/vulkan/PipelineLayoutVk.cpp
@@ -29,7 +29,7 @@ namespace backend { namespace vulkan {
         // this constraints at the NXT level?
         uint32_t numSetLayouts = 0;
         std::array<VkDescriptorSetLayout, kMaxBindGroups> setLayouts;
-        for (uint32_t setIndex : IterateBitSet(GetBindGroupsLayoutMask())) {
+        for (uint32_t setIndex : IterateBitSet(GetBindGroupLayoutsMask())) {
             setLayouts[numSetLayouts] = ToBackend(GetBindGroupLayout(setIndex))->GetHandle();
             numSetLayouts++;
         }

--- a/src/backend/vulkan/PipelineLayoutVk.cpp
+++ b/src/backend/vulkan/PipelineLayoutVk.cpp
@@ -23,7 +23,7 @@
 namespace backend { namespace vulkan {
 
     PipelineLayout::PipelineLayout(Device* device, const nxt::PipelineLayoutDescriptor* descriptor)
-        : PipelineLayoutBase(device, descriptor), mDevice(device) {
+        : PipelineLayoutBase(device, descriptor) {
         // Compute the array of VkDescriptorSetLayouts that will be chained in the create info.
         // TODO(cwallez@chromium.org) Vulkan doesn't allow holes in this array, should we expose
         // this constraints at the NXT level?
@@ -50,15 +50,15 @@ namespace backend { namespace vulkan {
         createInfo.pushConstantRangeCount = 1;
         createInfo.pPushConstantRanges = &pushConstantRange;
 
-        if (mDevice->fn.CreatePipelineLayout(mDevice->GetVkDevice(), &createInfo, nullptr,
-                                             &mHandle) != VK_SUCCESS) {
+        if (device->fn.CreatePipelineLayout(device->GetVkDevice(), &createInfo, nullptr,
+                                            &mHandle) != VK_SUCCESS) {
             ASSERT(false);
         }
     }
 
     PipelineLayout::~PipelineLayout() {
         if (mHandle != VK_NULL_HANDLE) {
-            mDevice->GetFencedDeleter()->DeleteWhenUnused(mHandle);
+            ToBackend(GetDevice())->GetFencedDeleter()->DeleteWhenUnused(mHandle);
             mHandle = VK_NULL_HANDLE;
         }
     }

--- a/src/backend/vulkan/PipelineLayoutVk.h
+++ b/src/backend/vulkan/PipelineLayoutVk.h
@@ -32,8 +32,6 @@ namespace backend { namespace vulkan {
 
       private:
         VkPipelineLayout mHandle = VK_NULL_HANDLE;
-
-        Device* mDevice = nullptr;
     };
 
 }}  // namespace backend::vulkan


### PR DESCRIPTION
Instead of initializing all of the bind group layouts in the pipeline
layout to default values, let them be nullptr and allow this elsewhere.

This is a follow-up on some changes in #206.

Also, rename GetBindGroupsLayoutMask -> GetBindGroupLayoutsMask