### PR TITLE
Change WIN32 to _WIN32.

### DIFF
--- a/src/include/dawn/dawn_export.h
+++ b/src/include/dawn/dawn_export.h
@@ -15,7 +15,7 @@
 #ifndef DAWN_EXPORT_H_
 #define DAWN_EXPORT_H_
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #    if defined(DAWN_IMPLEMENTATION)
 #        define DAWN_EXPORT __declspec(dllexport)
 #    else

--- a/src/include/dawn_native/dawn_native_export.h
+++ b/src/include/dawn_native/dawn_native_export.h
@@ -15,7 +15,7 @@
 #ifndef DAWNNATIVE_EXPORT_H_
 #define DAWNNATIVE_EXPORT_H_
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #    if defined(DAWN_NATIVE_IMPLEMENTATION)
 #        define DAWN_NATIVE_EXPORT __declspec(dllexport)
 #    else

--- a/src/include/dawn_wire/dawn_wire_export.h
+++ b/src/include/dawn_wire/dawn_wire_export.h
@@ -15,7 +15,7 @@
 #ifndef DAWNWIRE_EXPORT_H_
 #define DAWNWIRE_EXPORT_H_
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #    if defined(DAWN_WIRE_IMPLEMENTATION)
 #        define DAWN_WIRE_EXPORT __declspec(dllexport)
 #    else


### PR DESCRIPTION
WIN32 is defined by the SDK, but _WIN32 is defined by the compiler.
Since Dawn doesn't necessarily include <windows.h> everywhere dawn.h is
included, we should use _WIN32 (which will always be defined).