### PR TITLE
Implement copying between a buffer and a texture 2D array on Vulkan

### DIFF
--- a/dawn.json
+++ b/dawn.json
@@ -345,7 +345,8 @@
                     {"name": "width", "type": "uint32_t"},
                     {"name": "height", "type": "uint32_t"},
                     {"name": "depth", "type": "uint32_t"},
-                    {"name": "level", "type": "uint32_t"}
+                    {"name": "level", "type": "uint32_t"},
+                    {"name": "slice", "type": "uint32_t"}
                 ],
                 "TODO": [
                     "Make pretty with Offset and Extents structures",
@@ -365,6 +366,7 @@
                     {"name": "height", "type": "uint32_t"},
                     {"name": "depth", "type": "uint32_t"},
                     {"name": "level", "type": "uint32_t"},
+                    {"name": "slice", "type": "uint32_t"},
                     {"name": "buffer", "type": "buffer"},
                     {"name": "buffer offset", "type": "uint32_t"},
                     {"name": "row pitch", "type": "uint32_t"}

--- a/examples/CppHelloTriangle.cpp
+++ b/examples/CppHelloTriangle.cpp
@@ -71,7 +71,7 @@ void initTextures() {
 
     dawn::Buffer stagingBuffer = utils::CreateBufferFromData(device, data.data(), static_cast<uint32_t>(data.size()), dawn::BufferUsageBit::TransferSrc);
     dawn::CommandBuffer copy = device.CreateCommandBufferBuilder()
-        .CopyBufferToTexture(stagingBuffer, 0, 0, texture, 0, 0, 0, 1024, 1024, 1, 0)
+        .CopyBufferToTexture(stagingBuffer, 0, 0, texture, 0, 0, 0, 1024, 1024, 1, 0, 0)
         .GetResult();
 
     queue.Submit(1, &copy);

--- a/examples/glTFViewer/glTFViewer.cpp
+++ b/examples/glTFViewer/glTFViewer.cpp
@@ -434,7 +434,7 @@ namespace {
 
             dawn::Buffer staging = utils::CreateBufferFromData(device, data, rowPitch * iImage.height, dawn::BufferUsageBit::TransferSrc);
             auto cmdbuf = device.CreateCommandBufferBuilder()
-                .CopyBufferToTexture(staging, 0, rowPitch, oTexture, 0, 0, 0, iImage.width, iImage.height, 1, 0)
+                .CopyBufferToTexture(staging, 0, rowPitch, oTexture, 0, 0, 0, iImage.width, iImage.height, 1, 0, 0)
                 .GetResult();
             queue.Submit(1, &cmdbuf);
 

--- a/src/dawn_native/CommandBuffer.cpp
+++ b/src/dawn_native/CommandBuffer.cpp
@@ -46,15 +46,20 @@ namespace dawn_native {
                 uint64_t(location.y) + uint64_t(location.height) >
                     (static_cast<uint64_t>(texture->GetHeight()) >> level) ||
                 uint64_t(location.z) + uint64_t(location.depth) >
-                    (static_cast<uint64_t>(texture->GetDepth()))){
+                    (static_cast<uint64_t>(texture->GetDepth()))) {
                 DAWN_RETURN_ERROR("Copy would touch outside of the texture");
             }
 
-            // TODO(jiawei.shao@intel.com): support 1D and 3D textures
-            ASSERT(texture->GetDimension() == dawn::TextureDimension::e2D);
-            if (location.depth != 1u)
-            {
-                DAWN_RETURN_ERROR("No support for copying to multiple 2D array layers for now");
+            switch (texture->GetDimension()) {
+                case dawn::TextureDimension::e2D:
+                    if (location.depth != 1u) {
+                        DAWN_RETURN_ERROR("No support for copying to multiple 2D array layers for now");
+                    }
+                    break;
+
+                // TODO(jiawei.shao@intel.com): support 1D and 3D textures
+                default:
+                    UNREACHABLE();
             }
 
             return {};

--- a/src/dawn_native/CommandBuffer.cpp
+++ b/src/dawn_native/CommandBuffer.cpp
@@ -53,7 +53,8 @@ namespace dawn_native {
             switch (texture->GetDimension()) {
                 case dawn::TextureDimension::e2D:
                     if (location.depth != 1u) {
-                        DAWN_RETURN_ERROR("No support for copying to multiple 2D array layers for now");
+                        DAWN_RETURN_ERROR(
+                            "No support for copying to multiple 2D array layers for now");
                     }
                     break;
 

--- a/src/dawn_native/CommandBuffer.cpp
+++ b/src/dawn_native/CommandBuffer.cpp
@@ -44,14 +44,17 @@ namespace dawn_native {
             if (uint64_t(location.x) + uint64_t(location.width) >
                     (static_cast<uint64_t>(texture->GetWidth()) >> level) ||
                 uint64_t(location.y) + uint64_t(location.height) >
-                    (static_cast<uint64_t>(texture->GetHeight()) >> level)) {
+                    (static_cast<uint64_t>(texture->GetHeight()) >> level) ||
+                uint64_t(location.z) + uint64_t(location.depth) >
+                    (static_cast<uint64_t>(texture->GetDepth()))){
                 DAWN_RETURN_ERROR("Copy would touch outside of the texture");
             }
 
-            // TODO(cwallez@chromium.org): Check the depth bound differently for 2D arrays and 3D
-            // textures
-            if (location.z != 0 || location.depth != 1) {
-                DAWN_RETURN_ERROR("No support for z != 0 and depth != 1 for now");
+            // TODO(jiawei.shao@intel.com): support 1D and 3D textures
+            ASSERT(texture->GetDimension() == dawn::TextureDimension::e2D);
+            if (location.depth != 1u)
+            {
+                DAWN_RETURN_ERROR("No support for copying to multiple 2D array layers for now");
             }
 
             return {};

--- a/src/dawn_native/CommandBuffer.h
+++ b/src/dawn_native/CommandBuffer.h
@@ -77,7 +77,8 @@ namespace dawn_native {
                                  uint32_t width,
                                  uint32_t height,
                                  uint32_t depth,
-                                 uint32_t level);
+                                 uint32_t level,
+                                 uint32_t slice);
         void CopyTextureToBuffer(TextureBase* texture,
                                  uint32_t x,
                                  uint32_t y,
@@ -86,6 +87,7 @@ namespace dawn_native {
                                  uint32_t height,
                                  uint32_t depth,
                                  uint32_t level,
+                                 uint32_t slice,
                                  BufferBase* buffer,
                                  uint32_t bufferOffset,
                                  uint32_t rowPitch);

--- a/src/dawn_native/Commands.h
+++ b/src/dawn_native/Commands.h
@@ -64,6 +64,7 @@ namespace dawn_native {
         uint32_t x, y, z;
         uint32_t width, height, depth;
         uint32_t level;
+        uint32_t slice;
     };
 
     struct CopyBufferToBufferCmd {

--- a/src/dawn_native/vulkan/CommandBufferVk.cpp
+++ b/src/dawn_native/vulkan/CommandBufferVk.cpp
@@ -53,16 +53,19 @@ namespace dawn_native { namespace vulkan {
 
             region.imageSubresource.aspectMask = texture->GetVkAspectMask();
             region.imageSubresource.mipLevel = textureLocation.level;
-            region.imageSubresource.baseArrayLayer = 0;
+
+            // TODO(jiawei.shao@intel.com): support 1D and 3D textures
+            ASSERT(texture->GetDimension() == dawn::TextureDimension::e2D);
+            region.imageSubresource.baseArrayLayer = textureLocation.z;
             region.imageSubresource.layerCount = 1;
 
             region.imageOffset.x = textureLocation.x;
             region.imageOffset.y = textureLocation.y;
-            region.imageOffset.z = textureLocation.z;
+            region.imageOffset.z = 0;
 
             region.imageExtent.width = textureLocation.width;
             region.imageExtent.height = textureLocation.height;
-            region.imageExtent.depth = textureLocation.depth;
+            region.imageExtent.depth = 1;
 
             return region;
         }

--- a/src/dawn_native/vulkan/CommandBufferVk.cpp
+++ b/src/dawn_native/vulkan/CommandBufferVk.cpp
@@ -71,8 +71,6 @@ namespace dawn_native { namespace vulkan {
                     UNREACHABLE();
             }
 
-
-
             return region;
         }
 

--- a/src/dawn_native/vulkan/CommandBufferVk.cpp
+++ b/src/dawn_native/vulkan/CommandBufferVk.cpp
@@ -53,23 +53,16 @@ namespace dawn_native { namespace vulkan {
 
             region.imageSubresource.aspectMask = texture->GetVkAspectMask();
             region.imageSubresource.mipLevel = textureLocation.level;
+            region.imageSubresource.baseArrayLayer = textureLocation.slice;
+            region.imageSubresource.layerCount = 1;
 
-            switch (texture->GetDimension()) {
-                case dawn::TextureDimension::e2D:
-                    region.imageSubresource.baseArrayLayer = textureLocation.z;
-                    region.imageSubresource.layerCount = 1;
-                    region.imageOffset.x = textureLocation.x;
-                    region.imageOffset.y = textureLocation.y;
-                    region.imageOffset.z = 0;
-                    region.imageExtent.width = textureLocation.width;
-                    region.imageExtent.height = textureLocation.height;
-                    region.imageExtent.depth = 1;
-                    break;
+            region.imageOffset.x = textureLocation.x;
+            region.imageOffset.y = textureLocation.y;
+            region.imageOffset.z = textureLocation.z;
 
-                // TODO(jiawei.shao@intel.com): support 1D and 3D textures
-                default:
-                    UNREACHABLE();
-            }
+            region.imageExtent.width = textureLocation.width;
+            region.imageExtent.height = textureLocation.height;
+            region.imageExtent.depth = textureLocation.depth;
 
             return region;
         }

--- a/src/dawn_native/vulkan/CommandBufferVk.cpp
+++ b/src/dawn_native/vulkan/CommandBufferVk.cpp
@@ -54,18 +54,24 @@ namespace dawn_native { namespace vulkan {
             region.imageSubresource.aspectMask = texture->GetVkAspectMask();
             region.imageSubresource.mipLevel = textureLocation.level;
 
-            // TODO(jiawei.shao@intel.com): support 1D and 3D textures
-            ASSERT(texture->GetDimension() == dawn::TextureDimension::e2D);
-            region.imageSubresource.baseArrayLayer = textureLocation.z;
-            region.imageSubresource.layerCount = 1;
+            switch (texture->GetDimension()) {
+                case dawn::TextureDimension::e2D:
+                    region.imageSubresource.baseArrayLayer = textureLocation.z;
+                    region.imageSubresource.layerCount = 1;
+                    region.imageOffset.x = textureLocation.x;
+                    region.imageOffset.y = textureLocation.y;
+                    region.imageOffset.z = 0;
+                    region.imageExtent.width = textureLocation.width;
+                    region.imageExtent.height = textureLocation.height;
+                    region.imageExtent.depth = 1;
+                    break;
 
-            region.imageOffset.x = textureLocation.x;
-            region.imageOffset.y = textureLocation.y;
-            region.imageOffset.z = 0;
+                // TODO(jiawei.shao@intel.com): support 1D and 3D textures
+                default:
+                    UNREACHABLE();
+            }
 
-            region.imageExtent.width = textureLocation.width;
-            region.imageExtent.height = textureLocation.height;
-            region.imageExtent.depth = 1;
+
 
             return region;
         }

--- a/src/dawn_native/vulkan/TextureVk.cpp
+++ b/src/dawn_native/vulkan/TextureVk.cpp
@@ -257,7 +257,7 @@ namespace dawn_native { namespace vulkan {
 
         switch (GetDimension()) {
             case dawn::TextureDimension::e2D:
-                createInfo.extent = VkExtent3D{ GetWidth(), GetHeight(), 1 };
+                createInfo.extent = VkExtent3D{GetWidth(), GetHeight(), 1};
                 createInfo.arrayLayers = GetDepth();
                 break;
 

--- a/src/dawn_native/vulkan/TextureVk.cpp
+++ b/src/dawn_native/vulkan/TextureVk.cpp
@@ -247,11 +247,6 @@ namespace dawn_native { namespace vulkan {
         createInfo.imageType = VulkanImageType(GetDimension());
         createInfo.format = VulkanImageFormat(GetFormat());
         createInfo.mipLevels = GetNumMipLevels();
-
-        // TODO(jiawei.shao@intel.com): support 1D and 3D textures
-        ASSERT(GetDimension() == dawn::TextureDimension::e2D);
-        createInfo.extent = VkExtent3D{ GetWidth(), GetHeight(), 1 };
-        createInfo.arrayLayers = GetDepth();
         createInfo.samples = VK_SAMPLE_COUNT_1_BIT;
         createInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
         createInfo.usage = VulkanImageUsage(GetUsage(), GetFormat());
@@ -259,6 +254,17 @@ namespace dawn_native { namespace vulkan {
         createInfo.queueFamilyIndexCount = 0;
         createInfo.pQueueFamilyIndices = nullptr;
         createInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+        switch (GetDimension()) {
+            case dawn::TextureDimension::e2D:
+                createInfo.extent = VkExtent3D{ GetWidth(), GetHeight(), 1 };
+                createInfo.arrayLayers = GetDepth();
+                break;
+
+            // TODO(jiawei.shao@intel.com): support 1D and 3D textures
+            default:
+                UNREACHABLE();
+        }
 
         if (device->fn.CreateImage(device->GetVkDevice(), &createInfo, nullptr, &mHandle) !=
             VK_SUCCESS) {

--- a/src/dawn_native/vulkan/TextureVk.cpp
+++ b/src/dawn_native/vulkan/TextureVk.cpp
@@ -246,9 +246,12 @@ namespace dawn_native { namespace vulkan {
         createInfo.flags = 0;
         createInfo.imageType = VulkanImageType(GetDimension());
         createInfo.format = VulkanImageFormat(GetFormat());
-        createInfo.extent = VkExtent3D{GetWidth(), GetHeight(), GetDepth()};
         createInfo.mipLevels = GetNumMipLevels();
-        createInfo.arrayLayers = 1;
+
+        // TODO(jiawei.shao@intel.com): support 1D and 3D textures
+        ASSERT(GetDimension() == dawn::TextureDimension::e2D);
+        createInfo.extent = VkExtent3D{ GetWidth(), GetHeight(), 1 };
+        createInfo.arrayLayers = GetDepth();
         createInfo.samples = VK_SAMPLE_COUNT_1_BIT;
         createInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
         createInfo.usage = VulkanImageUsage(GetUsage(), GetFormat());

--- a/src/dawn_native/vulkan/TextureVk.cpp
+++ b/src/dawn_native/vulkan/TextureVk.cpp
@@ -246,7 +246,9 @@ namespace dawn_native { namespace vulkan {
         createInfo.flags = 0;
         createInfo.imageType = VulkanImageType(GetDimension());
         createInfo.format = VulkanImageFormat(GetFormat());
+        createInfo.extent = VkExtent3D{GetWidth(), GetHeight(), GetDepth()};
         createInfo.mipLevels = GetNumMipLevels();
+        createInfo.arrayLayers = GetArrayLayers();
         createInfo.samples = VK_SAMPLE_COUNT_1_BIT;
         createInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
         createInfo.usage = VulkanImageUsage(GetUsage(), GetFormat());
@@ -254,17 +256,6 @@ namespace dawn_native { namespace vulkan {
         createInfo.queueFamilyIndexCount = 0;
         createInfo.pQueueFamilyIndices = nullptr;
         createInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-        switch (GetDimension()) {
-            case dawn::TextureDimension::e2D:
-                createInfo.extent = VkExtent3D{GetWidth(), GetHeight(), 1};
-                createInfo.arrayLayers = GetDepth();
-                break;
-
-            // TODO(jiawei.shao@intel.com): support 1D and 3D textures
-            default:
-                UNREACHABLE();
-        }
 
         if (device->fn.CreateImage(device->GetVkDevice(), &createInfo, nullptr, &mHandle) !=
             VK_SUCCESS) {

--- a/src/tests/DawnTest.cpp
+++ b/src/tests/DawnTest.cpp
@@ -259,7 +259,7 @@ std::ostringstream& DawnTest::AddTextureExpectation(const char* file,
     // the texture might have been modified.
     dawn::CommandBuffer commands =
         device.CreateCommandBufferBuilder()
-            .CopyTextureToBuffer(source, x, y, 0, width, height, 1, level, readback.buffer,
+            .CopyTextureToBuffer(source, x, y, 0, width, height, 1, level, 0, readback.buffer,
                                  readback.offset, rowPitch)
             .GetResult();
 

--- a/src/tests/end2end/CopyTests.cpp
+++ b/src/tests/end2end/CopyTests.cpp
@@ -63,8 +63,8 @@ class CopyTests_T2B : public CopyTests {
                 for (unsigned int x = 0; x < width; ++x) {
                     unsigned int i = x + y * texelsPerRow;
                     data[i] = RGBA8(
-                        static_cast<uint8_t>((x + layer)% 256),
-                        static_cast<uint8_t>((y + layer)% 256),
+                        static_cast<uint8_t>((x + layer * x)% 256),
+                        static_cast<uint8_t>((y + layer * y)% 256),
                         static_cast<uint8_t>(x / 256),
                         static_cast<uint8_t>(y / 256));
                 }
@@ -90,57 +90,64 @@ class CopyTests_T2B : public CopyTests {
             uint32_t texelsPerRow = rowPitch / kBytesPerTexel;
             uint32_t texelCountPerLayer = texelsPerRow * (height - 1) + width;
 
-            // Create an upload buffer and use it to populate the `level` mip of the texture
+            // Create an upload buffer and use it to populate all slices of the `level` mip of the texture
             std::vector<std::vector<RGBA8>> textureArrayData(textureSpec.arrayLayer);
-            std::vector<dawn::CommandBuffer> commands(textureSpec.arrayLayer);
-            for (uint32_t layer = 0; layer < textureSpec.arrayLayer; ++layer) {
-                textureArrayData[layer].resize(texelCountPerLayer);
-                FillTextureData(width, height, rowPitch / kBytesPerTexel, textureArrayData[layer].data(), layer);
-                dawn::Buffer uploadBuffer = utils::CreateBufferFromData(device, textureArrayData[layer].data(),
-                    static_cast<uint32_t>(sizeof(RGBA8) * textureArrayData[layer].size()), dawn::BufferUsageBit::TransferSrc);
+            std::vector<dawn::CommandBuffer> commands(textureSpec.arrayLayer * 2);
+            for (uint32_t slice = 0; slice < textureSpec.arrayLayer; ++slice) {
+                textureArrayData[slice].resize(texelCountPerLayer);
+                FillTextureData(width, height, rowPitch / kBytesPerTexel, textureArrayData[slice].data(), slice);
+                dawn::Buffer uploadBuffer = utils::CreateBufferFromData(device, textureArrayData[slice].data(),
+                    static_cast<uint32_t>(sizeof(RGBA8) * textureArrayData[slice].size()), dawn::BufferUsageBit::TransferSrc);
 
-                commands[layer] = device.CreateCommandBufferBuilder()
-                    .CopyBufferToTexture(uploadBuffer, 0, rowPitch, texture, 0, 0, layer, width, height, 1, textureSpec.level)
+                commands[slice] = device.CreateCommandBufferBuilder()
+                    .CopyBufferToTexture(uploadBuffer, 0, rowPitch, texture, 0, 0, 0, width, height, 1, textureSpec.level, slice)
                     .GetResult();
+            }
+
+            // Create a buffer of size `size * textureSpec.arrayLayer` and populate it with empty data (0,0,0,0)
+            // Note: Prepopulating the buffer with empty data ensures that there is not random data in the expectation
+            // and helps ensure that the padding due to the row pitch is not modified by the copy
+            dawn::BufferDescriptor bufDescriptor;
+            bufDescriptor.size = bufferSpec.size * textureSpec.arrayLayer;
+            bufDescriptor.usage = dawn::BufferUsageBit::TransferSrc | dawn::BufferUsageBit::TransferDst;
+            dawn::Buffer buffer = device.CreateBuffer(&bufDescriptor);
+            std::vector<RGBA8> emptyData(bufferSpec.size / kBytesPerTexel * textureSpec.arrayLayer);
+            buffer.SetSubData(0, static_cast<uint32_t>(emptyData.size() * sizeof(RGBA8)), reinterpret_cast<const uint8_t*>(emptyData.data()));
+
+            uint32_t bufferOffset = bufferSpec.offset;
+            for (uint32_t slice = 0; slice < textureSpec.arrayLayer; ++slice) {
+                // Copy the region [(`x`, `y`), (`x + copyWidth, `y + copyWidth`)] from the `level` mip into the buffer at `offset + bufferSpec.size * slice` and `rowPitch`
+                commands[textureSpec.arrayLayer + slice] = device.CreateCommandBufferBuilder()
+                    .CopyTextureToBuffer(texture, textureSpec.x, textureSpec.y, 0, textureSpec.copyWidth, textureSpec.copyHeight, 1, textureSpec.level, slice, buffer, bufferOffset, bufferSpec.rowPitch)
+                    .GetResult();
+                bufferOffset += bufferSpec.size;
             }
 
             queue.Submit(static_cast<uint32_t>(commands.size()), commands.data());
 
-            // Create a buffer of size `size` and populate it with empty data (0,0,0,0)
-            // Note: Prepopulating the buffer with empty data ensures that there is not random data in the expectation
-            // and helps ensure that the padding due to the row pitch is not modified by the copy
-            dawn::BufferDescriptor bufDescriptor;
-            bufDescriptor.size = bufferSpec.size;
-            bufDescriptor.usage = dawn::BufferUsageBit::TransferSrc | dawn::BufferUsageBit::TransferDst;
-            dawn::Buffer buffer = device.CreateBuffer(&bufDescriptor);
-
-            std::vector<RGBA8> emptyData(bufferSpec.size / kBytesPerTexel);
-
-            for (uint32_t layer = 0; layer < textureSpec.arrayLayer; ++layer) {
-                buffer.SetSubData(0, static_cast<uint32_t>(emptyData.size() * sizeof(RGBA8)), reinterpret_cast<const uint8_t*>(emptyData.data()));
-
-                // Copy the region [(`x`, `y`), (`x + copyWidth, `y + copyWidth`)] from the `level` mip into the buffer at the specified `offset` and `rowPitch`
-                dawn::CommandBuffer command = device.CreateCommandBufferBuilder()
-                    .CopyTextureToBuffer(texture, textureSpec.x, textureSpec.y, layer, textureSpec.copyWidth, textureSpec.copyHeight, 1, textureSpec.level, buffer, bufferSpec.offset, bufferSpec.rowPitch)
-                    .GetResult();
-                queue.Submit(1, &command);
-
+            bufferOffset = bufferSpec.offset;
+            std::vector<RGBA8> expected(bufferSpec.rowPitch / kBytesPerTexel * (textureSpec.copyHeight - 1) + textureSpec.copyWidth);
+            for (uint32_t slice = 0; slice < textureSpec.arrayLayer; ++slice) {
                 // Pack the data used to create the upload buffer in the specified copy region to have the same format as the expected buffer data.
-                std::vector<RGBA8> expected(bufferSpec.rowPitch / kBytesPerTexel * (textureSpec.copyHeight - 1) + textureSpec.copyWidth);
+                std::fill(expected.begin(), expected.end(), RGBA8());
                 PackTextureData(
-                    &textureArrayData[layer][textureSpec.x + textureSpec.y * (rowPitch / kBytesPerTexel)],
+                    &textureArrayData[slice][textureSpec.x + textureSpec.y * (rowPitch / kBytesPerTexel)],
                     textureSpec.copyWidth,
                     textureSpec.copyHeight,
                     rowPitch / kBytesPerTexel,
                     expected.data(),
                     bufferSpec.rowPitch / kBytesPerTexel);
 
-                EXPECT_BUFFER_U32_RANGE_EQ(reinterpret_cast<const uint32_t*>(expected.data()), buffer, bufferSpec.offset, static_cast<uint32_t>(expected.size())) <<
+                EXPECT_BUFFER_U32_RANGE_EQ(reinterpret_cast<const uint32_t*>(expected.data()), buffer, bufferOffset, static_cast<uint32_t>(expected.size())) <<
                     "Texture to Buffer copy failed copying region [(" << textureSpec.x << ", " << textureSpec.y << "), (" << textureSpec.x + textureSpec.copyWidth << ", " << textureSpec.y + textureSpec.copyHeight <<
-                    ")) from " << textureSpec.width << " x " << textureSpec.height << " texture at mip level " << textureSpec.level << " layer " << layer <<
-                    " to " << bufferSpec.size << "-byte buffer with offset " << bufferSpec.offset << " and row pitch " << bufferSpec.rowPitch << std::endl;
+                    ")) from " << textureSpec.width << " x " << textureSpec.height << " texture at mip level " << textureSpec.level << " layer " << slice <<
+                    " to " << bufDescriptor.size << "-byte buffer with offset " << bufferOffset << " and row pitch " << bufferSpec.rowPitch << std::endl;
+
+                bufferOffset += bufferSpec.size;
             }
         }
+
+
 };
 
 class CopyTests_B2T : public CopyTests {
@@ -194,13 +201,13 @@ protected:
             dawn::Buffer uploadBuffer = utils::CreateBufferFromData(device, emptyData.data(), static_cast<uint32_t>(sizeof(RGBA8) * emptyData.size()), dawn::BufferUsageBit::TransferSrc);
 
             commands[0] = device.CreateCommandBufferBuilder()
-                .CopyBufferToTexture(uploadBuffer, 0, rowPitch, texture, 0, 0, 0, width, height, 1, textureSpec.level)
+                .CopyBufferToTexture(uploadBuffer, 0, rowPitch, texture, 0, 0, 0, width, height, 1, textureSpec.level, 0)
                 .GetResult();
         }
 
         // Copy to the region [(`x`, `y`), (`x + copyWidth, `y + copyWidth`)] at the `level` mip from the buffer at the specified `offset` and `rowPitch`
         commands[1] = device.CreateCommandBufferBuilder()
-            .CopyBufferToTexture(buffer, bufferSpec.offset, bufferSpec.rowPitch, texture, textureSpec.x, textureSpec.y, 0, textureSpec.copyWidth, textureSpec.copyHeight, 1, textureSpec.level)
+            .CopyBufferToTexture(buffer, bufferSpec.offset, bufferSpec.rowPitch, texture, textureSpec.x, textureSpec.y, 0, textureSpec.copyWidth, textureSpec.copyHeight, 1, textureSpec.level, 0)
             .GetResult();
 
         queue.Submit(2, commands);
@@ -366,7 +373,7 @@ TEST_P(CopyTests_T2B, Texture2DArrayRegion)
 {
     // TODO(jiawei.shao@intel.com): support 2D array texture on OpenGL, D3D12 and Metal.
     if (IsOpenGL() || IsD3D12() || IsMetal()) {
-        std::cout << "Test skipped on D3D12 and Metal" << std::endl;
+        std::cout << "Test skipped on OpenGL, D3D12 and Metal" << std::endl;
         return;
     }
 
@@ -380,7 +387,7 @@ TEST_P(CopyTests_T2B, Texture2DArrayRegion)
 TEST_P(CopyTests_T2B, Texture2DArrayMip) {
     // TODO(jiawei.shao@intel.com): support 2D array texture on OpenGL, D3D12 and Metal.
     if (IsOpenGL() || IsD3D12() || IsMetal()) {
-        std::cout << "Test skipped on D3D12 and Metal" << std::endl;
+        std::cout << "Test skipped on OpenGL, D3D12 and Metal" << std::endl;
         return;
     }
     constexpr uint32_t kWidth = 256;
@@ -390,7 +397,6 @@ TEST_P(CopyTests_T2B, Texture2DArrayMip) {
         DoTest({ kWidth, kHeight, 0, 0, kWidth >> i, kHeight >> i, i, kLayers }, MinimumBufferSpec(kWidth >> i, kHeight >> i));
     }
 }
-
 
 DAWN_INSTANTIATE_TEST(CopyTests_T2B, D3D12Backend, MetalBackend, OpenGLBackend, VulkanBackend)
 

--- a/src/tests/end2end/CopyTests.cpp
+++ b/src/tests/end2end/CopyTests.cpp
@@ -93,8 +93,7 @@ class CopyTests_T2B : public CopyTests {
             // Create an upload buffer and use it to populate the `level` mip of the texture
             std::vector<std::vector<RGBA8>> textureArrayData(textureSpec.arrayLayer);
             std::vector<dawn::CommandBuffer> commands(textureSpec.arrayLayer);
-            for (uint32_t layer = 0; layer < textureSpec.arrayLayer; ++layer)
-            {
+            for (uint32_t layer = 0; layer < textureSpec.arrayLayer; ++layer) {
                 textureArrayData[layer].resize(texelCountPerLayer);
                 FillTextureData(width, height, rowPitch / kBytesPerTexel, textureArrayData[layer].data(), layer);
                 dawn::Buffer uploadBuffer = utils::CreateBufferFromData(device, textureArrayData[layer].data(),
@@ -116,8 +115,8 @@ class CopyTests_T2B : public CopyTests {
             dawn::Buffer buffer = device.CreateBuffer(&bufDescriptor);
 
             std::vector<RGBA8> emptyData(bufferSpec.size / kBytesPerTexel);
-            for (uint32_t layer = 0; layer < textureSpec.arrayLayer; ++layer)
-            {
+
+            for (uint32_t layer = 0; layer < textureSpec.arrayLayer; ++layer) {
                 buffer.SetSubData(0, static_cast<uint32_t>(emptyData.size() * sizeof(RGBA8)), reinterpret_cast<const uint8_t*>(emptyData.data()));
 
                 // Copy the region [(`x`, `y`), (`x + copyWidth, `y + copyWidth`)] from the `level` mip into the buffer at the specified `offset` and `rowPitch`

--- a/src/tests/end2end/SamplerTests.cpp
+++ b/src/tests/end2end/SamplerTests.cpp
@@ -101,7 +101,7 @@ protected:
 
         dawn::Buffer stagingBuffer = utils::CreateBufferFromData(device, data, sizeof(data), dawn::BufferUsageBit::TransferSrc);
         dawn::CommandBuffer copy = device.CreateCommandBufferBuilder()
-            .CopyBufferToTexture(stagingBuffer, 0, 256, texture, 0, 0, 0, 2, 2, 1, 0)
+            .CopyBufferToTexture(stagingBuffer, 0, 256, texture, 0, 0, 0, 2, 2, 1, 0, 0)
             .GetResult();
 
         queue.Submit(1, &copy);


### PR DESCRIPTION
This patch implements the creation of a 2D array texture and
copying data between a buffer and a layer of a 2D array texture
on Vulkan back-ends. A new parameter "slice" is added to both
CopyBufferToTexture and CopyTextureToBuffer to specify the
slice of the 2D array texture in this copy operation.

TEST=dawn_end2end_tests