### PR TITLE
cr-buildbucket.cfg: Fix missing clang and no_clang mixins

### DIFF
--- a/infra/config/global/cr-buildbucket.cfg
+++ b/infra/config/global/cr-buildbucket.cfg
@@ -35,6 +35,18 @@ acl_sets {
 }
 
 builder_mixins {
+  name: "clang"
+  recipe {
+    properties_j: "clang:true"
+  }
+}
+builder_mixins {
+  name: "no_clang"
+  recipe {
+    properties_j: "clang:false"
+  }
+}
+builder_mixins {
   name: "release"
   recipe {
     properties_j: "debug:false"


### PR DESCRIPTION
PTAL @SenorBlanco 
I already landed this on Gerrit to see if it would fix luci-config (it does!) and I'll force push again once this commit is landed on Github.