### PR TITLE
Update Travis to use clang-format-8 after LLVm release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
   sources:
    # PPA for clang 6.0
    - llvm-toolchain-trusty-6.0
-   # PPA for clang-format 7
+   # PPA for clang-format 8
    - llvm-toolchain-trusty
    # PPA for a more recen libstdc++
    - ubuntu-toolchain-r-test
@@ -44,7 +44,7 @@ addons:
    # Required dependency for GLFW on Linux
    - xorg-dev
    # Format using the latest and greatest
-   - clang-format-7
+   - clang-format-8
 
 before_install:
  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
@@ -72,4 +72,4 @@ script:
  - cd ..
 
  # Lint
- - if [ "$TRAVIS_OS_NAME" == "linux" ]; then ./scripts/travis_lint_format.sh clang-format-7; fi
+ - if [ "$TRAVIS_OS_NAME" == "linux" ]; then ./scripts/travis_lint_format.sh clang-format-8; fi


### PR DESCRIPTION
LLVM 7.0 was branched from ToT because it is going to be released soon.
This means that the repo we use to get clang-format now is LLVM 8.0 so
we update to clang-format-8.

We cannot add the LLVM 7.0 specific repo because it isn't in the Travis
APT source whitelist yet. Opened an issue to add to the whitelist:
https://github.com/travis-ci/apt-source-whitelist/issues/386

Will land this TBR if it passes CI to unblock @Jiawei-Shao.