### PR TITLE
Implement DAWN_SKIP_TEST_IF for dawn_end2end_tests

### DIFF
--- a/src/tests/DawnTest.h
+++ b/src/tests/DawnTest.h
@@ -177,6 +177,13 @@ class DawnTest : public ::testing::TestWithParam<BackendType> {
                                 testName##params, sizeof(testName##params) / sizeof(firstParam))), \
                             testing::PrintToStringParamName());
 
+// Skip a test when the given condition is satisfied.
+#define DAWN_SKIP_TEST_IF(condition)                               \
+    if (condition) {                                               \
+        std::cout << "Test skipped: " #condition "." << std::endl; \
+        return;                                                    \
+    }
+
 namespace detail {
     // Helper functions used for DAWN_INSTANTIATE_TEST
     bool IsBackendAvailable(BackendType type);

--- a/src/tests/end2end/BufferTests.cpp
+++ b/src/tests/end2end/BufferTests.cpp
@@ -221,12 +221,9 @@ TEST_P(BufferSetSubDataTests, SmallDataAtOffset) {
 
 // Stress test for many calls to SetSubData
 TEST_P(BufferSetSubDataTests, ManySetSubData) {
-    if (IsD3D12() || IsMetal() || IsVulkan()) {
-        // TODO(cwallez@chromium.org): Use ringbuffers for SetSubData on explicit APIs.
-        // otherwise this creates too many resources and can take freeze the driver(?)
-        std::cout << "Test skipped on D3D12, Metal and Vulkan" << std::endl;
-        return;
-    }
+    // TODO(cwallez@chromium.org): Use ringbuffers for SetSubData on explicit APIs.
+    // otherwise this creates too many resources and can take freeze the driver(?)
+    DAWN_SKIP_TEST_IF(IsD3D12() || IsMetal() || IsVulkan());
 
     constexpr uint32_t kSize = 4000 * 1000;
     constexpr uint32_t kElements = 1000 * 1000;

--- a/src/tests/end2end/ComputeCopyStorageBufferTests.cpp
+++ b/src/tests/end2end/ComputeCopyStorageBufferTests.cpp
@@ -105,11 +105,8 @@ TEST_P(ComputeCopyStorageBufferTests, SizedArrayOfBasic) {
 
 // Test that a slightly-less-trivial compute-shader memcpy implementation works.
 TEST_P(ComputeCopyStorageBufferTests, SizedArrayOfStruct) {
-    if (IsD3D12()) {
-        // TODO(kainino@chromium.org): Fails on D3D12. Probably due to a limitation in SPIRV-Cross?
-        std::cout << "Test skipped on D3D12" << std::endl;
-        return;
-    }
+    // TODO(kainino@chromium.org): Fails on D3D12. Probably due to a limitation in SPIRV-Cross?
+    DAWN_SKIP_TEST_IF(IsD3D12());
 
     BasicTest(R"(
         #version 450

--- a/src/tests/end2end/CopyTests.cpp
+++ b/src/tests/end2end/CopyTests.cpp
@@ -368,10 +368,7 @@ TEST_P(CopyTests_T2B, RowPitchUnaligned) {
 TEST_P(CopyTests_T2B, Texture2DArrayRegion)
 {
     // TODO(jiawei.shao@intel.com): support 2D array texture on OpenGL, D3D12 and Metal.
-    if (IsOpenGL() || IsD3D12() || IsMetal()) {
-        std::cout << "Test skipped on OpenGL, D3D12 and Metal" << std::endl;
-        return;
-    }
+    DAWN_SKIP_TEST_IF(IsOpenGL() || IsD3D12() || IsMetal());
 
     constexpr uint32_t kWidth = 256;
     constexpr uint32_t kHeight = 128;
@@ -382,10 +379,8 @@ TEST_P(CopyTests_T2B, Texture2DArrayRegion)
 // Test that copying texture 2D array mips with 256-byte aligned sizes works
 TEST_P(CopyTests_T2B, Texture2DArrayMip) {
     // TODO(jiawei.shao@intel.com): support 2D array texture on OpenGL, D3D12 and Metal.
-    if (IsOpenGL() || IsD3D12() || IsMetal()) {
-        std::cout << "Test skipped on OpenGL, D3D12 and Metal" << std::endl;
-        return;
-    }
+    DAWN_SKIP_TEST_IF(IsOpenGL() || IsD3D12() || IsMetal());
+
     constexpr uint32_t kWidth = 256;
     constexpr uint32_t kHeight = 128;
     constexpr uint32_t kLayers = 6u;

--- a/src/tests/end2end/IndexFormatTests.cpp
+++ b/src/tests/end2end/IndexFormatTests.cpp
@@ -201,10 +201,7 @@ TEST_P(IndexFormatTest, Uint16PrimitiveRestart) {
 // prevent a case in D3D12 where the index format would be captured from the last
 // pipeline on SetIndexBuffer.
 TEST_P(IndexFormatTest, ChangePipelineAfterSetIndexBuffer) {
-    if (IsD3D12() || IsVulkan()) {
-        std::cout << "Test skipped on D3D12 and Vulkan" << std::endl;
-        return;
-    }
+    DAWN_SKIP_TEST_IF(IsD3D12() || IsVulkan());
 
     dawn::RenderPipeline pipeline32 = MakeTestPipeline(dawn::IndexFormat::Uint32);
     dawn::RenderPipeline pipeline16 = MakeTestPipeline(dawn::IndexFormat::Uint16);

--- a/src/tests/end2end/ScissorTests.cpp
+++ b/src/tests/end2end/ScissorTests.cpp
@@ -89,10 +89,7 @@ TEST_P(ScissorTest, LargerThanAttachment) {
 
 // Test setting an empty scissor rect
 TEST_P(ScissorTest, EmptyRect) {
-    if (IsMetal()) {
-        std::cout << "Test skipped on Metal" << std::endl;
-        return;
-    }
+    DAWN_SKIP_TEST_IF(IsMetal());
 
     utils::BasicRenderPass renderPass = utils::CreateBasicRenderPass(device, 2, 2);
     dawn::RenderPipeline pipeline = CreateQuadPipeline(renderPass.colorFormat);


### PR DESCRIPTION
This patch implements a micro DAWN_SKIP_TEST_IF in DawnTest.h which
can be used to skip running a test in dawn_end2end_tests when the
given condition is satisfied.