### PR TITLE
Support 2D array texture copying on D3D12, Metal and OpenGL

### DIFF
--- a/src/dawn_native/d3d12/CommandBufferD3D12.cpp
+++ b/src/dawn_native/d3d12/CommandBufferD3D12.cpp
@@ -333,7 +333,9 @@ namespace dawn_native { namespace d3d12 {
                     D3D12_TEXTURE_COPY_LOCATION textureLocation;
                     textureLocation.pResource = texture->GetD3D12Resource();
                     textureLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
-                    textureLocation.SubresourceIndex = copy->destination.level;
+                    textureLocation.SubresourceIndex =
+                        texture->GetNumMipLevels() * copy->destination.slice +
+                        copy->destination.level;
 
                     for (uint32_t i = 0; i < copySplit.count; ++i) {
                         auto& info = copySplit.copies[i];
@@ -379,7 +381,8 @@ namespace dawn_native { namespace d3d12 {
                     D3D12_TEXTURE_COPY_LOCATION textureLocation;
                     textureLocation.pResource = texture->GetD3D12Resource();
                     textureLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
-                    textureLocation.SubresourceIndex = copy->source.level;
+                    textureLocation.SubresourceIndex =
+                        texture->GetNumMipLevels() * copy->source.slice + copy->source.level;
 
                     for (uint32_t i = 0; i < copySplit.count; ++i) {
                         auto& info = copySplit.copies[i];

--- a/src/dawn_native/d3d12/TextureCopySplitter.cpp
+++ b/src/dawn_native/d3d12/TextureCopySplitter.cpp
@@ -50,7 +50,7 @@ namespace dawn_native { namespace d3d12 {
         TextureCopySplit copy;
 
         if (z != 0 || depth > 1) {
-            // TODO(enga@google.com): Handle 3D / 2D arrays
+            // TODO(enga@google.com): Handle 3D
             ASSERT(false);
             return copy;
         }

--- a/src/dawn_native/d3d12/TextureD3D12.cpp
+++ b/src/dawn_native/d3d12/TextureD3D12.cpp
@@ -114,7 +114,7 @@ namespace dawn_native { namespace d3d12 {
         resourceDescriptor.Alignment = 0;
         resourceDescriptor.Width = GetWidth();
         resourceDescriptor.Height = GetHeight();
-        resourceDescriptor.DepthOrArraySize = static_cast<UINT16>(GetDepth());
+        resourceDescriptor.DepthOrArraySize = GetDepthOrArraySize();
         resourceDescriptor.MipLevels = static_cast<UINT16>(GetNumMipLevels());
         resourceDescriptor.Format = D3D12TextureFormat(GetFormat());
         resourceDescriptor.SampleDesc.Count = 1;
@@ -149,6 +149,15 @@ namespace dawn_native { namespace d3d12 {
 
     ID3D12Resource* Texture::GetD3D12Resource() {
         return mResourcePtr;
+    }
+
+    UINT16 Texture::GetDepthOrArraySize() {
+        switch (GetDimension()) {
+            case dawn::TextureDimension::e2D:
+                return static_cast<UINT16>(GetArrayLayers());
+            default:
+                UNREACHABLE();
+        }
     }
 
     void Texture::TransitionUsageNow(ComPtr<ID3D12GraphicsCommandList> commandList,

--- a/src/dawn_native/d3d12/TextureD3D12.h
+++ b/src/dawn_native/d3d12/TextureD3D12.h
@@ -38,6 +38,8 @@ namespace dawn_native { namespace d3d12 {
                                 dawn::TextureUsageBit usage);
 
       private:
+        UINT16 GetDepthOrArraySize();
+
         ComPtr<ID3D12Resource> mResource = {};
         ID3D12Resource* mResourcePtr = nullptr;
         dawn::TextureUsageBit mLastUsage = dawn::TextureUsageBit::None;

--- a/src/dawn_native/metal/CommandBufferMTL.mm
+++ b/src/dawn_native/metal/CommandBufferMTL.mm
@@ -270,7 +270,7 @@ namespace dawn_native { namespace metal {
                               sourceBytesPerImage:(copy->rowPitch * dst.height)
                                        sourceSize:size
                                         toTexture:texture->GetMTLTexture()
-                                 destinationSlice:0
+                                 destinationSlice:dst.slice
                                  destinationLevel:dst.level
                                 destinationOrigin:origin];
                 } break;
@@ -294,7 +294,7 @@ namespace dawn_native { namespace metal {
 
                     encoders.EnsureBlit(commandBuffer);
                     [encoders.blit copyFromTexture:texture->GetMTLTexture()
-                                       sourceSlice:0
+                                       sourceSlice:src.slice
                                        sourceLevel:src.level
                                       sourceOrigin:origin
                                         sourceSize:size

--- a/src/dawn_native/metal/TextureMTL.mm
+++ b/src/dawn_native/metal/TextureMTL.mm
@@ -58,10 +58,11 @@ namespace dawn_native { namespace metal {
             return result;
         }
 
-        MTLTextureType MetalTextureType(dawn::TextureDimension dimension) {
+        MTLTextureType MetalTextureType(dawn::TextureDimension dimension,
+                                        unsigned int arrayLayers) {
             switch (dimension) {
                 case dawn::TextureDimension::e2D:
-                    return MTLTextureType2D;
+                    return (arrayLayers > 1) ? MTLTextureType2DArray : MTLTextureType2D;
             }
         }
     }
@@ -70,14 +71,14 @@ namespace dawn_native { namespace metal {
         : TextureBase(device, descriptor) {
         auto desc = [MTLTextureDescriptor new];
         [desc autorelease];
-        desc.textureType = MetalTextureType(GetDimension());
+        desc.textureType = MetalTextureType(GetDimension(), GetArrayLayers());
         desc.usage = MetalTextureUsage(GetUsage());
         desc.pixelFormat = MetalPixelFormat(GetFormat());
         desc.width = GetWidth();
         desc.height = GetHeight();
         desc.depth = GetDepth();
         desc.mipmapLevelCount = GetNumMipLevels();
-        desc.arrayLength = 1;
+        desc.arrayLength = GetArrayLayers();
         desc.storageMode = MTLStorageModePrivate;
 
         auto mtlDevice = device->GetMTLDevice();

--- a/src/dawn_native/vulkan/TextureVk.cpp
+++ b/src/dawn_native/vulkan/TextureVk.cpp
@@ -333,7 +333,7 @@ namespace dawn_native { namespace vulkan {
         barrier.subresourceRange.baseMipLevel = 0;
         barrier.subresourceRange.levelCount = GetNumMipLevels();
         barrier.subresourceRange.baseArrayLayer = 0;
-        barrier.subresourceRange.layerCount = 1;
+        barrier.subresourceRange.layerCount = GetArrayLayers();
 
         ToBackend(GetDevice())
             ->fn.CmdPipelineBarrier(commands, srcStages, dstStages, 0, 0, nullptr, 0, nullptr, 1,

--- a/src/tests/end2end/CopyTests.cpp
+++ b/src/tests/end2end/CopyTests.cpp
@@ -365,11 +365,7 @@ TEST_P(CopyTests_T2B, RowPitchUnaligned) {
 }
 
 // Test that copying regions of each texture 2D array layer works
-TEST_P(CopyTests_T2B, Texture2DArrayRegion)
-{
-    // TODO(jiawei.shao@intel.com): support 2D array texture on OpenGL, D3D12 and Metal.
-    DAWN_SKIP_TEST_IF(IsOpenGL() || IsD3D12() || IsMetal());
-
+TEST_P(CopyTests_T2B, Texture2DArrayRegion) {
     constexpr uint32_t kWidth = 256;
     constexpr uint32_t kHeight = 128;
     constexpr uint32_t kLayers = 6u;
@@ -378,9 +374,6 @@ TEST_P(CopyTests_T2B, Texture2DArrayRegion)
 
 // Test that copying texture 2D array mips with 256-byte aligned sizes works
 TEST_P(CopyTests_T2B, Texture2DArrayMip) {
-    // TODO(jiawei.shao@intel.com): support 2D array texture on OpenGL, D3D12 and Metal.
-    DAWN_SKIP_TEST_IF(IsOpenGL() || IsD3D12() || IsMetal());
-
     constexpr uint32_t kWidth = 256;
     constexpr uint32_t kHeight = 128;
     constexpr uint32_t kLayers = 6u;


### PR DESCRIPTION
This patch implements the creation of 2D array textures and copying
between a buffer and a layer of a 2D array texture on D3D12, Metal
and OpenGL back-ends.

This patch also fixes the barrier in vulkan::Texture::TransitionUsageNow
to make the barrier cover all the slices in a 2D array texture.

TEST=dawn_end2end_tests