### PR TITLE
Make Dawn error macro more explicit and have an "error type"

### DIFF
--- a/generator/templates/dawn_native/ValidationUtils.cpp
+++ b/generator/templates/dawn_native/ValidationUtils.cpp
@@ -24,7 +24,7 @@ namespace dawn_native {
                         return {};
                 {% endfor %}
                 default:
-                    DAWN_RETURN_ERROR("Invalid value for {{as_cType(type.name)}}");
+                    return DAWN_VALIDATION_ERROR("Invalid value for {{as_cType(type.name)}}");
             }
         }
 
@@ -35,7 +35,7 @@ namespace dawn_native {
             if ((value & static_cast<dawn::{{as_cppType(type.name)}}>(~{{type.full_mask}})) == 0) {
                 return {};
             }
-            DAWN_RETURN_ERROR("Invalid value for {{as_cType(type.name)}}");
+            return DAWN_VALIDATION_ERROR("Invalid value for {{as_cType(type.name)}}");
         }
 
     {% endfor %}

--- a/src/dawn_native/CommandBufferStateTracker.cpp
+++ b/src/dawn_native/CommandBufferStateTracker.cpp
@@ -117,19 +117,19 @@ namespace dawn_native {
         ASSERT(aspects.any());
 
         if (aspects[VALIDATION_ASPECT_INDEX_BUFFER]) {
-            DAWN_RETURN_ERROR("Missing index buffer");
+            return DAWN_VALIDATION_ERROR("Missing index buffer");
         }
 
         if (aspects[VALIDATION_ASPECT_VERTEX_BUFFERS]) {
-            DAWN_RETURN_ERROR("Missing vertex buffer");
+            return DAWN_VALIDATION_ERROR("Missing vertex buffer");
         }
 
         if (aspects[VALIDATION_ASPECT_BIND_GROUPS]) {
-            DAWN_RETURN_ERROR("Missing bind group");
+            return DAWN_VALIDATION_ERROR("Missing bind group");
         }
 
         if (aspects[VALIDATION_ASPECT_PIPELINE]) {
-            DAWN_RETURN_ERROR("Missing pipeline");
+            return DAWN_VALIDATION_ERROR("Missing pipeline");
         }
 
         UNREACHABLE();

--- a/src/dawn_native/ComputePipeline.cpp
+++ b/src/dawn_native/ComputePipeline.cpp
@@ -20,18 +20,20 @@ namespace dawn_native {
 
     MaybeError ValidateComputePipelineDescriptor(DeviceBase*,
                                                  const ComputePipelineDescriptor* descriptor) {
-        DAWN_TRY_ASSERT(descriptor->nextInChain == nullptr, "nextInChain must be nullptr");
+        if (descriptor->nextInChain != nullptr) {
+            return DAWN_VALIDATION_ERROR("nextInChain must be nullptr");
+        }
 
         if (descriptor->entryPoint != std::string("main")) {
-            DAWN_RETURN_ERROR("Currently the entry point has to be main()");
+            return DAWN_VALIDATION_ERROR("Currently the entry point has to be main()");
         }
 
         if (descriptor->module->GetExecutionModel() != dawn::ShaderStage::Compute) {
-            DAWN_RETURN_ERROR("Setting module with wrong execution model");
+            return DAWN_VALIDATION_ERROR("Setting module with wrong execution model");
         }
 
         if (!descriptor->module->IsCompatibleWithPipelineLayout(descriptor->layout)) {
-            DAWN_RETURN_ERROR("Stage not compatible with layout");
+            return DAWN_VALIDATION_ERROR("Stage not compatible with layout");
         }
 
         return {};

--- a/src/dawn_native/Error.cpp
+++ b/src/dawn_native/Error.cpp
@@ -18,8 +18,12 @@
 
 namespace dawn_native {
 
-    ErrorData* MakeError(const char* message, const char* file, const char* function, int line) {
-        ErrorData* error = new ErrorData(message);
+    ErrorData* MakeError(ErrorType type,
+                         const char* message,
+                         const char* file,
+                         const char* function,
+                         int line) {
+        ErrorData* error = new ErrorData(type, message);
         error->AppendBacktrace(file, function, line);
         return error;
     }

--- a/src/dawn_native/ErrorData.cpp
+++ b/src/dawn_native/ErrorData.cpp
@@ -18,7 +18,8 @@ namespace dawn_native {
 
     ErrorData::ErrorData() = default;
 
-    ErrorData::ErrorData(std::string message) : mMessage(std::move(message)) {
+    ErrorData::ErrorData(ErrorType type, std::string message)
+        : mType(type), mMessage(std::move(message)) {
     }
 
     void ErrorData::AppendBacktrace(const char* file, const char* function, int line) {
@@ -28,6 +29,10 @@ namespace dawn_native {
         record.line = line;
 
         mBacktrace.push_back(std::move(record));
+    }
+
+    ErrorType ErrorData::GetType() const {
+        return mType;
     }
 
     const std::string& ErrorData::GetMessage() const {

--- a/src/dawn_native/ErrorData.h
+++ b/src/dawn_native/ErrorData.h
@@ -15,15 +15,18 @@
 #ifndef DAWNNATIVE_ERRORDATA_H_
 #define DAWNNATIVE_ERRORDATA_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
 namespace dawn_native {
 
+    enum class ErrorType : uint32_t;
+
     class ErrorData {
       public:
         ErrorData();
-        ErrorData(std::string message);
+        ErrorData(ErrorType type, std::string message);
 
         struct BacktraceRecord {
             const char* file;
@@ -32,10 +35,12 @@ namespace dawn_native {
         };
         void AppendBacktrace(const char* file, const char* function, int line);
 
+        ErrorType GetType() const;
         const std::string& GetMessage() const;
         const std::vector<BacktraceRecord>& GetBacktrace() const;
 
       private:
+        ErrorType mType;
         std::string mMessage;
         std::vector<BacktraceRecord> mBacktrace;
     };

--- a/src/dawn_native/PipelineLayout.cpp
+++ b/src/dawn_native/PipelineLayout.cpp
@@ -22,12 +22,18 @@ namespace dawn_native {
 
     MaybeError ValidatePipelineLayoutDescriptor(DeviceBase*,
                                                 const PipelineLayoutDescriptor* descriptor) {
-        DAWN_TRY_ASSERT(descriptor->nextInChain == nullptr, "nextInChain must be nullptr");
-        DAWN_TRY_ASSERT(descriptor->numBindGroupLayouts <= kMaxBindGroups,
-                        "too many bind group layouts");
+        if (descriptor->nextInChain != nullptr) {
+            return DAWN_VALIDATION_ERROR("nextInChain must be nullptr");
+        }
+
+        if (descriptor->numBindGroupLayouts > kMaxBindGroups) {
+            return DAWN_VALIDATION_ERROR("too many bind group layouts");
+        }
+
         for (uint32_t i = 0; i < descriptor->numBindGroupLayouts; ++i) {
-            DAWN_TRY_ASSERT(descriptor->bindGroupLayouts[i] != nullptr,
-                            "bind group layouts may not be null");
+            if (descriptor->bindGroupLayouts[i] == nullptr) {
+                return DAWN_VALIDATION_ERROR("bind group layouts may not be null");
+            }
         }
         return {};
     }

--- a/src/dawn_native/Sampler.cpp
+++ b/src/dawn_native/Sampler.cpp
@@ -20,7 +20,9 @@
 namespace dawn_native {
 
     MaybeError ValidateSamplerDescriptor(DeviceBase*, const SamplerDescriptor* descriptor) {
-        DAWN_TRY_ASSERT(descriptor->nextInChain == nullptr, "nextInChain must be nullptr");
+        if (descriptor->nextInChain != nullptr) {
+            return DAWN_VALIDATION_ERROR("nextInChain must be nullptr");
+        }
         DAWN_TRY(ValidateFilterMode(descriptor->minFilter));
         DAWN_TRY(ValidateFilterMode(descriptor->magFilter));
         DAWN_TRY(ValidateFilterMode(descriptor->mipmapFilter));

--- a/src/dawn_native/ShaderModule.cpp
+++ b/src/dawn_native/ShaderModule.cpp
@@ -26,7 +26,9 @@ namespace dawn_native {
 
     MaybeError ValidateShaderModuleDescriptor(DeviceBase*,
                                               const ShaderModuleDescriptor* descriptor) {
-        DAWN_TRY_ASSERT(descriptor->nextInChain == nullptr, "nextInChain must be nullptr");
+        if (descriptor->nextInChain != nullptr) {
+            return DAWN_VALIDATION_ERROR("nextInChain must be nullptr");
+        }
 
         spvtools::SpirvTools spirvTools(SPV_ENV_WEBGPU_0);
 
@@ -55,7 +57,7 @@ namespace dawn_native {
         });
 
         if (!spirvTools.Validate(descriptor->code, descriptor->codeSize)) {
-            DAWN_RETURN_ERROR(errorStream.str().c_str());
+            return DAWN_VALIDATION_ERROR(errorStream.str().c_str());
         }
 
         return {};

--- a/src/dawn_native/Texture.cpp
+++ b/src/dawn_native/Texture.cpp
@@ -20,7 +20,10 @@
 
 namespace dawn_native {
     MaybeError ValidateTextureDescriptor(DeviceBase*, const TextureDescriptor* descriptor) {
-        DAWN_TRY_ASSERT(descriptor->nextInChain == nullptr, "nextInChain must be nullptr");
+        if (descriptor->nextInChain != nullptr) {
+            return DAWN_VALIDATION_ERROR("nextInChain must be nullptr");
+        }
+
         DAWN_TRY(ValidateTextureUsageBit(descriptor->usage));
         DAWN_TRY(ValidateTextureDimension(descriptor->dimension));
         DAWN_TRY(ValidateTextureFormat(descriptor->format));
@@ -28,7 +31,7 @@ namespace dawn_native {
         // TODO(jiawei.shao@intel.com): check stuff based on the dimension
         if (descriptor->width == 0 || descriptor->height == 0 || descriptor->depth == 0 ||
             descriptor->arrayLayer == 0 || descriptor->mipLevel == 0) {
-            DAWN_RETURN_ERROR("Cannot create an empty texture");
+            return DAWN_VALIDATION_ERROR("Cannot create an empty texture");
         }
 
         return {};

--- a/src/dawn_native/d3d12/PlatformFunctions.cpp
+++ b/src/dawn_native/d3d12/PlatformFunctions.cpp
@@ -44,7 +44,7 @@ namespace dawn_native { namespace d3d12 {
                                "D3D12SerializeVersionedRootSignature", &error) ||
             !mD3D12Lib.GetProc(&d3d12CreateVersionedRootSignatureDeserializer,
                                "D3D12CreateVersionedRootSignatureDeserializer", &error)) {
-            DAWN_RETURN_ERROR(error.c_str());
+            return DAWN_CONTEXT_LOST_ERROR(error.c_str());
         }
 
         return {};
@@ -55,7 +55,7 @@ namespace dawn_native { namespace d3d12 {
         if (!mDXGILib.Open("dxgi.dll", &error) ||
             !mDXGILib.GetProc(&dxgiGetDebugInterface1, "DXGIGetDebugInterface1", &error) ||
             !mDXGILib.GetProc(&createDxgiFactory2, "CreateDXGIFactory2", &error)) {
-            DAWN_RETURN_ERROR(error.c_str());
+            return DAWN_CONTEXT_LOST_ERROR(error.c_str());
         }
 
         return {};
@@ -65,7 +65,7 @@ namespace dawn_native { namespace d3d12 {
         std::string error;
         if (!mD3DCompilerLib.Open("d3dcompiler_47.dll", &error) ||
             !mD3DCompilerLib.GetProc(&d3dCompile, "D3DCompile", &error)) {
-            DAWN_RETURN_ERROR(error.c_str());
+            return DAWN_CONTEXT_LOST_ERROR(error.c_str());
         }
 
         return {};

--- a/src/tests/unittests/ErrorTests.cpp
+++ b/src/tests/unittests/ErrorTests.cpp
@@ -34,10 +34,10 @@ TEST(ErrorTests, Error_Success) {
     ASSERT_TRUE(result.IsSuccess());
 }
 
-// Check returning an error MaybeError with DAWN_RETURN_ERROR
+// Check returning an error MaybeError with "return DAWN_VALIDATION_ERROR"
 TEST(ErrorTests, Error_Error) {
     auto ReturnError = []() -> MaybeError {
-        DAWN_RETURN_ERROR(dummyErrorMessage);
+        return DAWN_VALIDATION_ERROR(dummyErrorMessage);
     };
 
     MaybeError result = ReturnError();
@@ -59,10 +59,10 @@ TEST(ErrorTests, ResultOrError_Success) {
     ASSERT_EQ(result.AcquireSuccess(), &dummySuccess);
 }
 
-// Check returning an error ResultOrError with DAWN_RETURN_ERROR
+// Check returning an error ResultOrError with "return DAWN_VALIDATION_ERROR"
 TEST(ErrorTests, ResultOrError_Error) {
     auto ReturnError = []() -> ResultOrError<int*> {
-        DAWN_RETURN_ERROR(dummyErrorMessage);
+        return DAWN_VALIDATION_ERROR(dummyErrorMessage);
     };
 
     ResultOrError<int*> result = ReturnError();
@@ -96,7 +96,7 @@ TEST(ErrorTests, TRY_Success) {
 // Check DAWN_TRY handles errors correctly.
 TEST(ErrorTests, TRY_Error) {
     auto ReturnError = []() -> MaybeError {
-        DAWN_RETURN_ERROR(dummyErrorMessage);
+        return DAWN_VALIDATION_ERROR(dummyErrorMessage);
     };
 
     auto Try = [ReturnError]() -> MaybeError {
@@ -117,7 +117,7 @@ TEST(ErrorTests, TRY_Error) {
 // Check DAWN_TRY adds to the backtrace.
 TEST(ErrorTests, TRY_AddsToBacktrace) {
     auto ReturnError = []() -> MaybeError {
-        DAWN_RETURN_ERROR(dummyErrorMessage);
+        return DAWN_VALIDATION_ERROR(dummyErrorMessage);
     };
 
     auto SingleTry = [ReturnError]() -> MaybeError {
@@ -172,7 +172,7 @@ TEST(ErrorTests, TRY_RESULT_Success) {
 // Check DAWN_TRY_ASSIGN handles errors correctly.
 TEST(ErrorTests, TRY_RESULT_Error) {
     auto ReturnError = []() -> ResultOrError<int*> {
-        DAWN_RETURN_ERROR(dummyErrorMessage);
+        return DAWN_VALIDATION_ERROR(dummyErrorMessage);
     };
 
     auto Try = [ReturnError]() -> ResultOrError<int*> {
@@ -196,7 +196,7 @@ TEST(ErrorTests, TRY_RESULT_Error) {
 // Check DAWN_TRY_ASSIGN adds to the backtrace.
 TEST(ErrorTests, TRY_RESULT_AddsToBacktrace) {
     auto ReturnError = []() -> ResultOrError<int*> {
-        DAWN_RETURN_ERROR(dummyErrorMessage);
+        return DAWN_VALIDATION_ERROR(dummyErrorMessage);
     };
 
     auto SingleTry = [ReturnError]() -> ResultOrError<int*> {
@@ -227,7 +227,7 @@ TEST(ErrorTests, TRY_RESULT_AddsToBacktrace) {
 // Check a ResultOrError can be DAWN_TRY_ASSIGNED in a function that returns an Error
 TEST(ErrorTests, TRY_RESULT_ConversionToError) {
     auto ReturnError = []() -> ResultOrError<int*> {
-        DAWN_RETURN_ERROR(dummyErrorMessage);
+        return DAWN_VALIDATION_ERROR(dummyErrorMessage);
     };
 
     auto Try = [ReturnError]() -> MaybeError {
@@ -250,7 +250,7 @@ TEST(ErrorTests, TRY_RESULT_ConversionToError) {
 // Check DAWN_TRY handles errors correctly.
 TEST(ErrorTests, TRY_ConversionToErrorOrResult) {
     auto ReturnError = []() -> MaybeError {
-        DAWN_RETURN_ERROR(dummyErrorMessage);
+        return DAWN_VALIDATION_ERROR(dummyErrorMessage);
     };
 
     auto Try = [ReturnError]() -> ResultOrError<int*>{


### PR DESCRIPTION
The error type will help distinguish between validation errors, context
losts and others which should be handled differently.

Take advantage of advantage of this to change DAWN_RETURN_ERROR to
"return DAWN_FOO_ERROR" to have the return be more explicit. Also
removes usage of DAWN_TRY_ASSERT for more explicit checks.