### PR TITLE
Add correct rpath for dawn samples on linux when using gn build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -126,6 +126,20 @@ config("libdawn_public") {
   ]
 }
 
+# Executable needs an rpath to find our shared libraries on OSX and Linux
+config("dawn_shared_library_public") {
+  if (is_mac) {
+    ldflags = [
+      "-rpath",
+      "@executable_path/",
+    ]
+  }
+
+  if (is_linux) {
+    configs = [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+  }
+}
+
 config("dawn_internal") {
   include_dirs = [ "src" ]
 
@@ -150,21 +164,14 @@ config("dawn_internal") {
     defines += [ "DAWN_ENABLE_BACKEND_VULKAN" ]
   }
 
-  configs = [ ":libdawn_public" ]
+  configs = [
+    ":libdawn_public",
+    ":dawn_shared_library_public",
+  ]
 
   # Only internal Dawn targets can use this config, this means only targets in
   # this BUILD.gn file.
   visibility = [ ":*" ]
-}
-
-# Executable needs an rpath to find our shared libraries on OSX
-config("dawn_shared_library_public") {
-  if (is_mac) {
-    ldflags = [
-      "-rpath",
-      "@executable_path/",
-    ]
-  }
 }
 
 static_library("dawn_common") {
@@ -225,7 +232,6 @@ dawn_generator("libdawn") {
       "-install_name",
       "@rpath/${target_name}.dylib",
     ]
-    public_configs = [ ":dawn_shared_library_public" ]
   }
 }
 
@@ -571,7 +577,6 @@ shared_library("libdawn_native") {
       "-install_name",
       "@rpath/${target_name}.dylib",
     ]
-    public_configs += [ ":dawn_shared_library_public" ]
   }
 }
 
@@ -625,7 +630,6 @@ shared_library("libdawn_wire") {
       "-install_name",
       "@rpath/${target_name}.dylib",
     ]
-    public_configs += [ ":dawn_shared_library_public" ]
   }
 }
 
@@ -705,10 +709,6 @@ dawn_generator("mock_dawn") {
 test("dawn_unittests") {
   configs += [ ":dawn_internal" ]
 
-  if (is_linux) {
-    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
-  }
-
   deps = [
     ":dawn_common",
     ":dawn_utils",
@@ -758,10 +758,6 @@ test("dawn_unittests") {
 
 test("dawn_end2end_tests") {
   configs += [ ":dawn_internal" ]
-
-  if (is_linux) {
-    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
-  }
 
   deps = [
     ":dawn_common",


### PR DESCRIPTION
Dawn Samples missing correct rpath settings on linux platform in
BUILD.gn. This failed program to find .so like libdawn_native on linux.