### PR TITLE
cr-buildbucket.cfg: Tighten bot dimensions

### DIFF
--- a/infra/config/global/cr-buildbucket.cfg
+++ b/infra/config/global/cr-buildbucket.cfg
@@ -79,6 +79,8 @@ buckets {
     hostname: "chromium-swarm.appspot.com"
     builder_defaults {
       dimensions: "pool:luci.flex.ci"
+      # We have 32bit test configurations but some of our toolchain is 64bit (like CIPD)
+      dimensions: "cpu:x86-64"
       caches {
         path: "win_toolchain"
         name: "win_toolchain"
@@ -120,12 +122,12 @@ buckets {
     # Mac: unlike Linux we only need to test x64 (and only clang too)
     builders {
       name: "mac-dbg"
-      dimensions: "os:Mac"
+      dimensions: "os:Mac-10.13"
       mixins: "debug"
     }
     builders {
       name: "mac-rel"
-      dimensions: "os:Mac"
+      dimensions: "os:Mac-10.13"
       mixins: "release"
     }
 
@@ -234,13 +236,13 @@ buckets: {
     # Actually on the CQ
     builders {
       name: "mac-dbg"
-      dimensions: "os:Mac"
+      dimensions: "os:Mac-10.13"
       mixins: "debug"
     }
     # Actually on the CQ
     builders {
       name: "mac-rel"
-      dimensions: "os:Mac"
+      dimensions: "os:Mac-10.13"
       mixins: "release"
     }
 


### PR DESCRIPTION
There was flakiness on CI because of two things:
 - On Windows there is a bot that's only 32bit and our tools are 64bit
so the gn gen step was failing.
 - On macOS we require a minimum SDK version of 10.12 (the default in
build/'s GN files) and would get scheduled on macOS 10.9.

TBR @SenorBlanco 