### PR TITLE
 Fixes for cq.cfg

### DIFF
--- a/infra/config/branch/cq.cfg
+++ b/infra/config/branch/cq.cfg
@@ -2,9 +2,11 @@
 # documentation of this file format.
 
 version: 1
-cq_name: "dawn"
 cq_status_url: "https://chromium-cq-status.appspot.com"
-git_repo_url: "https://chromium.googlesource.com/angle/angle"
+git_repo_url: "https://dawn.googlesource.com/dawn"
+
+gerrit {
+}
 
 verifiers {
   gerrit_cq_ability {


### PR DESCRIPTION
A fun bug happened because our CQ config landed both global/ and
branch/ in the same commit. LUCI tries to discover where cq.cfg with
refs.cfg, however the processing of cq.cfg is done before refs.cfg. This
means that when everything was landed at once, the processing of cq.cfg
didn't where to look, and then refs.cfg was processed, but too late.

So this whitespace change will dirty cq.cfg and cause LUCI to discover
it.

PTAL @SenorBlanco 