### PR TITLE
Mirror CI builders in the try pool

### DIFF
--- a/infra/config/global/cr-buildbucket.cfg
+++ b/infra/config/global/cr-buildbucket.cfg
@@ -198,30 +198,53 @@ buckets: {
       service_account: "dawn-try-builder@chops-service-accounts.iam.gserviceaccount.com"
     }
 
+    # A subset of the CI configurations are used for the CQ. We still mirror
+    # the CI builders here so we can trigger tryjobs on their specific
+    # configuration.
+
+    # CI Mirror only
     builders {
       name: "linux-clang-dbg-x64"
       dimensions: "os:Ubuntu-14.04"
       mixins: "debug"
       mixins: "x64"
     }
+    # CI Mirror only
+    builders {
+      name: "linux-clang-dbg-x86"
+      dimensions: "os:Ubuntu-14.04"
+      mixins: "debug"
+      mixins: "x86"
+    }
+    # Actually on the CQ
     builders {
       name: "linux-clang-rel-x64"
       dimensions: "os:Ubuntu-14.04"
       mixins: "release"
       mixins: "x64"
     }
+    # Actually on the CQ
+    builders {
+      name: "linux-clang-rel-x86"
+      dimensions: "os:Ubuntu-14.04"
+      mixins: "release"
+      mixins: "x86"
+    }
 
+    # Actually on the CQ
     builders {
       name: "mac-dbg"
       dimensions: "os:Mac"
       mixins: "debug"
     }
+    # Actually on the CQ
     builders {
       name: "mac-rel"
       dimensions: "os:Mac"
       mixins: "release"
     }
 
+    # Actually on the CQ
     builders {
       name: "win-clang-dbg-x64"
       dimensions: "os:Windows"
@@ -229,10 +252,43 @@ buckets: {
       mixins: "debug"
       mixins: "x64"
     }
+    # CI Mirror only
+    builders {
+      name: "win-clang-dbg-x86"
+      dimensions: "os:Windows"
+      mixins: "clang"
+      mixins: "debug"
+      mixins: "x86"
+    }
+    # Actually on the CQ
     builders {
       name: "win-clang-rel-x64"
       dimensions: "os:Windows"
       mixins: "clang"
+      mixins: "release"
+      mixins: "x64"
+    }
+    # CI Mirror only
+    builders {
+      name: "win-clang-rel-x86"
+      dimensions: "os:Windows"
+      mixins: "clang"
+      mixins: "release"
+      mixins: "x86"
+    }
+    # CI Mirror only
+    builders {
+      name: "win-msvc-dbg-x64"
+      dimensions: "os:Windows"
+      mixins: "no_clang"
+      mixins: "debug"
+      mixins: "x64"
+    }
+    # CI Mirror only
+    builders {
+      name: "win-msvc-rel-x64"
+      dimensions: "os:Windows"
+      mixins: "no_clang"
       mixins: "release"
       mixins: "x64"
     }


### PR DESCRIPTION
This will allow testing specific configurations that are on CI
builders when trying to fix them.

Landing this directly as it has been reviewed by tandrii@chromium.org [here](https://dawn-review.googlesource.com/c/dawn/+/1200).