### PR TITLE
Implement naive implicit barriers in the Vulkan backend.

### DIFF
--- a/src/backend/Buffer.cpp
+++ b/src/backend/Buffer.cpp
@@ -164,11 +164,8 @@ namespace backend {
     }
 
     bool BufferBase::IsUsagePossible(nxt::BufferUsageBit allowedUsage, nxt::BufferUsageBit usage) {
-        const nxt::BufferUsageBit allReadBits =
-            nxt::BufferUsageBit::MapRead | nxt::BufferUsageBit::TransferSrc |
-            nxt::BufferUsageBit::Index | nxt::BufferUsageBit::Vertex | nxt::BufferUsageBit::Uniform;
         bool allowed = (usage & allowedUsage) == usage;
-        bool readOnly = (usage & allReadBits) == usage;
+        bool readOnly = (usage & kReadOnlyBufferUsages) == usage;
         bool singleUse = nxt::HasZeroOrOneBits(usage);
         return allowed && (readOnly || singleUse);
     }

--- a/src/backend/Buffer.h
+++ b/src/backend/Buffer.h
@@ -23,6 +23,14 @@
 
 namespace backend {
 
+    static constexpr nxt::BufferUsageBit kReadOnlyBufferUsages =
+        nxt::BufferUsageBit::MapRead | nxt::BufferUsageBit::TransferSrc |
+        nxt::BufferUsageBit::Index | nxt::BufferUsageBit::Vertex | nxt::BufferUsageBit::Uniform;
+
+    static constexpr nxt::BufferUsageBit kWritableBufferUsages = nxt::BufferUsageBit::MapWrite |
+                                                                 nxt::BufferUsageBit::TransferDst |
+                                                                 nxt::BufferUsageBit::Storage;
+
     class BufferBase : public RefCounted {
       public:
         BufferBase(BufferBuilder* builder);

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -364,6 +364,7 @@ list(APPEND BACKEND_SOURCES
     ${BACKEND_DIR}/InputState.h
     ${BACKEND_DIR}/RenderPipeline.cpp
     ${BACKEND_DIR}/RenderPipeline.h
+    ${BACKEND_DIR}/PassResourceUsage.h
     ${BACKEND_DIR}/PerStage.cpp
     ${BACKEND_DIR}/PerStage.h
     ${BACKEND_DIR}/Pipeline.cpp

--- a/src/backend/CommandBuffer.h
+++ b/src/backend/CommandBuffer.h
@@ -19,6 +19,7 @@
 
 #include "backend/Builder.h"
 #include "backend/CommandAllocator.h"
+#include "backend/PassResourceUsage.h"
 #include "backend/RefCounted.h"
 
 #include <memory>
@@ -59,6 +60,7 @@ namespace backend {
         bool ValidateGetResult();
 
         CommandIterator AcquireCommands();
+        std::vector<PassResourceUsage> AcquirePassResourceUsage();
 
         // NXT API
         void BeginComputePass();
@@ -144,6 +146,9 @@ namespace backend {
         CommandIterator mIterator;
         bool mWasMovedToIterator = false;
         bool mWereCommandsAcquired = false;
+        bool mWerePassUsagesAcquired = false;
+
+        std::vector<PassResourceUsage> mPassResourceUsages;
     };
 
 }  // namespace backend

--- a/src/backend/CommandBufferStateTracker.cpp
+++ b/src/backend/CommandBufferStateTracker.cpp
@@ -28,6 +28,7 @@
 #include "common/BitSetIterator.h"
 
 namespace backend {
+
     CommandBufferStateTracker::CommandBufferStateTracker(CommandBufferBuilder* mBuilder)
         : mBuilder(mBuilder) {
     }

--- a/src/backend/CommandBufferStateTracker.h
+++ b/src/backend/CommandBufferStateTracker.h
@@ -24,6 +24,7 @@
 #include <set>
 
 namespace backend {
+
     class CommandBufferStateTracker {
       public:
         explicit CommandBufferStateTracker(CommandBufferBuilder* builder);
@@ -97,6 +98,7 @@ namespace backend {
         std::map<TextureBase*, nxt::TextureUsageBit> mMostRecentTextureUsages;
         std::set<TextureBase*> mTexturesAttached;
     };
+
 }  // namespace backend
 
 #endif  // BACKEND_COMMANDBUFFERSTATETRACKER_H

--- a/src/backend/PassResourceUsage.h
+++ b/src/backend/PassResourceUsage.h
@@ -1,0 +1,40 @@
+// Copyright 2018 The NXT Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_PASSRESOURCEUSAGE_H
+#define BACKEND_PASSRESOURCEUSAGE_H
+
+#include "nxt/nxtcpp.h"
+
+#include <vector>
+
+namespace backend {
+
+    class BufferBase;
+    class TextureBase;
+
+    // Which resources are used by pass and how they are used. The command buffer validation
+    // pre-computes this information so that backends with explicit barriers don't have to
+    // re-compute it.
+    struct PassResourceUsage {
+        std::vector<BufferBase*> buffers;
+        std::vector<nxt::BufferUsageBit> bufferUsages;
+
+        std::vector<TextureBase*> textures;
+        std::vector<nxt::TextureUsageBit> textureUsages;
+    };
+
+}  // namespace backend
+
+#endif  // BACKEND_PASSRESOURCEUSAGE_H

--- a/src/backend/SwapChain.cpp
+++ b/src/backend/SwapChain.cpp
@@ -82,6 +82,8 @@ namespace backend {
             return;
         }
 
+        OnBeforePresent(texture);
+
         mImplementation.Present(mImplementation.userData);
     }
 

--- a/src/backend/SwapChain.h
+++ b/src/backend/SwapChain.h
@@ -42,6 +42,7 @@ namespace backend {
       protected:
         const nxtSwapChainImplementation& GetImplementation();
         virtual TextureBase* GetNextTextureImpl(TextureBuilder* builder) = 0;
+        virtual void OnBeforePresent(TextureBase* texture) = 0;
 
       private:
         DeviceBase* mDevice = nullptr;

--- a/src/backend/Texture.h
+++ b/src/backend/Texture.h
@@ -28,6 +28,14 @@ namespace backend {
     bool TextureFormatHasStencil(nxt::TextureFormat format);
     bool TextureFormatHasDepthOrStencil(nxt::TextureFormat format);
 
+    static constexpr nxt::TextureUsageBit kReadOnlyTextureUsages =
+        nxt::TextureUsageBit::TransferSrc | nxt::TextureUsageBit::Sampled |
+        nxt::TextureUsageBit::Present;
+
+    static constexpr nxt::TextureUsageBit kWritableTextureUsages =
+        nxt::TextureUsageBit::TransferDst | nxt::TextureUsageBit::Storage |
+        nxt::TextureUsageBit::OutputAttachment;
+
     class TextureBase : public RefCounted {
       public:
         TextureBase(TextureBuilder* builder);

--- a/src/backend/d3d12/DeviceD3D12.cpp
+++ b/src/backend/d3d12/DeviceD3D12.cpp
@@ -51,7 +51,12 @@ namespace backend { namespace d3d12 {
 
     nxtSwapChainImplementation CreateNativeSwapChainImpl(nxtDevice device, HWND window) {
         Device* backendDevice = reinterpret_cast<Device*>(device);
-        return CreateSwapChainImplementation(new NativeSwapChainImpl(backendDevice, window));
+
+        nxtSwapChainImplementation impl;
+        impl = CreateSwapChainImplementation(new NativeSwapChainImpl(backendDevice, window));
+        impl.textureUsage = NXT_TEXTURE_USAGE_BIT_PRESENT;
+
+        return impl;
     }
 
     nxtTextureFormat GetNativeSwapChainPreferredFormat(

--- a/src/backend/d3d12/SwapChainD3D12.cpp
+++ b/src/backend/d3d12/SwapChainD3D12.cpp
@@ -44,4 +44,7 @@ namespace backend { namespace d3d12 {
         return new Texture(builder, nativeTexture);
     }
 
+    void SwapChain::OnBeforePresent(TextureBase*) {
+    }
+
 }}  // namespace backend::d3d12

--- a/src/backend/d3d12/SwapChainD3D12.h
+++ b/src/backend/d3d12/SwapChainD3D12.h
@@ -26,6 +26,7 @@ namespace backend { namespace d3d12 {
 
       protected:
         TextureBase* GetNextTextureImpl(TextureBuilder* builder) override;
+        void OnBeforePresent(TextureBase* texture) override;
     };
 
 }}  // namespace backend::d3d12

--- a/src/backend/metal/SwapChainMTL.h
+++ b/src/backend/metal/SwapChainMTL.h
@@ -28,6 +28,7 @@ namespace backend { namespace metal {
 
       protected:
         TextureBase* GetNextTextureImpl(TextureBuilder* builder) override;
+        void OnBeforePresent(TextureBase* texture) override;
     };
 
 }}  // namespace backend::metal

--- a/src/backend/metal/SwapChainMTL.mm
+++ b/src/backend/metal/SwapChainMTL.mm
@@ -44,4 +44,7 @@ namespace backend { namespace metal {
         return new Texture(builder, nativeTexture);
     }
 
+    void SwapChain::OnBeforePresent(TextureBase*) {
+    }
+
 }}  // namespace backend::metal

--- a/src/backend/null/NullBackend.cpp
+++ b/src/backend/null/NullBackend.cpp
@@ -250,4 +250,8 @@ namespace backend { namespace null {
     TextureBase* SwapChain::GetNextTextureImpl(TextureBuilder* builder) {
         return GetDevice()->CreateTexture(builder);
     }
+
+    void SwapChain::OnBeforePresent(TextureBase*) {
+    }
+
 }}  // namespace backend::null

--- a/src/backend/null/NullBackend.h
+++ b/src/backend/null/NullBackend.h
@@ -183,6 +183,7 @@ namespace backend { namespace null {
 
       protected:
         TextureBase* GetNextTextureImpl(TextureBuilder* builder) override;
+        void OnBeforePresent(TextureBase*) override;
     };
 
 }}  // namespace backend::null

--- a/src/backend/opengl/SwapChainGL.cpp
+++ b/src/backend/opengl/SwapChainGL.cpp
@@ -41,4 +41,7 @@ namespace backend { namespace opengl {
         return new Texture(builder, nativeTexture);
     }
 
+    void SwapChain::OnBeforePresent(TextureBase*) {
+    }
+
 }}  // namespace backend::opengl

--- a/src/backend/opengl/SwapChainGL.h
+++ b/src/backend/opengl/SwapChainGL.h
@@ -30,6 +30,7 @@ namespace backend { namespace opengl {
 
       protected:
         TextureBase* GetNextTextureImpl(TextureBuilder* builder) override;
+        void OnBeforePresent(TextureBase* texture) override;
     };
 
 }}  // namespace backend::opengl

--- a/src/backend/vulkan/BufferVk.h
+++ b/src/backend/vulkan/BufferVk.h
@@ -35,9 +35,10 @@ namespace backend { namespace vulkan {
 
         VkBuffer GetHandle() const;
 
-        void RecordBarrier(VkCommandBuffer commands,
-                           nxt::BufferUsageBit currentUsage,
-                           nxt::BufferUsageBit targetUsage) const;
+        // Transitions the buffer to be used as `usage`, recording any necessary barrier in
+        // `commands`.
+        // TODO(cwallez@chromium.org): coalesce barriers and do them early when possible.
+        void TransitionUsageNow(VkCommandBuffer commands, nxt::BufferUsageBit usage);
 
       private:
         void SetSubDataImpl(uint32_t start, uint32_t count, const uint8_t* data) override;
@@ -49,6 +50,8 @@ namespace backend { namespace vulkan {
 
         VkBuffer mHandle = VK_NULL_HANDLE;
         DeviceMemoryAllocation mMemoryAllocation;
+
+        nxt::BufferUsageBit mLastUsage = nxt::BufferUsageBit::None;
     };
 
     using BufferView = BufferViewBase;

--- a/src/backend/vulkan/CommandBufferVk.h
+++ b/src/backend/vulkan/CommandBufferVk.h
@@ -35,6 +35,7 @@ namespace backend { namespace vulkan {
         void RecordRenderPass(VkCommandBuffer commands, RenderPassDescriptor* renderPass);
 
         CommandIterator mCommands;
+        std::vector<PassResourceUsage> mPassResourceUsages;
     };
 
 }}  // namespace backend::vulkan

--- a/src/backend/vulkan/DeviceVk.cpp
+++ b/src/backend/vulkan/DeviceVk.cpp
@@ -69,8 +69,14 @@ namespace backend { namespace vulkan {
 
     nxtSwapChainImplementation CreateNativeSwapChainImpl(nxtDevice device, VkSurfaceKHR surface) {
         Device* backendDevice = reinterpret_cast<Device*>(device);
-        return CreateSwapChainImplementation(new NativeSwapChainImpl(backendDevice, surface));
+
+        nxtSwapChainImplementation impl;
+        impl = CreateSwapChainImplementation(new NativeSwapChainImpl(backendDevice, surface));
+        impl.textureUsage = NXT_TEXTURE_USAGE_BIT_PRESENT;
+
+        return impl;
     }
+
     nxtTextureFormat GetNativeSwapChainPreferredFormat(
         const nxtSwapChainImplementation* swapChain) {
         NativeSwapChainImpl* impl = reinterpret_cast<NativeSwapChainImpl*>(swapChain->userData);

--- a/src/backend/vulkan/NativeSwapChainImplVk.cpp
+++ b/src/backend/vulkan/NativeSwapChainImplVk.cpp
@@ -178,13 +178,12 @@ namespace backend { namespace vulkan {
     }
 
     nxtSwapChainError NativeSwapChainImpl::Present() {
-        // Since we're going to do a queue operations we need to flush pending commands such as
-        // layout transitions of the swapchain images to the PRESENT layout.
-        mDevice->SubmitPendingCommands();
+        // This assumes that the image has already been transitioned to the PRESENT layout and
+        // writes were made available to the stage.
 
         // Assuming that the present queue is the same as the graphics queue, the proper
-        // synchronization has already been done by the usage transition to present so we don't
-        // need to wait on any semaphores.
+        // synchronization has already been done on the queue so we don't need to wait on any
+        // semaphores.
         VkPresentInfoKHR presentInfo;
         presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
         presentInfo.pNext = nullptr;

--- a/src/backend/vulkan/SwapChainVk.h
+++ b/src/backend/vulkan/SwapChainVk.h
@@ -28,6 +28,10 @@ namespace backend { namespace vulkan {
 
       protected:
         TextureBase* GetNextTextureImpl(TextureBuilder* builder) override;
+        void OnBeforePresent(TextureBase* texture) override;
+
+      private:
+        nxt::TextureUsageBit mTextureUsage;
     };
 
 }}  // namespace backend::vulkan

--- a/src/backend/vulkan/TextureVk.h
+++ b/src/backend/vulkan/TextureVk.h
@@ -34,9 +34,10 @@ namespace backend { namespace vulkan {
         VkImage GetHandle() const;
         VkImageAspectFlags GetVkAspectMask() const;
 
-        void RecordBarrier(VkCommandBuffer commands,
-                           nxt::TextureUsageBit currentUsage,
-                           nxt::TextureUsageBit targetUsage) const;
+        // Transitions the texture to be used as `usage`, recording any necessary barrier in
+        // `commands`.
+        // TODO(cwallez@chromium.org): coalesce barriers and do them early when possible.
+        void TransitionUsageNow(VkCommandBuffer commands, nxt::TextureUsageBit usage);
 
       private:
         void TransitionUsageImpl(nxt::TextureUsageBit currentUsage,
@@ -44,6 +45,10 @@ namespace backend { namespace vulkan {
 
         VkImage mHandle = VK_NULL_HANDLE;
         DeviceMemoryAllocation mMemoryAllocation;
+
+        // A usage of none will make sure the texture is transitioned before its first use as
+        // required by the spec.
+        nxt::TextureUsageBit mLastUsage = nxt::TextureUsageBit::None;
     };
 
     class TextureView : public TextureViewBase {

--- a/src/include/nxt/EnumClassBitmasks.h
+++ b/src/include/nxt/EnumClassBitmasks.h
@@ -53,16 +53,23 @@ namespace nxt {
     struct LowerBitmask<T, typename std::enable_if<IsNXTBitmask<T>::enable>::type> {
         static constexpr bool enable = true;
         using type = T;
-        static T Lower(T t) {return t;}
+        constexpr static T Lower(T t) {
+            return t;
+        }
     };
 
     template<typename T>
     struct BoolConvertible {
         using Integral = typename UnderlyingType<T>::type;
 
-        BoolConvertible(Integral value) : value(value) {}
-        operator bool() const {return value != 0;}
-        operator T() const {return static_cast<T>(value);}
+        constexpr BoolConvertible(Integral value) : value(value) {
+        }
+        constexpr operator bool() const {
+            return value != 0;
+        }
+        constexpr operator T() const {
+            return static_cast<T>(value);
+        }
 
         Integral value;
     };
@@ -71,7 +78,9 @@ namespace nxt {
     struct LowerBitmask<BoolConvertible<T>> {
         static constexpr bool enable = true;
         using type = T;
-        static type Lower(BoolConvertible<T> t) {return t;}
+        static constexpr type Lower(BoolConvertible<T> t) {
+            return t;
+        }
     };
 
     template<typename T>
@@ -117,33 +126,35 @@ namespace nxt {
         return ~static_cast<Integral>(LowerBitmask<T1>::Lower(t));
     }
 
-    template<typename T, typename T2, typename = typename std::enable_if<
-        IsNXTBitmask<T>::enable && LowerBitmask<T2>::enable
-    >::type>
-    T& operator &= (T& l, T2 right) {
+    template <typename T,
+              typename T2,
+              typename = typename std::enable_if<IsNXTBitmask<T>::enable &&
+                                                 LowerBitmask<T2>::enable>::type>
+    constexpr T& operator&=(T& l, T2 right) {
         T r = LowerBitmask<T2>::Lower(right);
         l = l & r;
         return l;
     }
 
-    template<typename T, typename T2, typename = typename std::enable_if<
-        IsNXTBitmask<T>::enable && LowerBitmask<T2>::enable
-    >::type>
-    T& operator |= (T& l, T2 right) {
+    template <typename T,
+              typename T2,
+              typename = typename std::enable_if<IsNXTBitmask<T>::enable &&
+                                                 LowerBitmask<T2>::enable>::type>
+    constexpr T& operator|=(T& l, T2 right) {
         T r = LowerBitmask<T2>::Lower(right);
         l = l | r;
         return l;
     }
 
-    template<typename T, typename T2, typename = typename std::enable_if<
-        IsNXTBitmask<T>::enable && LowerBitmask<T2>::enable
-    >::type>
-    T& operator ^= (T& l, T2 right) {
+    template <typename T,
+              typename T2,
+              typename = typename std::enable_if<IsNXTBitmask<T>::enable &&
+                                                 LowerBitmask<T2>::enable>::type>
+    constexpr T& operator^=(T& l, T2 right) {
         T r = LowerBitmask<T2>::Lower(right);
         l = l ^ r;
         return l;
     }
-
 }
 
 #endif // NXT_ENUM_CLASS_BITMASKS_H_

--- a/src/include/nxt/nxt_wsi.h
+++ b/src/include/nxt/nxt_wsi.h
@@ -48,7 +48,10 @@ typedef struct {
     nxtSwapChainError (*Present)(void* userData);
 
     /// Each function is called with userData as its first argument.
-    void* userData = nullptr;
+    void* userData;
+
+    /// For use by the D3D12 and Vulkan backends: how the swapchain will use the texture.
+    nxtTextureUsageBit textureUsage;
 } nxtSwapChainImplementation;
 
 #if defined(NXT_ENABLE_BACKEND_D3D12) && defined(__cplusplus)


### PR DESCRIPTION
PTAL, this makes the Vulkan backend ignore frontend hints about transition and perform all transitions on its own. The current implementation is quite naive, but has the advantage of being simple and correct (at least it passes all the tests).

FYI the next steps are to do the same for D3D12, then remove the concept of usage transitions from NXT, then cleanups/optimizations.