### PR TITLE
Remove BindGroupBuilder::SetUsage

### DIFF
--- a/dawn.json
+++ b/dawn.json
@@ -34,12 +34,6 @@
                 ]
             },
             {
-                "name": "set usage",
-                "args": [
-                    {"name": "usage", "type": "bind group usage"}
-                ]
-            },
-            {
                 "name": "set buffer views",
                 "args": [
                     {"name": "start", "type": "uint32_t"},
@@ -66,13 +60,6 @@
         ],
         "TODO": [
             "When resource are added, add methods for setting the content of the bind group"
-        ]
-    },
-    "bind group usage": {
-        "category": "enum",
-        "values": [
-            {"value": 0, "name": "frozen"},
-            {"value": 1, "name": "dynamic"}
         ]
     },
     "bind group layout": {

--- a/examples/ComputeBoids.cpp
+++ b/examples/ComputeBoids.cpp
@@ -250,7 +250,6 @@ void initSim() {
     for (uint32_t i = 0; i < 2; ++i) {
         updateBGs[i] = device.CreateBindGroupBuilder()
             .SetLayout(bgl)
-            .SetUsage(dawn::BindGroupUsage::Frozen)
             .SetBufferViews(0, 1, &updateParamsView)
             .SetBufferViews(1, 1, &views[i])
             .SetBufferViews(2, 1, &views[(i + 1) % 2])

--- a/examples/CppHelloTriangle.cpp
+++ b/examples/CppHelloTriangle.cpp
@@ -132,7 +132,6 @@ void init() {
 
     bindGroup = device.CreateBindGroupBuilder()
         .SetLayout(bgl)
-        .SetUsage(dawn::BindGroupUsage::Frozen)
         .SetSamplers(0, 1, &sampler)
         .SetTextureViews(1, 1, &view)
         .GetResult();

--- a/examples/CubeReflection.cpp
+++ b/examples/CubeReflection.cpp
@@ -195,14 +195,12 @@ void init() {
 
     bindGroup[0] = device.CreateBindGroupBuilder()
         .SetLayout(bgl)
-        .SetUsage(dawn::BindGroupUsage::Frozen)
         .SetBufferViews(0, 1, &cameraBufferView)
         .SetBufferViews(1, 1, &transformBufferView[0])
         .GetResult();
 
     bindGroup[1] = device.CreateBindGroupBuilder()
         .SetLayout(bgl)
-        .SetUsage(dawn::BindGroupUsage::Frozen)
         .SetBufferViews(0, 1, &cameraBufferView)
         .SetBufferViews(1, 1, &transformBufferView[1])
         .GetResult();

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -299,8 +299,8 @@ namespace {
             .GetResult();
 
         auto bindGroupBuilder = device.CreateBindGroupBuilder();
-        bindGroupBuilder.SetLayout(bindGroupLayout)
-            .SetUsage(dawn::BindGroupUsage::Frozen);
+        bindGroupBuilder.SetLayout(bindGroupLayout);
+
         if (hasTexture) {
             const auto& textureView = textures[iTextureID];
             const auto& iSamplerID = scene.textures[iTextureID].sampler;

--- a/src/dawn_native/BindGroup.cpp
+++ b/src/dawn_native/BindGroup.cpp
@@ -27,16 +27,11 @@ namespace dawn_native {
 
     BindGroupBase::BindGroupBase(BindGroupBuilder* builder)
         : mLayout(std::move(builder->mLayout)),
-          mUsage(builder->mUsage),
           mBindings(std::move(builder->mBindings)) {
     }
 
     const BindGroupLayoutBase* BindGroupBase::GetLayout() const {
         return mLayout.Get();
-    }
-
-    dawn::BindGroupUsage BindGroupBase::GetUsage() const {
-        return mUsage;
     }
 
     BufferViewBase* BindGroupBase::GetBindingAsBufferView(size_t binding) {
@@ -68,15 +63,14 @@ namespace dawn_native {
     // BindGroupBuilder
 
     enum BindGroupSetProperties {
-        BINDGROUP_PROPERTY_USAGE = 0x1,
-        BINDGROUP_PROPERTY_LAYOUT = 0x2,
+        BINDGROUP_PROPERTY_LAYOUT = 0x1,
     };
 
     BindGroupBuilder::BindGroupBuilder(DeviceBase* device) : Builder(device) {
     }
 
     BindGroupBase* BindGroupBuilder::GetResultImpl() {
-        constexpr int allProperties = BINDGROUP_PROPERTY_USAGE | BINDGROUP_PROPERTY_LAYOUT;
+        constexpr int allProperties = BINDGROUP_PROPERTY_LAYOUT;
         if ((mPropertiesSet & allProperties) != allProperties) {
             HandleError("Bindgroup missing properties");
             return nullptr;
@@ -98,16 +92,6 @@ namespace dawn_native {
 
         mLayout = layout;
         mPropertiesSet |= BINDGROUP_PROPERTY_LAYOUT;
-    }
-
-    void BindGroupBuilder::SetUsage(dawn::BindGroupUsage usage) {
-        if ((mPropertiesSet & BINDGROUP_PROPERTY_USAGE) != 0) {
-            HandleError("Bindgroup usage property set multiple times");
-            return;
-        }
-
-        mUsage = usage;
-        mPropertiesSet |= BINDGROUP_PROPERTY_USAGE;
     }
 
     void BindGroupBuilder::SetBufferViews(uint32_t start,

--- a/src/dawn_native/BindGroup.h
+++ b/src/dawn_native/BindGroup.h
@@ -33,7 +33,6 @@ namespace dawn_native {
         BindGroupBase(BindGroupBuilder* builder);
 
         const BindGroupLayoutBase* GetLayout() const;
-        dawn::BindGroupUsage GetUsage() const;
         BufferViewBase* GetBindingAsBufferView(size_t binding);
         SamplerBase* GetBindingAsSampler(size_t binding);
         TextureViewBase* GetBindingAsTextureView(size_t binding);
@@ -42,7 +41,6 @@ namespace dawn_native {
 
       private:
         Ref<BindGroupLayoutBase> mLayout;
-        dawn::BindGroupUsage mUsage;
         std::array<Ref<RefCounted>, kMaxBindingsPerGroup> mBindings;
     };
 
@@ -52,7 +50,6 @@ namespace dawn_native {
 
         // Dawn API
         void SetLayout(BindGroupLayoutBase* layout);
-        void SetUsage(dawn::BindGroupUsage usage);
 
         void SetBufferViews(uint32_t start, uint32_t count, BufferViewBase* const* bufferViews);
         void SetSamplers(uint32_t start, uint32_t count, SamplerBase* const* samplers);
@@ -69,7 +66,6 @@ namespace dawn_native {
         int mPropertiesSet = 0;
 
         Ref<BindGroupLayoutBase> mLayout;
-        dawn::BindGroupUsage mUsage;
         std::array<Ref<RefCounted>, kMaxBindingsPerGroup> mBindings;
     };
 

--- a/src/tests/end2end/BlendStateTests.cpp
+++ b/src/tests/end2end/BlendStateTests.cpp
@@ -103,7 +103,6 @@ class BlendStateTest : public DawnTest {
 
             return device.CreateBindGroupBuilder()
                 .SetLayout(bindGroupLayout)
-                .SetUsage(dawn::BindGroupUsage::Frozen)
                 .SetBufferViews(0, 1, &view)
                 .GetResult();
         }

--- a/src/tests/end2end/ComputeCopyStorageBufferTests.cpp
+++ b/src/tests/end2end/ComputeCopyStorageBufferTests.cpp
@@ -73,7 +73,6 @@ void ComputeCopyStorageBufferTests::BasicTest(const char* shader) {
     // Set up bind group and issue dispatch
     auto bindGroup = device.CreateBindGroupBuilder()
                          .SetLayout(bgl)
-                         .SetUsage(dawn::BindGroupUsage::Frozen)
                          .SetBufferViews(0, 1, &srcView)
                          .SetBufferViews(1, 1, &dstView)
                          .GetResult();

--- a/src/tests/end2end/DepthStencilStateTests.cpp
+++ b/src/tests/end2end/DepthStencilStateTests.cpp
@@ -210,7 +210,6 @@ class DepthStencilStateTest : public DawnTest {
                 // Create a bind group for the data
                 dawn::BindGroup bindGroup = device.CreateBindGroupBuilder()
                     .SetLayout(bindGroupLayout)
-                    .SetUsage(dawn::BindGroupUsage::Frozen)
                     .SetBufferViews(0, 1, &view)
                     .GetResult();
 

--- a/src/tests/end2end/PushConstantTests.cpp
+++ b/src/tests/end2end/PushConstantTests.cpp
@@ -61,7 +61,6 @@ class PushConstantTest: public DawnTest {
 
             dawn::BindGroup bg = device.CreateBindGroupBuilder()
                 .SetLayout(bgl)
-                .SetUsage(dawn::BindGroupUsage::Frozen)
                 .SetBufferViews(0, extraBuffer ? 2 : 1, views)
                 .GetResult();
 

--- a/src/tests/end2end/SamplerTests.cpp
+++ b/src/tests/end2end/SamplerTests.cpp
@@ -120,7 +120,6 @@ protected:
 
         auto bindGroup = device.CreateBindGroupBuilder()
             .SetLayout(mBindGroupLayout)
-            .SetUsage(dawn::BindGroupUsage::Frozen)
             .SetSamplers(0, 1, &sampler)
             .SetTextureViews(1, 1, &mTextureView)
             .GetResult();

--- a/src/tests/unittests/validation/BindGroupValidationTests.cpp
+++ b/src/tests/unittests/validation/BindGroupValidationTests.cpp
@@ -37,7 +37,6 @@ TEST_F(BindGroupValidationTest, BufferViewOffset) {
 
         auto bindGroup = AssertWillBeSuccess(device.CreateBindGroupBuilder())
             .SetLayout(layout)
-            .SetUsage(dawn::BindGroupUsage::Frozen)
             .SetBufferViews(0, 1, &bufferView)
             .GetResult();
     }
@@ -50,7 +49,6 @@ TEST_F(BindGroupValidationTest, BufferViewOffset) {
 
         auto bindGroup = AssertWillBeSuccess(device.CreateBindGroupBuilder())
             .SetLayout(layout)
-            .SetUsage(dawn::BindGroupUsage::Frozen)
             .SetBufferViews(0, 1, &bufferView)
             .GetResult();
     }
@@ -63,7 +61,6 @@ TEST_F(BindGroupValidationTest, BufferViewOffset) {
 
         auto bindGroup = AssertWillBeError(device.CreateBindGroupBuilder())
             .SetLayout(layout)
-            .SetUsage(dawn::BindGroupUsage::Frozen)
             .SetBufferViews(0, 1, &bufferView)
             .GetResult();
     }
@@ -75,7 +72,6 @@ TEST_F(BindGroupValidationTest, BufferViewOffset) {
 
         auto bindGroup = AssertWillBeError(device.CreateBindGroupBuilder())
             .SetLayout(layout)
-            .SetUsage(dawn::BindGroupUsage::Frozen)
             .SetBufferViews(0, 1, &bufferView)
             .GetResult();
     }
@@ -87,7 +83,6 @@ TEST_F(BindGroupValidationTest, BufferViewOffset) {
 
         auto bindGroup = AssertWillBeError(device.CreateBindGroupBuilder())
             .SetLayout(layout)
-            .SetUsage(dawn::BindGroupUsage::Frozen)
             .SetBufferViews(0, 1, &bufferView)
             .GetResult();
     }
@@ -99,7 +94,6 @@ TEST_F(BindGroupValidationTest, BufferViewOffset) {
 
         auto bindGroup = AssertWillBeError(device.CreateBindGroupBuilder())
             .SetLayout(layout)
-            .SetUsage(dawn::BindGroupUsage::Frozen)
             .SetBufferViews(0, 1, &bufferView)
             .GetResult();
     }


### PR DESCRIPTION
BindGroup usage isn't something that's part of WebGPU's sketch.idl and
it might never exist. Remove it to simplify the migration of bindgroup
to descriptor.

PTAL @SenorBlanco @kainino0x 