### PR TITLE
Fix bind group binding ID validation.

### DIFF
--- a/src/backend/BindGroupLayout.cpp
+++ b/src/backend/BindGroupLayout.cpp
@@ -36,7 +36,8 @@ namespace backend {
             DAWN_TRY(ValidateShaderStageBit(binding.visibility));
             DAWN_TRY(ValidateBindingType(binding.type));
 
-            DAWN_TRY_ASSERT(!bindingsSet[binding.binding], "some binding index was specified more than once");
+            DAWN_TRY_ASSERT(!bindingsSet[binding.binding],
+                            "some binding index was specified more than once");
             bindingsSet.set(binding.binding);
         }
         return {};

--- a/src/backend/BindGroupLayout.cpp
+++ b/src/backend/BindGroupLayout.cpp
@@ -36,7 +36,7 @@ namespace backend {
             DAWN_TRY(ValidateShaderStageBit(binding.visibility));
             DAWN_TRY(ValidateBindingType(binding.type));
 
-            DAWN_TRY_ASSERT(!bindingsSet[i], "some binding index was specified more than once");
+            DAWN_TRY_ASSERT(!bindingsSet[binding.binding], "some binding index was specified more than once");
             bindingsSet.set(binding.binding);
         }
         return {};

--- a/src/tests/unittests/validation/BindGroupValidationTests.cpp
+++ b/src/tests/unittests/validation/BindGroupValidationTests.cpp
@@ -122,3 +122,13 @@ TEST_F(BindGroupValidationTest, BindGroupLayoutCache) {
     // Caching should cause these to be the same.
     ASSERT_EQ(layout1.Get(), layout2.Get());
 }
+
+// This test verifies that the BindGroupLayout bindings are correctly validated, even if the
+// binding ids are out-of-order.
+TEST_F(BindGroupValidationTest, BindGroupBinding) {
+    auto layout = utils::MakeBindGroupLayout(
+        device, {
+                    {1, dawn::ShaderStageBit::Vertex, dawn::BindingType::UniformBuffer},
+                    {0, dawn::ShaderStageBit::Vertex, dawn::BindingType::UniformBuffer},
+                });
+}


### PR DESCRIPTION
Use the binding, not the iterator index.