### PR TITLE
cr-buildbucket.cfg: Add cache for win_toolchain

### DIFF
--- a/infra/config/global/cr-buildbucket.cfg
+++ b/infra/config/global/cr-buildbucket.cfg
@@ -91,6 +91,10 @@ buckets {
         name: "dawn"
       }
       service_account: "dawn-ci-builder@chops-service-accounts.iam.gserviceaccount.com"
+      caches {
+        path: "win_toolchain"
+        name: "win_toolchain"
+      }
     }
 
     # Linux: test combinations of {clang}x{release,debug}x{x86,x64}
@@ -198,6 +202,10 @@ buckets: {
         properties_j: "$depot_tools/bot_update:{\"apply_patch_on_gclient\":true}"
       }
       service_account: "dawn-try-builder@chops-service-accounts.iam.gserviceaccount.com"
+      caches {
+        path: "win_toolchain"
+        name: "win_toolchain"
+      }
     }
 
     # A subset of the CI configurations are used for the CQ. We still mirror


### PR DESCRIPTION
This has already been reviewed at https://dawn-review.googlesource.com/c/dawn/+/1340